### PR TITLE
chore(readme): roadmap added

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 <img align="right" width="342" src="https://user-images.githubusercontent.com/3684889/152149321-3f9c585d-7d87-4dad-ab14-def0d526e71c.png" hspace="50">
 
 - Collaborative editing
-  - [x] Implement Inline Tools JSON format [#1801](https://github.com/codex-team/editor.js/pull/1801)
+  - [ ] Implement Inline Tools JSON format `In progreess` [#1801](https://github.com/codex-team/editor.js/pull/1801)
   - [ ] Implement Operations creation and transformations
   - [ ] Implement Tools API changes
   - [ ] Implement Server and communication
@@ -27,7 +27,7 @@
 
 - Unified Toolbox
   - [x] Block Tunes moved left [#1815](https://github.com/codex-team/editor.js/pull/1815)
-  - [ ] Toolbox became vertical
+  - [ ] Toolbox became vertical `In progreess`
   - [ ] Ability to display several Toolbox buttons by the single Tool
   - [ ] Conversion Toolbar uses Unified Toolbox
   - [ ] Block Tunes became vertical

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 <img align="right" width="342" src="https://user-images.githubusercontent.com/3684889/152149321-3f9c585d-7d87-4dad-ab14-def0d526e71c.png" hspace="50">
 
 - Collaborative editing
-  - [ ] Implement Inline Tools JSON format `In progreess` [#1801](https://github.com/codex-team/editor.js/pull/1801)
+  - [ ] Implement Inline Tools JSON format `In progress` [#1801](https://github.com/codex-team/editor.js/pull/1801)
   - [ ] Implement Operations creation and transformations
   - [ ] Implement Tools API changes
   - [ ] Implement Server and communication
@@ -27,10 +27,10 @@
 
 - Unified Toolbox
   - [x] Block Tunes moved left [#1815](https://github.com/codex-team/editor.js/pull/1815)
-  - [ ] Toolbox became vertical `In progreess`
+  - [ ] Toolbox become vertical `In progress`
   - [ ] Ability to display several Toolbox buttons by the single Tool
   - [ ] Conversion Toolbar uses Unified Toolbox
-  - [ ] Block Tunes became vertical
+  - [ ] Block Tunes become vertical
   - [ ] Conversion Toolbar added to the Block Tunes
 - Ecosystem improvements
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,38 @@
 [![](https://img.shields.io/npm/l/@editorjs/editorjs?style=flat-square)](https://www.npmjs.com/package/@editorjs/editorjs)
 [![Join the chat at https://gitter.im/codex-team/editor.js](https://badges.gitter.im/codex-team/editor.js.svg)](https://gitter.im/codex-team/editor.js?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-| [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/edge/edge_48x48.png" alt="IE / Edge" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)</br>IE / Edge | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_48x48.png" alt="Firefox" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)</br>Firefox | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png" alt="Chrome" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)</br>Chrome | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari/safari_48x48.png" alt="Safari" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)</br>Safari | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari-ios/safari-ios_48x48.png" alt="iOS Safari" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)</br>iOS Safari | [<img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/opera/opera_48x48.png" alt="Opera" width="24px" height="24px" />](http://godban.github.io/browsers-support-badges/)</br>Opera |
+| | | | | | |
 | --------- | --------- | --------- | --------- | --------- | --------- |
-| Edge 12+ | Firefox 18+ | Chrome 49+ | Safari 10+ | Safari 10+ | Opera 36+
+| <img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/edge/edge_48x48.png" alt="IE / Edge" width="16px" height="16px" /> Edge 12+ | <img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/firefox/firefox_48x48.png" alt="Firefox" width="16px" height="16px" /> Firefox 18+ | <img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/chrome/chrome_48x48.png" alt="Chrome" width="16px" height="16px" /> Chrome 49+ | <img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari/safari_48x48.png" alt="Safari" width="16px" height="16px" /> Safari 10+ | <img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/safari-ios/safari-ios_48x48.png" alt="iOS Safari" width="16px" height="16px" /> iOS Safari 10+ | <img src="https://raw.githubusercontent.com/alrra/browser-logos/master/src/opera/opera_48x48.png" alt="Opera" width="16px" height="16px" /> Opera 36+
+
+
+
+## Roadmap
+
+<img align="right" width="342" src="https://user-images.githubusercontent.com/3684889/152149321-3f9c585d-7d87-4dad-ab14-def0d526e71c.png" hspace="50">
+
+- Collaborative editing
+  - [x] Implement Inline Tools JSON format [#1801](https://github.com/codex-team/editor.js/pull/1801)
+  - [ ] Implement Operations creation and transformations
+  - [ ] Implement Tools API changes
+  - [ ] Implement Server and communication
+  - [ ] Update basic tools to fit the new API
+
+- Unified Toolbox
+  - [x] Block Tunes moved left [#1815](https://github.com/codex-team/editor.js/pull/1815)
+  - [ ] Toolbox became vertical
+  - [ ] Ability to display several Toolbox buttons by the single Tool
+  - [ ] Conversion Toolbar uses Unified Toolbox
+  - [ ] Block Tunes became vertical
+  - [ ] Conversion Toolbar added to the Block Tunes
+- Ecosystem improvements
+
+<a href="https://opencollective.com/editorjs/donate" target="_blank">
+  <img width="459" alt="image" src="https://user-images.githubusercontent.com/3684889/152159639-f5e89362-19a1-4c71-a089-422e875fab7d.png">
+</a>
+
+## 
+
 
 ## If you like a project 💗💗💗
 
@@ -25,7 +54,6 @@ Support us by becoming a sponsor. Your logo will show up here with a link to you
 <a href="https://humm.earth/" target="_blank"><img src="https://images.opencollective.com/hummearth/2a8406a/logo/256.png" width="64"></a>
 <a href="https://tesen.com/" target="_blank"><img src="https://images.opencollective.com/tesen-media-inc/b90cf6a/logo/256.png" width="64"></a>
 <a href="https://slid.cc/" target="_blank"><img src="https://images.opencollective.com/slid_team/ff564d7/logo/256.png" width="64"></a>
-
 
 
  ### Backers


### PR DESCRIPTION
Currently we are working on some tasks. I've added them to the Roadmap section of readme to show community our plans. Also, there will be an ability to support roadmap if someone like it.

Also, I would suggest to create an Issue or Discussion for each Roadmap task where we can provide our investigations and discuss them with community.

<img width="1437" alt="image" src="https://user-images.githubusercontent.com/3684889/152170075-57e95e7d-27c2-4469-bdf9-f63663a463f9.png">

PS. Other readme sections should be updated as well.
