### PR TITLE
preserve block focus after keyboard events

### DIFF
--- a/src/components/core.ts
+++ b/src/components/core.ts
@@ -87,6 +87,7 @@ export default class Core {
             const { BlockManager, Caret } = this.moduleInstances;
 
             Caret.setToBlock(BlockManager.blocks[0], Caret.positions.START);
+            BlockManager.blocks[0].focused = true; //also turn on editor icon and styling -DJ
           }
 
           /**

--- a/src/components/modules/blockEvents.ts
+++ b/src/components/modules/blockEvents.ts
@@ -51,6 +51,7 @@ export default class BlockEvents extends Module {
         this.escapePressed(event);
         break;
     }
+    this.Editor.BlockManager.highlightCurrentNode(); //set focus on current block after key processed -DJ
   }
 
   /**
@@ -455,8 +456,9 @@ export default class BlockEvents extends Module {
       return;
     }
 
-    if (this.Editor.Caret.navigateNext()) {
-      /**
+//    if (this.Editor.Caret.navigateNext()) {
+    if (this.Editor.Caret.isAtEnd && this.Editor.Caret.navigateNext()) { //CAUTION: might create next block; only do this at end of current block -DJ
+        /**
        * Default behaviour moves cursor by 1 character, we need to prevent it
        */
       event.preventDefault();

--- a/src/components/modules/blockSelection.ts
+++ b/src/components/modules/blockSelection.ts
@@ -286,6 +286,7 @@ export default class BlockSelection extends Module {
       .removeAllRanges();
 
     block.selected = true;
+    block.focused = true; //also turn on editor icon and styling -DJ
 
     /** close InlineToolbar when we selected any Block */
     this.Editor.InlineToolbar.close();

--- a/src/components/modules/caret.ts
+++ b/src/components/modules/caret.ts
@@ -266,6 +266,7 @@ export default class Caret extends Module {
 
     BlockManager.setCurrentBlockByChildNode(block.holder);
     BlockManager.currentBlock.currentInput = element;
+    block.focused = true; //also turn on editor icon and styling -DJ
   }
 
   /**

--- a/src/components/modules/paste.ts
+++ b/src/components/modules/paste.ts
@@ -437,6 +437,7 @@ export default class Paste extends Module {
     this.processDataTransfer(event.clipboardData);
 
     BlockManager.clearFocused();
+    BlockManager.currentBlock.focused = true; //also turn on editor icon and styling -DJ
     Toolbar.close();
   }
 


### PR DESCRIPTION
Set focus again after keyboard event or block selection changed.
fixes #1130 

(I'm not too good with all the git branching stuff - hopefully I did it correctly)