### PR TITLE
Typos changes required to be fixed on website when using the import concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,8 @@ const EditorJS = require('@editorjs/editorjs');
 ```
 or
 
-using 'import' concept:
 ```javascript
-import EditorJs from (@editorjs/editorjs);
+import EditorJS from '@editorjs/editorjs';
 ```
 
 ##### Option B. Use a CDN

--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ Include module in your application
 ```javascript
 const EditorJS = require('@editorjs/editorjs');
 ```
+or
+
+using 'import' concept:
+```javascript
+import EditorJs from (@editorjs/editorjs);
+```
 
 ##### Option B. Use a CDN
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![](https://flat.badgen.net/bundlephobia/min/@editorjs/editorjs?color=cyan)](https://www.npmjs.com/package/@editorjs/editorjs)
 [![](https://flat.badgen.net/bundlephobia/minzip/@editorjs/editorjs?color=green)](https://www.npmjs.com/package/@editorjs/editorjs)
 [![Backers on Open Collective](https://opencollective.com/editorjs/backers/badge.svg)](#backers)
-[![Sponsors on Open Collective](https://opencollective.com/editorjs/sponsors/badge.svg)](#sponsors) 
+[![Sponsors on Open Collective](https://opencollective.com/editorjs/sponsors/badge.svg)](#sponsors)
 [![](https://flat.badgen.net/npm/license/@editorjs/editorjs)](https://www.npmjs.com/package/@editorjs/editorjs)
 [![Join the chat at https://gitter.im/codex-team/editor.js](https://badges.gitter.im/codex-team/editor.js.svg)](https://gitter.im/codex-team/editor.js?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
@@ -17,24 +17,24 @@
 If you like Editor.js you can support project improvements and development of new features with a donation to our collective.
 
  👉  [https://opencollective.com/editorjs](https://opencollective.com/editorjs)
- 
+
 ### Sponsors
 
 Support this project by becoming a sponsor. Your logo will show up here with a link to your website. [[Become a sponsor](https://opencollective.com/editorjs#sponsor)]
 
 <a href="https://opencollective.com/editorjs/sponsor/0/website" target="_blank"><img src="https://opencollective.com/editorjs/sponsor/0/avatar.svg"></a>
- 
+
  ### Backers
- 
+
  Thank you to all our backers! 🙏 [[Become a backer](https://opencollective.com/editorjs#backer)]
- 
+
  <a href="https://opencollective.com/editorjs#backers" target="_blank"><img src="https://opencollective.com/editorjs/backers.svg?width=890"></a>
- 
+
 ### Contributors
 
 This project exists thanks to all the people who contribute. <img src="https://opencollective.com/editorjs/contributors.svg?width=890&button=false" />
 
-We really welcome new contributors. If you want to make some code with us, please take a look at the [Good First Tasks](https://github.com/codex-team/editor.js/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+task%22). You can write to us on `team@codex.so` or via special [Telegram chat](https://t.me/editorjsdev), or any other way. 
+We really welcome new contributors. If you want to make some code with us, please take a look at the [Good First Tasks](https://github.com/codex-team/editor.js/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+task%22). You can write to us on `team@codex.so` or via special [Telegram chat](https://t.me/editorjsdev), or any other way.
 
 ## Documentation
 
@@ -142,11 +142,6 @@ npm i @editorjs/editorjs
 Include module in your application
 
 ```javascript
-const EditorJS = require('@editorjs/editorjs');
-```
-or
-
-```javascript
 import EditorJS from '@editorjs/editorjs';
 ```
 
@@ -245,11 +240,11 @@ Take a look at the [example.html](example/example.html) to view more detailed ex
 
 ## Credits and references
 
-- We use [HTMLJanitor](https://github.com/guardian/html-janitor) module in our Sanitizer module. 
+- We use [HTMLJanitor](https://github.com/guardian/html-janitor) module in our Sanitizer module.
 
 ## About team
 
-We are CodeX and we build products for developers and makers. 
+We are CodeX and we build products for developers and makers.
 
 Follow us on Twitter: [twitter.com/codex_team](https://twitter.com/codex_team)
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,10 +24,10 @@ Install the package via NPM or Yarn
 npm i @editorjs/editorjs
 ```
 
-Include module at your application 
+Include module at your application
 
 ```javascript
-const EditorJS = require('@editorjs/editorjs');
+import EditorJS from '@editorjs/editorjs';
 ```
 
 ### Use from CDN
@@ -68,7 +68,7 @@ Check [Editor.js's community](https://github.com/editor-js/) to see Tools exampl
 
 ## Create Editor instance
 
-Create an instance of Editor.js and pass [Configuration Object](../src/types-internal/editor-config.ts). 
+Create an instance of Editor.js and pass [Configuration Object](../src/types-internal/editor-config.ts).
 At least the `holderId` option is required.
 
 ```html
@@ -119,7 +119,7 @@ Editor.js needs a bit of time to initialize. It is an asynchronous action so it 
 
 If you need to know when the editor instance is ready you can use one of the following ways:
 
-##### Pass `onReady` property to the configuration object. 
+##### Pass `onReady` property to the configuration object.
 
 It must be a function:
 
@@ -189,7 +189,7 @@ var editor = new EditorJS({
     * onReady callback
     */
    onReady: () => {console.log('Editor.js is ready to work!')},
-   
+
    /**
     * onChange callback
     */


### PR DESCRIPTION
The misleading import concept typo on official documentation website need to be fixed. This may enhance no errors when importing modules.