### PR TITLE
Add addCaption and tabCaption settings into editor-config.d.ts,

### DIFF
--- a/src/components/modules/toolbar/index.ts
+++ b/src/components/modules/toolbar/index.ts
@@ -121,9 +121,11 @@ export default class Toolbar extends Module {
       const tooltip = this.Editor.Toolbox.nodes.tooltip;
       const fragment = document.createDocumentFragment();
 
-      fragment.appendChild(document.createTextNode('Add'));
+      const addCaption = this.config.addCaption || 'Add';
+      const tabCaption = this.config.tabCaption || 'Tab';
+      fragment.appendChild(document.createTextNode(addCaption));
       fragment.appendChild($.make('div', this.Editor.Toolbox.CSS.tooltipShortcut, {
-        textContent: '⇥ Tab',
+        textContent: `⇥ ${tabCaption}`,
       }));
 
       tooltip.style.left = '-17px';

--- a/types/configs/editor-config.d.ts
+++ b/types/configs/editor-config.d.ts
@@ -66,4 +66,14 @@ export interface EditorConfig {
    * Fires when something changed in DOM
    */
   onChange?(): void;
+
+  /**
+   * "Add" caption on the PlusButton's toolchip (for i18n)
+   */
+  addCaption?: string;
+
+  /**
+   * "Tab" caption on the PlusButton's toolchip (for i18n)
+   */
+  tabCaption?: string;
 }


### PR DESCRIPTION
..., modify toolbar/index.ts.

In the EditorJS user interface, only the plus button's tooltip caption cannot be changed in the user settings. The static values ​​"Add" and "Tab" can be replaced with arbitrary words for the purpose of i18n. This feature allows me to use Japanese, "追加" and "タブ".