### PR TITLE
Process patterns on each line on paste & pattern_processing_max_length moved to config

### DIFF
--- a/src/components/core.ts
+++ b/src/components/core.ts
@@ -159,8 +159,8 @@ export default class Core {
      * @type {{type: (*), data: {text: null}}}
      */
     const initialBlockData = {
-      type : this.config.initialBlock,
-      data : {},
+      type: this.config.initialBlock,
+      data: {},
     };
 
     this.config.placeholder = this.config.placeholder || false;
@@ -181,11 +181,18 @@ export default class Core {
      */
     if (_.isEmpty(this.config.data)) {
       this.config.data = {} as OutputData;
-      this.config.data.blocks = [ initialBlockData ];
+      this.config.data.blocks = [initialBlockData];
     } else {
       if (!this.config.data.blocks || this.config.data.blocks.length === 0) {
-        this.config.data.blocks = [ initialBlockData ];
+        this.config.data.blocks = [initialBlockData];
       }
+    }
+
+    /**
+     * If pattern_processing_max_length is empty then set a default value
+     */
+    if (this.config.pattern_processing_max_length == null) {
+      this.config.pattern_processing_max_length = 450;
     }
   }
 
@@ -202,7 +209,7 @@ export default class Core {
    * @returns {Promise<void>}
    */
   public async validate(): Promise<void> {
-    const { holderId, holder } = this.config;
+    const {holderId, holder} = this.config;
 
     if (holderId && holder) {
       throw Error('«holderId» and «holder» param can\'t assign at the same time.');
@@ -276,7 +283,7 @@ export default class Core {
    * Make modules instances and save it to the @property this.moduleInstances
    */
   private constructModules(): void {
-    modules.forEach( (Module) => {
+    modules.forEach((Module) => {
       try {
         /**
          * We use class name provided by displayName property
@@ -286,10 +293,10 @@ export default class Core {
          * @see  https://www.npmjs.com/package/babel-plugin-class-display-name
          */
         this.moduleInstances[Module.displayName] = new Module({
-          config : this.configuration,
+          config: this.configuration,
         });
-      } catch ( e ) {
-        _.log(`Module ${Module.displayName} skipped because`, 'warn',  e);
+      } catch (e) {
+        _.log(`Module ${Module.displayName} skipped because`, 'warn', e);
       }
     });
   }

--- a/src/components/modules/paste.ts
+++ b/src/components/modules/paste.ts
@@ -99,9 +99,6 @@ interface PasteData {
  */
 export default class Paste extends Module {
 
-  /** If string`s length is greater than this number we don't check paste patterns */
-  public static readonly PATTERN_PROCESSING_MAX_LENGTH = 450;
-
   /**
    * Tags` substitutions parameters
    */
@@ -604,8 +601,8 @@ export default class Paste extends Module {
 
     const currentBlockIsInitial = BlockManager.currentBlock && Tools.isInitial(BlockManager.currentBlock.tool);
 
-    if (currentBlockIsInitial && content.textContent.length < Paste.PATTERN_PROCESSING_MAX_LENGTH) {
-      const blockData = await this.processPattern(content.textContent);
+    if (currentBlockIsInitial && content.textContent.length < this.config.pattern_processing_max_length) {
+      const blockData = this.processPattern(content.textContent);
 
       if (blockData) {
         let insertedBlock;

--- a/src/components/modules/paste.ts
+++ b/src/components/modules/paste.ts
@@ -545,8 +545,6 @@ export default class Paste extends Module {
       return [];
     }
 
-    const tool = initialBlock;
-
     return plain
       .split(/\r?\n/)
       .filter((text) => text.trim())
@@ -555,9 +553,18 @@ export default class Paste extends Module {
 
         content.innerHTML = text;
 
-        const event = this.composePasteEvent('tag', {
+        let event = this.composePasteEvent('tag', {
           data: content,
         });
+        let tool = initialBlock;
+
+        if (text.length < this.config.pattern_processing_max_length) {
+          const blockData = this.processPattern(content.textContent);
+          if (blockData) {
+            event = blockData.event;
+            tool = blockData.tool;
+          }
+        }
 
         return {content, tool, isBlock: false, event};
       });

--- a/src/components/modules/paste.ts
+++ b/src/components/modules/paste.ts
@@ -641,8 +641,8 @@ export default class Paste extends Module {
    * @param {string} text
    * @returns Promise<{data: BlockToolData, tool: string}>
    */
-    const pattern =  this.toolsPatterns.find((substitute) => {
   private processPattern(text: string): { event: PasteEvent; tool: string } {
+    const pattern = this.toolsPatterns.find(substitute => {
       const execResult = substitute.pattern.exec(text);
 
       if (!execResult) {

--- a/src/components/modules/paste.ts
+++ b/src/components/modules/paste.ts
@@ -641,8 +641,8 @@ export default class Paste extends Module {
    * @param {string} text
    * @returns Promise<{data: BlockToolData, tool: string}>
    */
-  private async processPattern(text: string): Promise<{event: PasteEvent, tool: string}> {
     const pattern =  this.toolsPatterns.find((substitute) => {
+  private processPattern(text: string): { event: PasteEvent; tool: string } {
       const execResult = substitute.pattern.exec(text);
 
       if (!execResult) {

--- a/src/components/modules/paste.ts
+++ b/src/components/modules/paste.ts
@@ -208,9 +208,9 @@ export default class Paste extends Module {
     const isCurrentBlockInitial = BlockManager.currentBlock && Tools.isInitial(BlockManager.currentBlock.tool);
     const needToReplaceCurrentBlock = isCurrentBlockInitial && BlockManager.currentBlock.isEmpty;
 
-    await Promise.all(dataToInsert.map(
-      async (content, i) => await this.insertBlock(content, i === 0 && needToReplaceCurrentBlock),
-    ));
+    for (const [i, content] of dataToInsert.entries()) {
+      await this.insertBlock(content, i === 0 && needToReplaceCurrentBlock);
+    }
 
     if (BlockManager.currentBlock) {
       Caret.setToBlock(BlockManager.currentBlock, Caret.positions.END);

--- a/types/configs/editor-config.d.ts
+++ b/types/configs/editor-config.d.ts
@@ -29,7 +29,7 @@ export interface EditorConfig {
   /**
    * First Block placeholder
    */
-  placeholder?: string|false;
+  placeholder?: string | false;
 
   /**
    * Define default sanitizer configuration
@@ -45,7 +45,7 @@ export interface EditorConfig {
   /**
    * Map of Tools to use
    */
-  tools?: {[toolName: string]: ToolConstructable|ToolSettings};
+  tools?: {[toolName: string]: ToolConstructable | ToolSettings};
 
   /**
    * Data to render on Editor start
@@ -66,4 +66,9 @@ export interface EditorConfig {
    * Fires when something changed in DOM
    */
   onChange?(): void;
+
+  /** 
+   * If string`s length is greater than this number we don't check paste patterns in Paste module
+   * */
+  pattern_processing_max_length?: number;
 }


### PR DESCRIPTION
Before when you paste something which can be split by a newline each line will be seen as a 'tag'-event
Now each line will also be processed by `processPatterns` so if a pattern is found the line will be seen as a 'pattern'-event.

Also you can now add a `pattern_processing_max_length` prop in the config 