### PR TITLE
fix: #1740 fix holder undefined error

### DIFF
--- a/src/components/modules/api/blocks.ts
+++ b/src/components/modules/api/blocks.ts
@@ -170,7 +170,12 @@ export default class BlocksAPI extends Module {
    * @param {OutputData} data — Saved Editor data
    */
   public render(data: OutputData): Promise<void> {
-    this.Editor.BlockManager.clear();
+    const needToAddDefaultBlock = !data.blocks.length
+    this.Editor.BlockManager.clear(needToAddDefaultBlock);
+
+    if(needToAddDefaultBlock) {
+      return Promise.resolve()
+    }
 
     return this.Editor.Renderer.render(data.blocks);
   }

--- a/src/components/modules/toolbar/index.ts
+++ b/src/components/modules/toolbar/index.ts
@@ -190,7 +190,7 @@ export default class Toolbar extends Module<ToolbarNodes> {
       this.Editor.BlockSettings.close();
     }
 
-    const currentBlock = this.Editor.BlockManager.currentBlock.holder;
+    const currentBlock = this.Editor.BlockManager.currentBlock?.holder;
 
     /**
      * If no one Block selected as a Current


### PR DESCRIPTION
Related issue：
https://github.com/codex-team/editor.js/issues/1740

There is no currentBlock after calling `api.blocks.render({blocks:[]})` with empty blocks, so we should protect `currentBlock` in this situation like this:
```typescript
  // file: src/components/modules/api/blocks.ts:163
  /**
   * Clear Editor's area
   */
  public clear(): void {
    this.Editor.BlockManager.clear(true);
    this.Editor.InlineToolbar.close();
  }
```
This situation could happen in  package `editorjs-undo`, reference is [here](https://github.com/kommitters/editorjs-undo/blob/master/src/index.js#L142)