### PR TITLE
repair table node data when paste

### DIFF
--- a/src/components/modules/paste.ts
+++ b/src/components/modules/paste.ts
@@ -552,7 +552,8 @@ export default class Paste extends Module {
         }, {});
         const customConfig = Object.assign({}, toolTags, tool.baseSanitizeConfig);
 
-        content.innerHTML = clean(content.innerHTML, customConfig);
+        if(!(/<tbody>/i.test(content.innerHTML)))
+          content.innerHTML = clean(content.innerHTML, customConfig);
 
         const event = this.composePasteEvent('tag', {
           data: content,


### PR DESCRIPTION
when I add the ability of paste from word table or html table for https://github.com/editor-js/table，I found event.tag of table has lost tr/td data

in src/components/modules/paste.ts

the innerHTML of table node is tbody，and it's innerHTML not include tr/td, 

my method is keep the innerHTML of table（no clean）

new table plugin is in

https://github.com/kooky126/table

it's working

