### PR TITLE
Remove project id and Correct the command name.

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,4 @@
 {
-  "projectId": "tivr7e",
   "env": {
   },
   "fixturesFolder": "test/cypress/fixtures",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "svg": "svg-sprite-generate -d src/assets/ -o dist/sprite.svg",
     "pull_tools": "git submodule update --init --recursive",
     "checkout_tools": "git submodule foreach git pull origin master",
-    "test:e2e": "cypress open"
+    "test:e2e": "cypress run"
   },
   "author": "CodeX",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR removes the `project id` from the cypress.json and changes the command from `cypress open` to `cypress run`