### PR TITLE
[Fix] isFunction function for async functions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,7 +20,7 @@
 - `New` — `API` — The new `UiApi` section was added. It allows accessing some editor UI nodes and methods.
 - `Refactoring` — Toolbox became a standalone class instead of a Module. It can be accessed only through the Toolbar module.
 - `Refactoring` — CI flow optimized.
-- `Fix` - Recognize async onPaste handlers in tools [#1803](https://github.com/codex-team/editor.js/issues/1803)
+- `Fix` - Recognize async `onPaste` handlers in tools [#1803](https://github.com/codex-team/editor.js/issues/1803).
 
 ### 2.22.3
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.23.1
+
+- `Fix` - Recognize async onPaste handlers in tools [#1803](https://github.com/codex-team/editor.js/issues/1803)
+
 ### 2.23.0
 
 - `Improvement` — *EditorConfig* — The `onChange` callback now accepts two arguments: EditorJS API and the CustomEvent with `type` and `detail` allowing to determine what happened with a Block

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-### 2.23.1
-
-- `Fix` - Recognize async onPaste handlers in tools [#1803](https://github.com/codex-team/editor.js/issues/1803)
-
 ### 2.23.0
 
 - `Improvement` — *EditorConfig* — The `onChange` callback now accepts two arguments: EditorJS API and the CustomEvent with `type` and `detail` allowing to determine what happened with a Block
@@ -24,6 +20,7 @@
 - `New` — `API` — The new `UiApi` section was added. It allows accessing some editor UI nodes and methods.
 - `Refactoring` — Toolbox became a standalone class instead of a Module. It can be accessed only through the Toolbar module.
 - `Refactoring` — CI flow optimized.
+- `Fix` - Recognize async onPaste handlers in tools [#1803](https://github.com/codex-team/editor.js/issues/1803)
 
 ### 2.22.3
 

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -194,8 +194,8 @@ export function typeOf(object: any): string {
  * @returns {boolean}
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isFunction(fn: any): fn is Function {
-  return typeOf(fn) === 'function';
+export function isFunction(fn: any): fn is (...args: any[]) => any {
+  return typeOf(fn) === 'function' || typeOf(fn) === 'asyncfunction';
 }
 
 /**

--- a/test/cypress/tests/utils.spec.ts
+++ b/test/cypress/tests/utils.spec.ts
@@ -1,0 +1,62 @@
+import { isFunction } from '../../../src/components/utils';
+
+function syncFunction(): void {}
+
+async function asyncFunction(): Promise<void> {}
+
+const syncArrowFunction = (): void => {};
+
+const asyncArrowFunction = async (): Promise<void> => {};
+
+describe('isFunction function', () => {
+  it('should recognise sync functions', () => {
+    /**
+     * Act
+     */
+    const commonFunctionResult = isFunction(syncFunction);
+    const arrowFunctionResult = isFunction(syncArrowFunction);
+
+    /**
+     * Assert
+     */
+    expect(commonFunctionResult).to.eq(true);
+    expect(arrowFunctionResult).to.eq(true);
+  });
+
+  it('should recognise async functions', () => {
+    /**
+     * Act
+     */
+    const commonFunctionResult = isFunction(asyncFunction);
+    const arrowFunctionResult = isFunction(asyncArrowFunction);
+
+    /**
+     * Assert
+     */
+    expect(commonFunctionResult).to.eq(true);
+    expect(arrowFunctionResult).to.eq(true);
+  });
+
+  it('should return false if it isn\'t a function', () => {
+    /**
+     * Arrange
+     */
+    const obj = {};
+    const num = 123;
+    const str = '123';
+
+    /**
+     * Act
+     */
+    const objResult = isFunction(obj);
+    const numResult = isFunction(num);
+    const strResult = isFunction(str);
+
+    /**
+     * Assert
+     */
+    expect(objResult).to.eq(false);
+    expect(numResult).to.eq(false);
+    expect(strResult).to.eq(false);
+  });
+});

--- a/test/cypress/tests/utils.spec.ts
+++ b/test/cypress/tests/utils.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
 import { isFunction } from '../../../src/components/utils';
 
 function syncFunction(): void {}


### PR DESCRIPTION
I've added a second condition for AsyncFunction and changed the return type because Function is a banned type.
This PR will fix #1803.