### PR TITLE
Adding `configuration` field-type to EditorJS class

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -113,6 +113,7 @@ declare class EditorJS {
   public toolbar: Toolbar;
   public inlineToolbar: InlineToolbar;
   public readOnly: ReadOnly;
+  public configuration: EditorConfig;
   constructor(configuration?: EditorConfig|string);
 
   /**


### PR DESCRIPTION
`configuration` object is a part of EditorJS instance, therefore, we must have its type definition in this file.
So that we won't get any typescript errors on accessing this object on other projects.

i.e. 
> Property 'configuration' does not exist on type 'EditorJS'. ts(2339)