### PR TITLE
fix(ci): incorrect release tag fixed

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.23.1
+
+— `Fix` — Incorrect release tag fixed
+
 ### 2.23.0
 
 - `Improvement` — *EditorConfig* — The `onChange` callback now accepts two arguments: EditorJS API and the CustomEvent with `type` and `detail` allowing to determine what happened with a Block

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/editorjs",
-  "version": "2.23.0-rc.2",
+  "version": "2.23.1",
   "description": "Editor.js — Native JS, based on API and Open Source",
   "main": "dist/editor.js",
   "types": "./types/index.d.ts",


### PR DESCRIPTION
This PR will release the `2.23.1` version including updates that was not included in 2.23.0 because of wrong release tag version.