### PR TITLE
Improved dev environment setup experience by documenting `yarn _tools:make`

### DIFF
--- a/example/example-dev.html
+++ b/example/example-dev.html
@@ -2,7 +2,8 @@
  Use this page for debugging purposes.
 
  Editor Tools are loaded as git-submodules.
- You can pull modules by running `yarn pull_tools` and start experimenting.
+ You can pull modules by running `yarn pull_tools`, `yarn _tools:make` and start experimenting.
+ Build your changes with `yarn build:dev` and open this page in your browser.
  -->
 <!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
The current `example-dev.html` tells about `yarn pull_tools` but does not mention how to install plugins to make the page work.
I created a yarn script to update yarn packages in submodules and rebuild them so that the example-dev page works