### PR TITLE
Config option `ignoreDeleteFullBlockByKey`

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Unreleased
+
+- `New` - Config option `ignoreDeleteFullBlockByKey` to disable block deletion via backspace
+
 ### 2.22.0
 
 - `New` - `onChange` callback now receive Block API object of affected block

--- a/example/example-delete.html
+++ b/example/example-delete.html
@@ -1,0 +1,226 @@
+<!--
+  This page contains example of editor.js ignoreDeleteFullBlockByKey feature.
+  See <script> section -> ignoreDeleteFullBlockByKey property of the configuration object
+
+  \ (•◡•) /
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Editor.js 🤩🧦🤨 example</title>
+  <link href="https://fonts.googleapis.com/css?family=PT+Mono" rel="stylesheet">
+  <link href="assets/demo.css" rel="stylesheet">
+  <script src="assets/json-preview.js"></script>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+</head>
+<body>
+<div class="ce-example">
+  <div class="ce-example__header">
+    <a class="ce-example__header-logo" href="https://codex.so/editor">Editor.js 🤩🧦🤨</a>
+
+    <div class="ce-example__header-menu">
+      <a href="https://github.com/editor-js" target="_blank">Plugins</a>
+      <a href="https://editorjs.io/usage" target="_blank">Usage</a>
+      <a href="https://editorjs.io/configuration" target="_blank">Configuration</a>
+      <a href="https://editorjs.io/creating-a-block-tool" target="_blank">API</a>
+    </div>
+  </div>
+  <div class="ce-example__content _ce-example__content--small">
+    <div id="editorjs"></div>
+    <div id="hint-core" style="text-align: center;">
+      No core bundle file found. Run <code class="inline-code">yarn build</code>
+    </div>
+
+    <div class="ce-example__button" id="saveButton">
+      editor.save()
+    </div>
+  </div>
+  <div class="ce-example__output">
+    <pre class="ce-example__output-content" id="output"></pre>
+
+    <div class="ce-example__output-footer">
+      <a href="https://codex.so" style="font-weight: bold;">Made by CodeX</a>
+    </div>
+  </div>
+</div>
+
+<!-- Load Tools -->
+<script src="https://cdn.jsdelivr.net/npm/@editorjs/header@latest"></script><!-- Header -->
+<script src="https://cdn.jsdelivr.net/npm/@editorjs/delimiter@latest"></script><!-- Delimiter -->
+
+<!-- Load Editor.js's Core -->
+<script src="../dist/editor.js" onload="document.getElementById('hint-core').hidden = true"></script>
+
+<!-- Initialization -->
+<script>
+  /**
+   * Saving button
+   */
+  const saveButton = document.getElementById('saveButton');
+
+  /**
+   * Custom plugin without input field
+   */
+  class CustomPlugin {
+
+    VALUES = ['the', 'quick', 'brown', 'fox', 'jumps', 'over', 'the', 'lazy', 'dog'];
+
+    constructor(props) {
+        this.data = props.data
+    }
+
+    static get toolbox() {
+      return {
+        title: 'Custom plugin',
+        icon: 'CP'
+      };
+    }
+
+    render() {
+      this.el = document.createElement('div');
+      this.el.style.border = '1px dashed #000';
+      this.el.style.padding = '10px';
+      this.el.innerText = this.data && this.data.text || 'No Data';
+      return this.el;
+    }
+
+    save(blockContent) {
+      return this.data;
+    }
+
+    renderSettings() {
+      const wrapper = document.createElement('div');
+      let button = document.createElement('div');
+      button.classList.add('cdx-settings-button');
+      button.innerHTML = 'V';
+      wrapper.appendChild(button);
+      button.addEventListener('click', () => {
+        const random = Math.floor(Math.random() * this.VALUES.length);
+        this.data = { text: this.VALUES[random] }
+        this.el.innerText = this.data.text
+      });
+      return wrapper;
+    }
+  }
+
+  /**
+   * To initialize the Editor, create a new instance with configuration object
+   * @see docs/installation.md for mode details
+   */
+  var editor = new EditorJS({
+    /**
+     * Wrapper of Editor
+     */
+    holder: 'editorjs',
+
+    ignoreDeleteFullBlockByKey: true,
+
+    /**
+     * Tools list
+     */
+     tools: {
+      paragraph: {
+        config: {
+          placeholder: "Enter something"
+        }
+      },
+      /**
+       * Each Tool is a Plugin. Pass them via 'class' option with necessary settings {@link docs/tools.md}
+       */
+      header: {
+        class: Header,
+        inlineToolbar: ['link'],
+        config: {
+          placeholder: 'Header'
+        },
+        shortcut: 'CMD+SHIFT+H'
+      },
+
+      custom: {
+        class: CustomPlugin
+      },
+
+      delimiter: Delimiter,
+    },
+
+    /**
+     * Initial Editor data
+     */
+    data: {
+      blocks: [
+        {
+          type: "header",
+          data: {
+            text: "Editor.js",
+            level: 2
+          }
+        },
+        {
+          type : 'paragraph',
+          data : {
+            text : 'Here we have plugins which display data but do not have input fields.'
+          }
+        },
+        {
+          type: "custom",
+          data: {
+            text: "Some value"
+          }
+        },
+        {
+          type : 'paragraph',
+          data : {
+            text: 'Hitting backspace from the start of this block will not remove the previous block when ignoreDeleteFullBlockByKey is set to true.'
+          }
+        },
+        {
+          type : 'delimiter',
+          data : {}
+        },
+        {
+          type : 'paragraph',
+          data : {
+            text: 'The delimiter can be removed with backspace, as it is empty.'
+          }
+        },
+        {
+          type : 'delimiter',
+          data : {}
+        },
+        {
+          type: "custom",
+          data: {
+            text: "Another value"
+          }
+        },
+        {
+          type : 'paragraph',
+          data : {
+            text : ''
+          }
+        },
+        {
+          type : 'paragraph',
+          data : {
+            text : 'The empty paragraph above this will be removed when hitting backspace there. The caret will move to this block, as the custom plugin has no input.'
+          }
+        }
+      ]
+    },
+    onReady: function(){
+      saveButton.click();
+    },
+  });
+
+  /**
+   * Saving example
+   */
+  saveButton.addEventListener('click', function () {
+    editor.save().then((savedData) => {
+      cPreview.show(savedData, document.getElementById("output"));
+    });
+  });
+</script>
+</body>
+</html>

--- a/types/configs/editor-config.d.ts
+++ b/types/configs/editor-config.d.ts
@@ -101,4 +101,12 @@ export interface EditorConfig {
    * Common Block Tunes list. Will be added to all the blocks which do not specify their own 'tunes' set
    */
   tunes?: string[];
+
+  /**
+   * If set to true, previous blocks with data will not be removed when
+   * backspace is hit at the beginning of a block. This is useful if you have
+   * "data" blocks which do not have input fields and don't want them to be
+   * accidentally removed by a keystroke.
+   */
+  ignoreDeleteFullBlockByKey?: boolean;
 }


### PR DESCRIPTION
to disable block deletion via backspace.

Background:

In our project we have some blocks which are not inline editable, but have a modal editor. All those plugins do not include any input fields. When users hit the backspace key, the whole block will be deleted without being able to undo. With this customizable setting we want to disable deleting those blocks, so the users will have to explicitly click the X button in the tune settings to remove the block.