### PR TITLE
Remove unnecessary window promise from Initialisation test.

### DIFF
--- a/test/cypress/tests/initialization.spec.ts
+++ b/test/cypress/tests/initialization.spec.ts
@@ -17,14 +17,12 @@ describe('Editor basic initialization', () => {
     });
 
     it('should create a visible UI', () => {
-      cy.window().then((window) => {
-        /**
-         * Assert if created instance is visible or not.
-         */
-        cy.get('[data-cy=editorjs]')
-          .get('div.codex-editor')
-          .should('be.visible');
-      });
+      /**
+       * Assert if created instance is visible or not.
+       */
+      cy.get('[data-cy=editorjs]')
+        .get('div.codex-editor')
+        .should('be.visible');
     });
   });
 });


### PR DESCRIPTION
Removes the unnecessary promise to access the browser `window` object which is not used. 

```javascript
it('should create a visible UI', () => {
      cy.window().then((window) => {
        /**
         * Assert if created instance is visible or not.
         */
        cy.get('[data-cy=editorjs]')
          .get('div.codex-editor')
          .should('be.visible');
});
```


In this test the cy.window().then() promise is unnecessary as window object is not actually being used.