### PR TITLE
Make submodules installation hint more explicit

### DIFF
--- a/check_submodules.sh
+++ b/check_submodules.sh
@@ -1,0 +1,13 @@
+submodules=$(grep path .gitmodules | sed 's/.*= //')
+missing=false
+
+while read -r line ; do
+    if ! test -f "$line/.git"; then
+        echo "    - $line submodule is not initialized."
+        missing=true
+    fi
+done <<< "$submodules"
+
+if [ "$missing" = true ] ; then
+    printf "\n(!) Some modules are missing, consider running yarn pull_tools\n\n"
+fi

--- a/example/example-dev.html
+++ b/example/example-dev.html
@@ -28,11 +28,11 @@
     </div>
     <div class="ce-example__content _ce-example__content--small">
       <div id="editorjs"></div>
-      <div id="hint-core" style="text-align: center;">
-        No core bundle file found. Run <code class="inline-code">yarn build</code>
-      </div>
       <div id="hint-tools" style="text-align: center;">
         No submodules found. Run <code class="inline-code">yarn pull_tools</code>
+      </div>
+      <div id="hint-core" style="text-align: center;">
+        No core bundle file found. Run <code class="inline-code">yarn build</code>
       </div>
       <div class="ce-example__button" id="saveButton">
         editor.save()

--- a/example/example-rtl.html
+++ b/example/example-rtl.html
@@ -27,11 +27,11 @@
   </div>
   <div class="ce-example__content _ce-example__content--small">
     <div id="editorjs"></div>
-    <div id="hint-core" style="text-align: center;">
-      No core bundle file found. Run <code class="inline-code">yarn build</code>
-    </div>
     <div id="hint-tools" style="text-align: center;">
       No submodules found. Run <code class="inline-code">yarn pull_tools</code>
+    </div>
+    <div id="hint-core" style="text-align: center;">
+      No core bundle file found. Run <code class="inline-code">yarn build</code>
     </div>
     <div class="ce-example__button" id="saveButton">
       editor.save()

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   ],
   "scripts": {
     "clear": "rimraf dist && mkdirp dist",
-    "build": "yarn clear && yarn svg && yarn build:webpack:prod",
-    "build:dev": "yarn clear && yarn svg && yarn build:webpack:dev",
+    "build": "yarn clear && yarn svg && bash ./check_submodules.sh && yarn build:webpack:prod",
+    "build:dev": "yarn clear && yarn svg && bash ./check_submodules.sh && yarn build:webpack:dev",
     "build:webpack:dev": "webpack --mode development --progress --display-error-details --display-entrypoints --watch",
     "build:webpack:prod": "webpack --mode production",
     "lint": "eslint src/ --ext .ts && yarn lint:tests",


### PR DESCRIPTION
Hi there.

If you open an example HTML file now you will see 2 errors:
`No core bundle file found. Run yarn build`
`No submodules found. Run yarn pull_tools`

But you're not able to build a core bundle w/o submodules and if you tried you would get a confusing error about path resolving.
I've swapped those messages to make it a bit simpler.

**UPD.**
I've just added a script to check missing submodules to run it before a build. Output is shown below.
<img width="330" alt="pic" src="https://user-images.githubusercontent.com/37555845/112735314-1e1e5680-8f5c-11eb-8787-045d486261a4.png">

Also, I noticed that `.gitmodules` contains `example/tools/underline` is missing in `git submodule status` => `git submodule update --init --recursive`. Is it an error or I'm doing something wrong?