### PR TITLE
fix(blocks): plugin's destroy() method will be called on blocks removing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.22.2
+
+- `Fix` — Block's destroy method is called on block deletion
+
 ### 2.22.1
 
 - `Fix` — I18n for internal Block Tunes [#1661](https://github.com/codex-team/editor.js/issues/1661)

--- a/src/components/modules/blockManager.ts
+++ b/src/components/modules/blockManager.ts
@@ -439,6 +439,7 @@ export default class BlockManager extends Module {
 
     const blockToRemove = this._blocks[index];
 
+    blockToRemove.destroy();
     this._blocks.remove(index);
 
     /**

--- a/src/components/utils/events.ts
+++ b/src/components/utils/events.ts
@@ -1,3 +1,5 @@
+import { isEmpty } from '../utils';
+
 /**
  * @class EventDispatcher
  *
@@ -68,7 +70,7 @@ export default class EventsDispatcher<Events extends string = string> {
    * @param {object} data - subscribers get this data when they were fired
    */
   public emit(eventName: Events, data?: object): void {
-    if (!this.subscribers[eventName]) {
+    if (isEmpty(this.subscribers) || !this.subscribers[eventName]) {
       return;
     }
 


### PR DESCRIPTION
For now there is no call for a `destroy()` method after block's removing.

This PR added this call.