### PR TITLE
Add unique id for each block

### DIFF
--- a/src/components/block/api.ts
+++ b/src/components/block/api.ts
@@ -13,6 +13,15 @@ import { BlockAPI as BlockAPIInterface } from '../../../types/api';
 function BlockAPI(block: Block): void {
   const blockAPI: BlockAPIInterface = {
     /**
+     * Tool id
+     *
+     * @returns {string}
+     */
+    get id(): string {
+      return block.id;
+    },
+
+    /**
      * Tool name
      *
      * @returns {string}

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -28,6 +28,11 @@ import MoveDownTune from '../block-tunes/block-tune-move-down';
  */
 interface BlockConstructorOptions {
   /**
+   * Tool's id
+   */
+  id: string;
+
+  /**
    * Tool's name
    */
   name: string;
@@ -101,6 +106,11 @@ export default class Block {
       dropTarget: 'ce-block--drop-target',
     };
   }
+
+  /**
+   * unique identifier
+   */
+  public id: string;
 
   /**
    * Block Tool`s name
@@ -194,6 +204,7 @@ export default class Block {
 
   /**
    * @param {object} options - block constructor options
+   * @param {string} options.id - Tool's unique id
    * @param {string} options.name - Tool name that passed on initialization
    * @param {BlockToolData} options.data - Tool's initial data
    * @param {BlockToolConstructable} options.Tool — Tool's class
@@ -201,12 +212,14 @@ export default class Block {
    * @param {ApiModule} options.api - Editor API module for pass it to the Block Tunes
    */
   constructor({
+    id,
     name,
     data,
     Tool,
     settings,
     api,
   }: BlockConstructorOptions) {
+    this.id = id;
     this.name = name;
     this.class = Tool;
     this.settings = settings;
@@ -542,6 +555,7 @@ export default class Block {
         measuringEnd = window.performance.now();
 
         return {
+          id: this.id,
           tool: this.name,
           data: finishedExtraction,
           time: measuringEnd - measuringStart,

--- a/src/components/core.ts
+++ b/src/components/core.ts
@@ -2,7 +2,7 @@ import $ from './dom';
 // eslint-disable-next-line import/no-duplicates
 import * as _ from './utils';
 // eslint-disable-next-line import/no-duplicates
-import { LogLevels } from './utils';
+import {generateUuidv4, LogLevels} from './utils';
 import { EditorConfig, OutputData, SanitizerConfig } from '../../types';
 import { EditorModules } from '../types-internal/editor-modules';
 import I18n from './i18n';
@@ -176,6 +176,7 @@ export default class Core {
      * @type {{type: (*), data: {text: null}}}
      */
     const initialBlockData = {
+      id: generateUuidv4(),
       type: this.config.initialBlock,
       data: {},
     };

--- a/src/components/modules/blockManager.ts
+++ b/src/components/modules/blockManager.ts
@@ -12,6 +12,7 @@ import $ from '../dom';
 import * as _ from '../utils';
 import Blocks from '../blocks';
 import { BlockToolConstructable, BlockToolData, PasteEvent } from '../../../types';
+import {generateUuidv4} from '../utils';
 
 /**
  * @typedef {BlockManager} BlockManager
@@ -190,14 +191,14 @@ export default class BlockManager extends Module {
     Listeners.on(
       document,
       'copy',
-      (e: ClipboardEvent) => BlockEvents.handleCommandC(e)
+      (e: ClipboardEvent) => BlockEvents.handleCommandC(e),
     );
 
     /** Copy and cut */
     Listeners.on(
       document,
       'cut',
-      (e: ClipboardEvent) => BlockEvents.handleCommandX(e)
+      (e: ClipboardEvent) => BlockEvents.handleCommandX(e),
     );
   }
 
@@ -210,10 +211,11 @@ export default class BlockManager extends Module {
    *
    * @returns {Block}
    */
-  public composeBlock({ tool, data = {} }: {tool: string; data?: BlockToolData}): Block {
+  public composeBlock({ tool, id = generateUuidv4(), data = {} }: {tool: string; id?: string; data?: BlockToolData}): Block {
     const settings = this.Editor.Tools.getToolSettings(tool);
     const Tool = this.Editor.Tools.available[tool] as BlockToolConstructable;
     const block = new Block({
+      id,
       name: tool,
       data,
       Tool,
@@ -239,12 +241,14 @@ export default class BlockManager extends Module {
    * @returns {Block}
    */
   public insert({
+    id = generateUuidv4(),
     tool = this.config.initialBlock,
     data = {},
     index,
     needToFocus = true,
     replace = false,
   }: {
+    id?: string;
     tool?: string;
     data?: BlockToolData;
     index?: number;
@@ -258,9 +262,12 @@ export default class BlockManager extends Module {
     }
 
     const block = this.composeBlock({
+      id,
       tool,
       data,
     });
+
+    console.log('INSERT: ' + id + ' (' + tool + ')');
 
     this._blocks.insert(newIndex, block, replace);
 

--- a/src/components/modules/paste.ts
+++ b/src/components/modules/paste.ts
@@ -739,10 +739,10 @@ export default class Paste extends Module {
    *
    * @returns {void}
    */
-  private insertEditorJSData(blocks: Array<Pick<SavedData, 'data' | 'tool'>>): void {
+  private insertEditorJSData(blocks: Array<Pick<SavedData, 'id' | 'data' | 'tool'>>): void {
     const { BlockManager, Tools } = this.Editor;
 
-    blocks.forEach(({ tool, data }, i) => {
+    blocks.forEach(({ id, tool, data }, i) => {
       let needToReplaceCurrentBlock = false;
 
       if (i === 0) {
@@ -752,6 +752,7 @@ export default class Paste extends Module {
       }
 
       BlockManager.insert({
+        id,
         tool,
         data,
         replace: needToReplaceCurrentBlock,

--- a/src/components/modules/renderer.ts
+++ b/src/components/modules/renderer.ts
@@ -1,7 +1,7 @@
 import Module from '../__module';
 /* eslint-disable import/no-duplicates */
 import * as _ from '../utils';
-import { ChainData } from '../utils';
+import {ChainData, generateUuidv4} from '../utils';
 import { BlockToolConstructable, OutputBlockData } from '../../../types';
 
 /**
@@ -24,12 +24,14 @@ export default class Renderer extends Module {
    *
    * blocks: [
    *   {
+   *     id   : 'eab2b1cd-a3d3-48d1-aadb-bd821d8ec871',
    *     type : 'paragraph',
    *     data : {
    *       text : 'Hello from Codex!'
    *     }
    *   },
    *   {
+   *     id   : '391a1351-6ec6-473b-8b99-b20507e2d4c2',
    *     type : 'paragraph',
    *     data : {
    *       text : 'Leave feedback if you like it!'
@@ -64,12 +66,17 @@ export default class Renderer extends Module {
    */
   public async insertBlock(item: OutputBlockData): Promise<void> {
     const { Tools, BlockManager } = this.Editor;
+    const id = item.id || generateUuidv4();
     const tool = item.type;
     const data = item.data;
+
+    console.log('BEFORE insertBlock: ' + item.id);
+    console.log('AFTER insertBlock: ' + id);
 
     if (tool in Tools.available) {
       try {
         BlockManager.insert({
+          id,
           tool,
           data,
         });
@@ -81,6 +88,7 @@ export default class Renderer extends Module {
       /** If Tool is unavailable, create stub Block for it */
       const stubData = {
         savedData: {
+          id,
           type: tool,
           data,
         },
@@ -95,6 +103,7 @@ export default class Renderer extends Module {
       }
 
       const stub = BlockManager.insert({
+        id,
         tool: Tools.stubTool,
         data: stubData,
       });

--- a/src/components/modules/saver.ts
+++ b/src/components/modules/saver.ts
@@ -76,7 +76,7 @@ export default class Saver extends Module {
 
     _.log('[Editor.js saving]:', 'groupCollapsed');
 
-    allExtractedData.forEach(({ tool, data, time, isValid }) => {
+    allExtractedData.forEach(({ id, tool, data, time, isValid }) => {
       totalTime += time;
 
       /**
@@ -103,6 +103,7 @@ export default class Saver extends Module {
       }
 
       blocks.push({
+        id,
         type: tool,
         data,
       });

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -549,6 +549,20 @@ export function getValidUrl(url: string): string {
 }
 
 /**
+ * Creates a UUID v4 version
+ *
+ * @returns {string}
+ */
+export function generateUuidv4(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    // tslint:disable: no-bitwise
+    // tslint:disable-next-line: triple-equals
+    const r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+    return v.toString(16);
+  });
+}
+
+/**
  * Opens new Tab with passed URL
  *
  * @param {string} url - URL address to redirect

--- a/src/types-internal/block-data.d.ts
+++ b/src/types-internal/block-data.d.ts
@@ -4,6 +4,7 @@ import {BlockToolData} from '../../types/tools';
  * Tool's saved data
  */
 export interface SavedData {
+    id: string;
     tool: string;
     data: BlockToolData;
     time: number;
@@ -13,6 +14,7 @@ export interface SavedData {
  * Tool's data after validation
  */
 export interface ValidatedData {
+    id?: string;
     tool?: string;
     data?: BlockToolData;
     time?: number;

--- a/types/api/block.d.ts
+++ b/types/api/block.d.ts
@@ -8,6 +8,10 @@ export interface BlockAPI {
   /**
    * Tool name
    */
+  readonly id: string;
+  /**
+   * Tool name
+   */
   readonly name: string;
 
   /**

--- a/types/data-formats/output-data.d.ts
+++ b/types/data-formats/output-data.d.ts
@@ -5,6 +5,10 @@ import {BlockToolData} from '../tools';
  */
 export interface OutputBlockData {
   /**
+   * Unique Id of the block
+   */
+  id: string;
+  /**
    * Too type
    */
   type: string;


### PR DESCRIPTION
I'm adressing #873 with this PR. 

Tested Features:
* Existing data: If your previous block does not have an "id" property, it will create a new unique id
* Existing data: If your previous block does have an "id" property, it will keep the existing unique id
* Existing data: If a block gets changed the "id" property stays the same 
* Insert New Block: It will create a new unique id
* Move Blocks (Up/Down): It will keep the existing unique id

Important Note:
* If you "transform/transition" an existing block to another block it will receive a NEW unique id