### PR TITLE
Add tunes to block insert API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -75,7 +75,7 @@ use 'move' instead)
 
 `insertNewBlock()` - __Deprecated__ insert new Block after working place
 
-`insert(type?: string, data?: BlockToolData, config?: ToolConfig, index?: number, needToFocus?: boolean)` - insert new Block with passed parameters
+`insert(type?: string, data?: BlockToolData, config?: ToolConfig, index?: number, needToFocus?: boolean, tunes?: {[name: string]: BlockTuneData})` - insert new Block with passed parameters
 
 #### SanitizerAPI
 

--- a/src/components/modules/api/blocks.ts
+++ b/src/components/modules/api/blocks.ts
@@ -1,5 +1,6 @@
 import { BlockAPI as BlockAPIInterface, Blocks } from '../../../../types/api';
 import { BlockToolData, OutputData, ToolConfig } from '../../../../types';
+import { BlockTuneData } from '../../../../types/block-tunes/block-tune-data';
 import * as _ from './../../utils';
 import BlockAPI from '../../block/api';
 import Module from '../../__module';
@@ -218,19 +219,22 @@ export default class BlocksAPI extends Module {
    * @param {ToolConfig} config — Tool config
    * @param {number?} index — index where to insert new Block
    * @param {boolean?} needToFocus - flag to focus inserted Block
+   * @param {tunes?} tunes - tune data
    */
   public insert = (
     type: string = this.config.defaultBlock,
     data: BlockToolData = {},
     config: ToolConfig = {},
     index?: number,
-    needToFocus?: boolean
+    needToFocus?: boolean,
+    tunes?: {[name: string]: BlockTuneData}
   ): void => {
     this.Editor.BlockManager.insert({
       tool: type,
       data,
       index,
       needToFocus,
+      tunes: tunes
     });
   }
 


### PR DESCRIPTION
This PR allows users to insert blocks via the API, and tune them at the same time. This is a feature we've struggled without as there is currently no way to programmatically tune a block either.