### PR TITLE
issue-715: insert method in blocks API

### DIFF
--- a/src/components/modules/api/blocks.ts
+++ b/src/components/modules/api/blocks.ts
@@ -1,9 +1,9 @@
 import Module from '../../__module';
 
-import {Blocks} from '../../../../types/api';
-import {OutputData} from '../../../../types';
+import { Blocks } from '../../../../types/api';
+import { BlockToolData, OutputData, ToolConfig } from '../../../../types';
 import Block from '../../block';
-import {ModuleConfig} from '../../../types-internal/module-config';
+import { ModuleConfig } from '../../../types-internal/module-config';
 
 /**
  * @class BlocksAPI
@@ -26,6 +26,12 @@ export default class BlocksAPI extends Module {
       getBlocksCount: () => this.getBlocksCount(),
       stretchBlock: (index: number, status: boolean = true) => this.stretchBlock(index, status),
       insertNewBlock: () => this.insertNewBlock(),
+      insert: (
+        index: number,
+        toolName: string,
+        data: BlockToolData = {},
+        settings: ToolConfig = {},
+      ) => this.insert(index, toolName, data, settings),
     };
   }
 
@@ -145,6 +151,24 @@ export default class BlocksAPI extends Module {
    */
   public insertNewBlock() {
     const newBlock = this.Editor.BlockManager.insert();
+    this.Editor.Caret.setToBlock(newBlock);
+  }
+
+  /**
+   * Insert new block at index with data
+   *
+   * @param {number} index — index of new block
+   * @param {string} toolName — plugin name
+   * @param {BlockToolData} data — plugin data
+   * @param {ToolConfig} settings - default settings
+   */
+  public insert(
+    index: number,
+    toolName: string,
+    data: BlockToolData = {},
+    settings: ToolConfig = {},
+  ) {
+    const newBlock = this.Editor.BlockManager.insertAt(index, toolName, data, settings);
     this.Editor.Caret.setToBlock(newBlock);
   }
 }

--- a/src/components/modules/blockManager.ts
+++ b/src/components/modules/blockManager.ts
@@ -233,10 +233,30 @@ export default class BlockManager extends Module {
   ): Block {
     // Increment index before construct,
     // because developers can use API/Blocks/getCurrentInputIndex on the render() method
-    const newIndex = ++this.currentBlockIndex;
+    const newIndex = this.currentBlockIndex + 1;
+    return this.insertAt(newIndex, toolName, data, settings);
+  }
+
+  /**
+   * Insert new block into _blocks at index
+   *
+   * @param {Number} index — index of new block
+   * @param {String} toolName — plugin name, by default method inserts initial block type
+   * @param {Object} data — plugin data
+   * @param {Object} settings - default settings
+   *
+   * @return {Block}
+   */
+  public insertAt(
+    index: number,
+    toolName: string = this.config.initialBlock,
+    data: BlockToolData = {},
+    settings: ToolConfig = {},
+  ): Block {
+    this.currentBlockIndex = index;
     const block = this.composeBlock(toolName, data, settings);
 
-    this._blocks[newIndex] = block;
+    this._blocks[index] = block;
     return block;
   }
 

--- a/types/api/blocks.d.ts
+++ b/types/api/blocks.d.ts
@@ -1,4 +1,6 @@
-import {OutputData} from '../data-formats/output-data';
+import { OutputData } from '../data-formats/output-data';
+import { BlockToolData } from '../tools/block-tool-data';
+import { ToolConfig } from '../tools/tool-config';
 
 /**
  * Describes methods to manipulate with Editor`s blocks
@@ -65,4 +67,18 @@ export interface Blocks {
    * Insert new Initial Block after current Block
    */
   insertNewBlock(): void;
+
+  /**
+   * Insert new block at index with data
+   * @param {number} index — index of new block
+   * @param {string} toolName — plugin name
+   * @param {BlockToolData} data — plugin data
+   * @param {ToolConfig} settings - default settings
+   */
+  insert(
+    index: number,
+    toolName: string,
+    data?: BlockToolData,
+    settings?: ToolConfig,
+  ): void;
 }


### PR DESCRIPTION
Does the following:
1. Adds a `insertAt` method in the `blockManager`. Same as `insert` but accepts an index param as well
1. Refactored `insert` to use `insertAt` to avoid code duplication
1. Exposes the `insertAt` method to the public API, via the `editor.blocks.insert` method, to allow insertion of *any* blocks programmatically at any index

Solves https://github.com/codex-team/editor.js/issues/715


*First PR, feedback is welcomed*