### PR TITLE
fix: Multiple editor.js instances throws an error

### DIFF
--- a/src/components/modules/blockManager.ts
+++ b/src/components/modules/blockManager.ts
@@ -681,6 +681,18 @@ export default class BlockManager extends Module {
     /**
      * Update current block active input
      */
+
+    /**
+     * Fix: when we have multiple instances and
+     * currentBlockIndex is -1.
+     * 
+     * The method updateCurrentInput fails because the index not exists
+     * in the array
+     */
+
+     if(this.currentBlockIndex < 0) {
+      return;
+    }
     this.currentBlock.updateCurrentInput();
 
     return this.currentBlock;


### PR DESCRIPTION
## Issue

When I try to use a multiple instances of editor.js in the same page I get the next error:

![Captura de Pantalla 2021-12-21 a la(s) 14 30 07](https://user-images.githubusercontent.com/29413535/147160070-b5e97d32-bd3b-4e17-9238-1a80d5af979a.png)

## Solution

The method updateCurrentInput fails because the index not exists in the array.
I changed the method with a prev validation for only update the current block if the index exists

Maybe will be related #1503 