### PR TITLE
Add the save api shorthand to the types

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,6 +6,7 @@
 
 import {EditorConfig} from './configs';
 import {Blocks, Caret, Events, Listeners, Notifier, Sanitizer, Saver, Selection, Styles, Toolbar, InlineToolbar} from './api';
+import {OutputData} from './data-formats/output-data';
 
 /**
  * Interfaces used for development
@@ -75,6 +76,15 @@ declare class EditorJS {
   constructor(configuration?: EditorConfig|string);
 
   public destroy(): void;
+
+  /* Shorthands */
+
+  /**
+   * Saves Editors data and returns promise with it
+   *
+   * @returns {Promise<OutputData>}
+   */
+  save(): Promise<OutputData>;
 }
 
 export as namespace EditorJS;


### PR DESCRIPTION
This mr intentionally does not add all shorthands as long it is not
clear if this is the intended goal.

See #788