### PR TITLE
Fix inline toolbar closing on escape key press

### DIFF
--- a/src/components/modules/blockEvents.ts
+++ b/src/components/modules/blockEvents.ts
@@ -4,7 +4,7 @@
 import Module from '../__module';
 import _ from '../utils';
 import SelectionUtils from '../selection';
-import Flipper from "../flipper";
+import Flipper from '../flipper';
 
 export default class BlockEvents extends Module {
 
@@ -112,10 +112,8 @@ export default class BlockEvents extends Module {
     if (SelectionUtils.almostAllSelected(block.pluginsContent.textContent)) {
       InlineToolbar.close();
       BlockSettings.close();
-      ConversionToolbar.tryToShow(block);
     } else {
       ConversionToolbar.close();
-      InlineToolbar.tryToShow(true);
     }
 
     /**

--- a/src/components/modules/blockEvents.ts
+++ b/src/components/modules/blockEvents.ts
@@ -94,7 +94,6 @@ export default class BlockEvents extends Module {
    * - shows conversion toolbar with 85% of block selection
    */
   public keyup(event): void {
-
     /**
      * If shift key was pressed some special shortcut is used (eg. cross block selection via shift + arrows)
      */
@@ -102,24 +101,10 @@ export default class BlockEvents extends Module {
       return;
     }
 
-    const { InlineToolbar, ConversionToolbar, UI, BlockManager, BlockSettings } = this.Editor;
-    const block = BlockManager.getBlock(event.target);
-
-    /**
-     * Conversion Toolbar will be opened when user selects 85% of plugins content
-     * that why we must with the length of pluginsContent
-     */
-    if (SelectionUtils.almostAllSelected(block.pluginsContent.textContent)) {
-      InlineToolbar.close();
-      BlockSettings.close();
-    } else {
-      ConversionToolbar.close();
-    }
-
     /**
      * Check if editor is empty on each keyup and add special css class to wrapper
      */
-    UI.checkEmptiness();
+    this.Editor.UI.checkEmptiness();
   }
 
   /**

--- a/src/components/modules/ui.ts
+++ b/src/components/modules/ui.ts
@@ -14,6 +14,7 @@ import _ from '../utils';
 
 import Selection from '../selection';
 import Block from '../block';
+import SelectionUtils from '../selection';
 
 /**
  * @class
@@ -283,11 +284,9 @@ export default class UI extends Module {
     /**
      * Handle selection change on mobile devices for the Inline Toolbar support
      */
-    if (_.isTouchSupported()) {
-      this.Editor.Listeners.on(document, 'selectionchange', (event) => {
+    this.Editor.Listeners.on(document, 'selectionchange', (event) => {
         this.selectionChanged(event as Event);
       }, true);
-    }
 
     this.Editor.Listeners.on(window, 'resize', () => {
       this.resizeDebouncer();
@@ -593,7 +592,16 @@ export default class UI extends Module {
       return;
     }
 
-    this.Editor.InlineToolbar.tryToShow();
+    const { InlineToolbar, ConversionToolbar, BlockManager } = this.Editor;
+    const block = BlockManager.getBlock(focusedElement as HTMLElement);
+
+    if (SelectionUtils.almostAllSelected(block.pluginsContent.textContent)) {
+      InlineToolbar.close();
+      ConversionToolbar.tryToShow(block);
+    } else {
+      ConversionToolbar.close();
+      InlineToolbar.tryToShow(true);
+    }
   }
 
   /**


### PR DESCRIPTION
When the inline toolbar _or_ conversion toolbar are open, the escape key should close either of them. Currently both the toolbars close momentarily and then re-open when escape is pressed.

This PR removes code that appears to have been duplicated from the `mouseUp` event.

Resolves #692 