### PR TITLE
Sanitize outerHTML instead of innerHTML

### DIFF
--- a/src/components/modules/paste.ts
+++ b/src/components/modules/paste.ts
@@ -552,7 +552,18 @@ export default class Paste extends Module {
         }, {});
         const customConfig = Object.assign({}, toolTags, tool.baseSanitizeConfig);
 
-        content.innerHTML = clean(content.innerHTML, customConfig);
+        if (node.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
+          content.innerHTML = clean(content.innerHTML, customConfig);
+        } else {
+          const sanitizerWrapper = document.createElement('div');
+
+          sanitizerWrapper.innerHTML = clean(content.outerHTML, customConfig);
+          const sanitized = sanitizerWrapper.children[0].cloneNode(true);
+
+          content.replaceWith(sanitized);
+          content = sanitized;
+          sanitizerWrapper.remove();
+        }
 
         const event = this.composePasteEvent('tag', {
           data: content,


### PR DESCRIPTION
This fixes two things
1. the outerHTML of the pasted content is also santized
2. HTMLJanitor has a bug with tables that causes it to remove all the tags if you only pass the innerHTML resulting in a <table> with just text inside and no elements

What the code does

Checks if the pasted content is a data-fragment or an Element. Data fragments are still processed in the same way. Elements are now sanitized including the root node. 

```javascript
if (node.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
  content.innerHTML = (0, _sanitizer.clean)(content.innerHTML, customConfig);
} else {
  var sanitizerWrapper = document.createElement('div');
  sanitizerWrapper.innerHTML = (0, _sanitizer.clean)(content.outerHTML, customConfig);
  var sanitized = sanitizerWrapper.children[0].cloneNode(true);
  content.replaceWith(sanitized);
  content = sanitized;
  sanitizerWrapper.remove();
}
```
First we create a new element to handle the sanitization without affecting the content node
We then insert the sanitized node into the wrapper
We replace the content with the sanitized node. We cannot just do content.outerHTML = clean(content.outerHTML...) because that would detach the content node from the DOM causing the content.parentNode to be null which then breaks the next iteration of the loop we are inside currently
We then set the content variable to the sanitized node and remove the wrapper from the DOM.

Related to https://github.com/codex-team/editor.js/pull/1804 but retains the sanitization behavior. 