### PR TITLE
Use "npm dist-tag add" instead of "yarn tag add"

### DIFF
--- a/.github/workflows/publish-package-to-npm.yml
+++ b/.github/workflows/publish-package-to-npm.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Add LATEST tag for the published package if this is not a prerelease version
         if: github.event.release.prerelease != true
-        run: yarn tag add ${{ steps.package.outputs.name }}@${{ steps.package.outputs.version }} latest
+        run: npm dist-tag add  ${{ steps.package.outputs.name }}@${{ steps.package.outputs.version }} latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/publish-package-to-npm.yml
+++ b/.github/workflows/publish-package-to-npm.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Add LATEST tag for the published package if this is not a prerelease version
         if: github.event.release.prerelease != true
-        run: npm dist-tag add  ${{ steps.package.outputs.name }}@${{ steps.package.outputs.version }} latest
+        run: npm dist-tag add ${{ steps.package.outputs.name }}@${{ steps.package.outputs.version }} latest
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
`yarn tag add` somehow throws an error for existing versions, but `npm dist-tag add` works correctly.

resolve #1692