### PR TITLE
Fix position for the unlink button

### DIFF
--- a/src/styles/inline-toolbar.css
+++ b/src/styles/inline-toolbar.css
@@ -114,7 +114,6 @@
     }
     .icon--unlink {
       display: inline-block;
-      margin-bottom: -1px;
     }
   }
 


### PR DESCRIPTION
Found, that after adding link to the text and selecting text again is placing unlink button to the bottom of the element. Removing `margin-bottom: -1px;` fixes that.

![изображение](https://user-images.githubusercontent.com/19375789/80131320-b8cf2200-85a2-11ea-8572-815c5d5c827f.png)
