### PR TITLE
Add data property into InlineToolConstructorOptions

### DIFF
--- a/types/tools/inline-tool.d.ts
+++ b/types/tools/inline-tool.d.ts
@@ -43,6 +43,7 @@ export interface InlineTool extends BaseTool {
  */
 export interface InlineToolConstructorOptions {
   api: API;
+  data?: undefined;
   config?: ToolConfig;
 }
 


### PR DESCRIPTION
```typescript
// before
import { BaseTool, BlockTool, BlockToolConstructorOptions, InlineToolConstructorOptions } from "@editorjs/editorjs";

export class Example implements BaseTool, BlockTool {
  ...
  constructor({ data }: BlockToolConstructorOptions | (InlineToolConstructorOptions & { data?: undefined })) {
    console.log(data);
  }
  ...
}

// after
import { BaseTool, BlockTool, BlockToolConstructorOptions, InlineToolConstructorOptions } from "@editorjs/editorjs";

export class Example implements BaseTool, BlockTool {
  ...
  constructor({ data }: BlockToolConstructorOptions | InlineToolConstructorOptions) {
    console.log(data);
  }
  ...
}
```

I am using EditorJS based on TypeScript, but I want to add it because there is an inconvenient part of the type definition.
