### PR TITLE
feat(toolbox): popover adapted for mobile devices

### DIFF
--- a/src/components/modules/toolbar/index.ts
+++ b/src/components/modules/toolbar/index.ts
@@ -181,7 +181,10 @@ export default class Toolbar extends Module<ToolbarNodes> {
     } {
     return {
       opened: this.toolboxInstance.opened,
-      close: (): void => this.toolboxInstance.close(),
+      close: (): void => {
+        this.toolboxInstance.close();
+        this.Editor.Caret.setToBlock(this.Editor.BlockManager.currentBlock);
+      },
       open: (): void => {
         /**
          * Set current block to cover the case when the Toolbar showed near hovered Block but caret is set to another Block.

--- a/src/components/modules/toolbar/index.ts
+++ b/src/components/modules/toolbar/index.ts
@@ -510,6 +510,14 @@ export default class Toolbar extends Module<ToolbarNodes> {
      */
     this.eventsDispatcher.on(this.Editor.UI.events.blockHovered, (data: {block: Block}) => {
       /**
+       * Do not move Toolbar by hover on mobile view
+       * @see https://github.com/codex-team/editor.js/issues/1972
+       */
+      if (_.isMobile()) {
+        return;
+      }
+
+      /**
        * Do not move toolbar if Block Settings or Toolbox opened
        */
       if (this.Editor.BlockSettings.opened || this.toolboxInstance.opened) {

--- a/src/components/modules/toolbar/index.ts
+++ b/src/components/modules/toolbar/index.ts
@@ -511,6 +511,7 @@ export default class Toolbar extends Module<ToolbarNodes> {
     this.eventsDispatcher.on(this.Editor.UI.events.blockHovered, (data: {block: Block}) => {
       /**
        * Do not move Toolbar by hover on mobile view
+       *
        * @see https://github.com/codex-team/editor.js/issues/1972
        */
       if (_.isMobile()) {

--- a/src/components/modules/toolbar/index.ts
+++ b/src/components/modules/toolbar/index.ts
@@ -279,7 +279,7 @@ export default class Toolbar extends Module<ToolbarNodes> {
     /**
      * Move Toolbar to the Top coordinate of Block
      */
-    this.nodes.wrapper.style.transform = `translate3D(0, ${Math.floor(toolbarY)}px, 0)`;
+    this.nodes.wrapper.style.top = `${Math.floor(toolbarY)}px`;
 
     /**
      * Plus Button should be shown only for __empty__ __default__ block

--- a/src/components/modules/ui.ts
+++ b/src/components/modules/ui.ts
@@ -270,6 +270,14 @@ export default class UI extends Module<UINodes> {
   }
 
   /**
+   * Updates --vh variable value, which allows to calculate actual 100vh value for mobile browsers
+   */
+  private setAppHeightFraction(): void {
+    const doc = document.documentElement
+    doc.style.setProperty('--vh', (window.innerHeight * 0.01) + 'px');
+  }
+
+  /**
    * Makes Editor.js interface
    */
   private make(): void {
@@ -437,6 +445,11 @@ export default class UI extends Module<UINodes> {
      * Detect mobile version
      */
     this.checkIsMobile();
+
+    /**
+     * Updates stored window height fraction
+     */
+    this.setAppHeightFraction();
   }
 
   /**

--- a/src/components/modules/ui.ts
+++ b/src/components/modules/ui.ts
@@ -270,15 +270,6 @@ export default class UI extends Module<UINodes> {
   }
 
   /**
-   * Updates --vh variable value, which allows to calculate actual 100vh value for mobile browsers
-   */
-  private setAppHeightFraction(): void {
-    const doc = document.documentElement;
-
-    doc.style.setProperty('--vh', (window.innerHeight * 0.01) + 'px');
-  }
-
-  /**
    * Makes Editor.js interface
    */
   private make(): void {
@@ -446,11 +437,6 @@ export default class UI extends Module<UINodes> {
      * Detect mobile version
      */
     this.checkIsMobile();
-
-    /**
-     * Updates stored window height fraction
-     */
-    this.setAppHeightFraction();
   }
 
   /**

--- a/src/components/modules/ui.ts
+++ b/src/components/modules/ui.ts
@@ -273,7 +273,8 @@ export default class UI extends Module<UINodes> {
    * Updates --vh variable value, which allows to calculate actual 100vh value for mobile browsers
    */
   private setAppHeightFraction(): void {
-    const doc = document.documentElement
+    const doc = document.documentElement;
+
     doc.style.setProperty('--vh', (window.innerHeight * 0.01) + 'px');
   }
 

--- a/src/components/ui/toolbox.ts
+++ b/src/components/ui/toolbox.ts
@@ -6,7 +6,6 @@ import ToolsCollection from '../tools/collection';
 import { API } from '../../../types';
 import EventsDispatcher from '../utils/events';
 import Popover, { PopoverEvent } from '../utils/popover';
-import Listeners from '../utils/listeners';
 
 /**
  * @todo check small tools number — there should not be a scroll
@@ -83,11 +82,6 @@ export default class Toolbox extends EventsDispatcher<ToolboxEvent> {
    * Text labels used in the Toolbox. Should be passed from the i18n module
    */
   private i18nLabels: Record<toolboxTextLabelsKeys, string>;
-
-  /**
-   * Listeners util instance
-   */
-   private listeners: Listeners = new Listeners();
 
   /**
    * Current module HTML Elements
@@ -186,7 +180,6 @@ export default class Toolbox extends EventsDispatcher<ToolboxEvent> {
     this.api.listeners.offById(this.clickListenerId);
 
     this.removeAllShortcuts();
-    this.listeners.removeAll();
   }
 
   /**

--- a/src/components/ui/toolbox.ts
+++ b/src/components/ui/toolbox.ts
@@ -155,7 +155,7 @@ export default class Toolbox extends EventsDispatcher<ToolboxEvent> {
       this.close();
     });
 
-    if (_.isMobile) {
+    if (_.isMobile()) {
       this.listeners.on(document, 'scroll', () => {
         this.close();
       });

--- a/src/components/ui/toolbox.ts
+++ b/src/components/ui/toolbox.ts
@@ -142,6 +142,7 @@ export default class Toolbox extends EventsDispatcher<ToolboxEvent> {
         return {
           icon: tool.toolbox.icon,
           label: tool.toolbox.title,
+          name: tool.name,
           onClick: (item): void => {
             this.toolButtonActivated(tool.name);
           },

--- a/src/components/ui/toolbox.ts
+++ b/src/components/ui/toolbox.ts
@@ -155,12 +155,6 @@ export default class Toolbox extends EventsDispatcher<ToolboxEvent> {
       this.close();
     });
 
-    if (_.isMobile()) {
-      this.listeners.on(document, 'scroll', () => {
-        this.close();
-      });
-    }
-
     /**
      * Enable tools shortcuts
      */

--- a/src/components/ui/toolbox.ts
+++ b/src/components/ui/toolbox.ts
@@ -5,7 +5,8 @@ import BlockTool from '../tools/block';
 import ToolsCollection from '../tools/collection';
 import { API } from '../../../types';
 import EventsDispatcher from '../utils/events';
-import Popover from '../utils/popover';
+import Popover, { PopoverEvent } from '../utils/popover';
+import Listeners from '../utils/listeners';
 
 /**
  * @todo check small tools number — there should not be a scroll
@@ -84,6 +85,11 @@ export default class Toolbox extends EventsDispatcher<ToolboxEvent> {
   private i18nLabels: Record<toolboxTextLabelsKeys, string>;
 
   /**
+   * Listeners util instance
+   */
+   private listeners: Listeners = new Listeners();
+
+  /**
    * Current module HTML Elements
    */
   private nodes: {
@@ -144,6 +150,16 @@ export default class Toolbox extends EventsDispatcher<ToolboxEvent> {
       }),
     });
 
+    this.popover.on(PopoverEvent.OverlayClicked, () => {
+      this.close();
+    });
+
+    if (_.isMobile) {
+      this.listeners.on(document, 'scroll', () => {
+        this.close();
+      });
+    }
+
     /**
      * Enable tools shortcuts
      */
@@ -175,6 +191,7 @@ export default class Toolbox extends EventsDispatcher<ToolboxEvent> {
     this.api.listeners.offById(this.clickListenerId);
 
     this.removeAllShortcuts();
+    this.listeners.removeAll();
   }
 
   /**

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -762,3 +762,8 @@ export function cacheable<Target, Value, Arguments extends unknown[] = unknown[]
 
   return descriptor;
 };
+
+/**
+ * True if screen has mobile size
+ */
+export const isMobile = window.matchMedia('(max-width: 650px)').matches;

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -766,4 +766,6 @@ export function cacheable<Target, Value, Arguments extends unknown[] = unknown[]
 /**
  * True if screen has mobile size
  */
-export const isMobile = window.matchMedia('(max-width: 650px)').matches;
+export function isMobile(): boolean {
+  return window.matchMedia('(max-width: 650px)').matches;
+}

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -2,6 +2,7 @@ import Dom from '../dom';
 import Listeners from './listeners';
 import Flipper from '../flipper';
 import SearchInput from './search-input';
+import { isMobile } from '../utils';
 
 /**
  * Describe parameters for rendering the single item of Popover
@@ -96,7 +97,7 @@ export default class Popover {
     noFoundMessageShown: string;
     popoverOverlay: string;
     popoverOverlayHidden: string;
-    } {
+  } {
     return {
       popover: 'ce-popover',
       popoverOpened: 'ce-popover--opened',
@@ -160,6 +161,11 @@ export default class Popover {
     if (this.searchable) {
       window.requestAnimationFrame(() => {
         this.search.focus();
+      });
+    }
+    if (isMobile) {
+      this.listeners.on(document, 'scroll', () => {
+        this.hide();
       });
     }
   }

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -3,6 +3,7 @@ import Listeners from './listeners';
 import Flipper from '../flipper';
 import SearchInput from './search-input';
 import EventsDispatcher from './events';
+import { isMobile } from '../utils';
 
 /**
  * Describe parameters for rendering the single item of Popover
@@ -113,6 +114,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
     noFoundMessageShown: string;
     popoverOverlay: string;
     popoverOverlayHidden: string;
+    documentScrollLocked: string;
     } {
     return {
       popover: 'ce-popover',
@@ -128,6 +130,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
       noFoundMessageShown: 'ce-popover__no-found--shown',
       popoverOverlay: 'ce-popover__overlay',
       popoverOverlayHidden: 'ce-popover__overlay--hidden',
+      documentScrollLocked: 'ce-scroll-locked',
     };
   }
 
@@ -180,6 +183,10 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
         this.search.focus();
       });
     }
+
+    if (isMobile()) {
+      document.documentElement.classList.add(Popover.CSS.documentScrollLocked);
+    }
   }
 
   /**
@@ -189,6 +196,10 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
     this.nodes.popover.classList.remove(Popover.CSS.popoverOpened);
     this.nodes.overlay.classList.add(Popover.CSS.popoverOverlayHidden);
     this.flipper.deactivate();
+
+    if (isMobile()) {
+      document.documentElement.classList.remove(Popover.CSS.documentScrollLocked);
+    }
   }
 
   /**

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -2,7 +2,7 @@ import Dom from '../dom';
 import Listeners from './listeners';
 import Flipper from '../flipper';
 import SearchInput from './search-input';
-import { isMobile } from '../utils';
+import EventsDispatcher from './events';
 
 /**
  * Describe parameters for rendering the single item of Popover
@@ -32,9 +32,19 @@ export interface PopoverItem {
 }
 
 /**
+ * Event that can be triggered by the Popover
+ */
+export enum PopoverEvent {
+  /**
+   * When popover overlay is clicked
+   */
+  OverlayClicked = 'overlay-clicked',
+}
+
+/**
  * Popover is the UI element for displaying vertical lists
  */
-export default class Popover {
+export default class Popover extends EventsDispatcher<PopoverEvent> {
   /**
    * Items list to be displayed
    */
@@ -97,7 +107,7 @@ export default class Popover {
     noFoundMessageShown: string;
     popoverOverlay: string;
     popoverOverlayHidden: string;
-  } {
+    } {
     return {
       popover: 'ce-popover',
       popoverOpened: 'ce-popover--opened',
@@ -131,6 +141,7 @@ export default class Popover {
     filterLabel: string;
     nothingFoundLabel: string;
   }) {
+    super();
     this.items = items;
     this.className = className || '';
     this.searchable = searchable;
@@ -161,11 +172,6 @@ export default class Popover {
     if (this.searchable) {
       window.requestAnimationFrame(() => {
         this.search.focus();
-      });
-    }
-    if (isMobile) {
-      this.listeners.on(document, 'scroll', () => {
-        this.hide();
       });
     }
   }
@@ -230,7 +236,7 @@ export default class Popover {
     });
 
     this.listeners.on(this.nodes.overlay, 'click', () => {
-      this.hide();
+      this.emit(PopoverEvent.OverlayClicked);
     });
   }
 

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -1,7 +1,7 @@
 import Dom from '../dom';
 import Listeners from './listeners';
 import Flipper from '../flipper';
-import SearchInput from "./search-input";
+import SearchInput from './search-input';
 
 /**
  * Describe parameters for rendering the single item of Popover
@@ -194,7 +194,7 @@ export default class Popover {
     });
 
     this.nodes.wrapper.appendChild(this.nodes.items);
-    this.nodes.nothingFound = Dom.make('div', [Popover.CSS.noFoundMessage], {
+    this.nodes.nothingFound = Dom.make('div', [ Popover.CSS.noFoundMessage ], {
       textContent: this.nothingFoundLabel,
     });
 

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -20,6 +20,7 @@ export interface PopoverItem {
 
   /**
    * Item name
+   * Used in data attributes needed for cypress tests
    */
   name?: string;
 

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -303,7 +303,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
   private createItem(item: PopoverItem): HTMLElement {
     const el = Dom.make('div', Popover.CSS.item);
 
-    el.setAttribute('data-tool', item.name);
+    el.setAttribute('data-item-name', item.name);
     const label = Dom.make('div', Popover.CSS.itemLabel, {
       innerHTML: item.label,
     });

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -44,12 +44,16 @@ export default class Popover {
    */
   private nodes: {
     wrapper: HTMLElement;
+    popover: HTMLElement;
     items: HTMLElement;
     nothingFound: HTMLElement;
+    overlay: HTMLElement;
   } = {
     wrapper: null,
+    popover: null,
     items: null,
     nothingFound: null,
+    overlay: null,
   }
 
   /**
@@ -90,6 +94,8 @@ export default class Popover {
     itemSecondaryLabel: string;
     noFoundMessage: string;
     noFoundMessageShown: string;
+    popoverOverlay: string;
+    popoverOverlayHidden: string;
     } {
     return {
       popover: 'ce-popover',
@@ -103,6 +109,8 @@ export default class Popover {
       itemSecondaryLabel: 'ce-popover__item-secondary-label',
       noFoundMessage: 'ce-popover__no-found',
       noFoundMessageShown: 'ce-popover__no-found--shown',
+      popoverOverlay: 'ce-popover__overlay',
+      popoverOverlayHidden: 'ce-popover__overlay--hidden',
     };
   }
 
@@ -145,7 +153,8 @@ export default class Popover {
    * Shows the Popover
    */
   public show(): void {
-    this.nodes.wrapper.classList.add(Popover.CSS.popoverOpened);
+    this.nodes.popover.classList.add(Popover.CSS.popoverOpened);
+    this.nodes.overlay.classList.remove(Popover.CSS.popoverOverlayHidden);
     this.flipper.activate();
 
     if (this.searchable) {
@@ -159,7 +168,8 @@ export default class Popover {
    * Hides the Popover
    */
   public hide(): void {
-    this.nodes.wrapper.classList.remove(Popover.CSS.popoverOpened);
+    this.nodes.popover.classList.remove(Popover.CSS.popoverOpened);
+    this.nodes.overlay.classList.add(Popover.CSS.popoverOverlayHidden);
     this.flipper.deactivate();
   }
 
@@ -181,10 +191,15 @@ export default class Popover {
    * Makes the UI
    */
   private render(): void {
-    this.nodes.wrapper = Dom.make('div', [Popover.CSS.popover, this.className]);
+    this.nodes.wrapper = Dom.make('div', this.className);
+    this.nodes.popover = Dom.make('div', Popover.CSS.popover);
+    this.nodes.wrapper.appendChild(this.nodes.popover);
+
+    this.nodes.overlay = Dom.make('div', [Popover.CSS.popoverOverlay, Popover.CSS.popoverOverlayHidden]);
+    this.nodes.wrapper.appendChild(this.nodes.overlay);
 
     if (this.searchable) {
-      this.addSearch(this.nodes.wrapper);
+      this.addSearch(this.nodes.popover);
     }
 
     this.nodes.items = Dom.make('div', Popover.CSS.itemsWrapper);
@@ -193,19 +208,23 @@ export default class Popover {
       this.nodes.items.appendChild(this.createItem(item));
     });
 
-    this.nodes.wrapper.appendChild(this.nodes.items);
+    this.nodes.popover.appendChild(this.nodes.items);
     this.nodes.nothingFound = Dom.make('div', [ Popover.CSS.noFoundMessage ], {
       textContent: this.nothingFoundLabel,
     });
 
-    this.nodes.wrapper.appendChild(this.nodes.nothingFound);
+    this.nodes.popover.appendChild(this.nodes.nothingFound);
 
-    this.listeners.on(this.nodes.wrapper, 'click', (event: KeyboardEvent|MouseEvent) => {
+    this.listeners.on(this.nodes.popover, 'click', (event: KeyboardEvent|MouseEvent) => {
       const clickedItem = (event.target as HTMLElement).closest(`.${Popover.CSS.item}`) as HTMLElement;
 
       if (clickedItem) {
         this.itemClicked(clickedItem);
       }
+    });
+
+    this.listeners.on(this.nodes.overlay, 'click', () => {
+      this.hide();
     });
   }
 

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -19,6 +19,11 @@ export interface PopoverItem {
   label: string;
 
   /**
+   * Item name
+   */
+  name?: string;
+
+  /**
    * Additional displayed text
    */
   secondaryLabel?: string;
@@ -215,7 +220,6 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
     }
 
     this.nodes.items = Dom.make('div', Popover.CSS.itemsWrapper);
-
     this.items.forEach(item => {
       this.nodes.items.appendChild(this.createItem(item));
     });
@@ -286,6 +290,8 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
    */
   private createItem(item: PopoverItem): HTMLElement {
     const el = Dom.make('div', Popover.CSS.item);
+
+    el.setAttribute('data-tool', item.name);
     const label = Dom.make('div', Popover.CSS.itemLabel, {
       innerHTML: item.label,
     });

--- a/src/components/utils/search-input.ts
+++ b/src/components/utils/search-input.ts
@@ -26,10 +26,12 @@ export default class SearchInput {
    */
   private static get CSS(): {
     input: string;
+    icon: string;
     wrapper: string;
     } {
     return {
       wrapper: 'cdx-search-field',
+      icon: 'cdx-search-field__icon',
       input: 'cdx-search-field__input',
     };
   }
@@ -80,13 +82,15 @@ export default class SearchInput {
    */
   private render(placeholder: string): void {
     this.wrapper = Dom.make('div', SearchInput.CSS.wrapper);
+    const iconWrapper = Dom.make('div', SearchInput.CSS.icon);
     const icon = $.svg('search', 16, 16);
 
     this.input = Dom.make('input', SearchInput.CSS.input, {
       placeholder,
     }) as HTMLInputElement;
 
-    this.wrapper.appendChild(icon);
+    iconWrapper.appendChild(icon);
+    this.wrapper.appendChild(iconWrapper);
     this.wrapper.appendChild(this.input);
 
     this.listeners.on(this.input, 'input', () => {

--- a/src/components/utils/search-input.ts
+++ b/src/components/utils/search-input.ts
@@ -1,6 +1,6 @@
 import Dom from '../dom';
 import Listeners from './listeners';
-import $ from "../dom";
+import $ from '../dom';
 
 /**
  * Item that could be searched
@@ -13,7 +13,6 @@ interface SearchableItem {
  * Provides search input element and search logic
  */
 export default class SearchInput {
-
   private wrapper: HTMLElement;
   private input: HTMLInputElement;
   private listeners: Listeners;

--- a/src/styles/animations.css
+++ b/src/styles/animations.css
@@ -117,3 +117,20 @@
     transform: translateY(0);
   }
 }
+
+@keyframes panelShowingMobile {
+  from {
+    opacity: 0;
+    transform: translateY(14px) scale(0.98);
+  }
+
+  70% {
+    opacity: 1;
+    transform: translateY(-4px);
+  }
+
+  to {
+
+    transform: translateY(0);
+  }
+}

--- a/src/styles/input.css
+++ b/src/styles/input.css
@@ -4,18 +4,28 @@ select, button, progress { max-width: 100%; }
 .cdx-search-field {
   background: rgba(232,232,235,0.49);
   border: 1px solid rgba(226,226,229,0.20);
-  border-radius: 5px;
-  padding: 4px 7px;
-  display: flex;
-  align-items: center;
+  border-radius: 6px;
+  padding: 3px;
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  grid-template-rows: auto;
 
-  .icon {
-    width: 14px;
-    height: 14px;
-    margin-right: 17px;
-    margin-left: 2px;
-    color: var(--grayText);
+  &__icon {
+    width: var(--toolbox-buttons-size);
+    height: var(--toolbox-buttons-size);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-right: 10px;
+
+    .icon {
+      width: 14px;
+      height: 14px;
+      color: var(--grayText);
+      flex-shrink: 0;
+    }
   }
+
 
   &__input {
     font-size: 14px;

--- a/src/styles/popover.css
+++ b/src/styles/popover.css
@@ -33,7 +33,7 @@
     border-bottom-width: 4px;
   }
 
-  @media (--mobile){
+  @media (--mobile) {
     position: fixed;
     max-width: none;
     min-width: auto;

--- a/src/styles/popover.css
+++ b/src/styles/popover.css
@@ -11,9 +11,11 @@
   overflow: hidden;
   box-sizing: border-box;
   flex-shrink: 0;
-
+  
   @apply --overlay-pane;
 
+  z-index: 4;
+  
   flex-wrap: nowrap;
 
   &--opened {
@@ -98,5 +100,24 @@
     &:hover {
       background-color: transparent;
     }
+  }
+
+  @media (--mobile) {
+    &__overlay {
+      position: fixed;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      background: var(--color-dark);
+      opacity: 0.5;
+      z-index: 3;
+    }
+  }
+
+  &__overlay--hidden {
+    opacity: 0;
+    z-index: 0;
+    display: none;
   }
 }

--- a/src/styles/popover.css
+++ b/src/styles/popover.css
@@ -92,6 +92,10 @@
       padding-right: 5px;
       margin-bottom: -2px;
       opacity: 0.6;
+
+      @media (--mobile){
+        display: none;
+      }
     }
   }
 

--- a/src/styles/popover.css
+++ b/src/styles/popover.css
@@ -1,8 +1,8 @@
 .ce-popover {
   position: absolute;
+  opacity: 0;
   visibility: hidden;
-  transition: opacity 100ms ease;
-  will-change: opacity;
+  will-change: opacity, transform;
   display: flex;
   flex-direction: column;
   padding: 4px;
@@ -11,15 +11,20 @@
   overflow: hidden;
   box-sizing: border-box;
   flex-shrink: 0;
-  
+
   @apply --overlay-pane;
 
   z-index: 4;
-  
   flex-wrap: nowrap;
 
   &--opened {
-    visibility: visible;
+     opacity: 1;
+     visibility: visible;
+     animation: panelShowing 100ms ease;
+
+     @media (--mobile) {
+       animation: panelShowingMobile 250ms ease;
+     }
   }
 
   &::-webkit-scrollbar {
@@ -39,16 +44,20 @@
     position: fixed;
     max-width: none;
     min-width: auto;
-    left: 0;
-    right: 0;
-    bottom: 0;
+    left: 5px;
+    right: 5px;
+    bottom: calc(5px + env(safe-area-inset-bottom));
     top: auto;
+    border-radius: 10px;
   }
 
   &__items {
     overflow-y: auto;
-    margin-top: 5px;
     overscroll-behavior: contain;
+
+    @media (--not-mobile) {
+      margin-top: 5px;
+    }
   }
 
   &__item {
@@ -112,12 +121,19 @@
       background: var(--color-dark);
       opacity: 0.5;
       z-index: 3;
+      transition: opacity 0.12s ease-in;
+      will-change: opacity;
+      visibility: visible;
+    }
+
+    .cdx-search-field {
+      display: none;
     }
   }
 
   &__overlay--hidden {
-    opacity: 0;
     z-index: 0;
-    display: none;
+    opacity: 0;
+    visibility: hidden;
   }
 }

--- a/src/styles/toolbar.css
+++ b/src/styles/toolbar.css
@@ -4,7 +4,7 @@
   right: 0;
   top: 0;
   transition: opacity 100ms ease;
-  will-change: opacity;
+  will-change: opacity, top;
 
   display: none;
 

--- a/src/styles/toolbar.css
+++ b/src/styles/toolbar.css
@@ -4,7 +4,8 @@
   right: 0;
   top: 0;
   transition: opacity 100ms ease;
-  will-change: opacity, transform;
+  will-change: opacity;
+
   display: none;
 
   &--opened {

--- a/src/styles/toolbox.css
+++ b/src/styles/toolbox.css
@@ -1,4 +1,18 @@
 .ce-toolbox {
-  top: var(--toolbar-buttons-size);
-  left: 0;
+  @media (--not-mobile){
+    position: absolute;
+    top: var(--toolbar-buttons-size);
+    left: 0;
+  }
+}
+
+.codex-editor--narrow .ce-toolbox {
+  @media (--not-mobile){
+    left: auto;
+    right: 0;
+
+    .ce-popover {
+      right: 0;
+    }
+  }
 }

--- a/src/styles/ui.css
+++ b/src/styles/ui.css
@@ -129,8 +129,7 @@
 }
 
 .ce-scroll-locked, .ce-scroll-locked > body {
-  height: 100vh; /* Fallback for browsers that do not support Custom Properties */
-  height: calc(var(--vh) * 100);
+  height: 100vh;
   overflow: hidden;
   /**
    * Mobile Safari fix

--- a/src/styles/ui.css
+++ b/src/styles/ui.css
@@ -127,3 +127,12 @@
     transform: rotate(360deg);
   }
 }
+
+.ce-scroll-locked, .ce-scroll-locked > body {
+  height: 100vh;
+  overflow: hidden;
+  /**
+   * Mobile Safari fix
+   */
+  position: relative;
+}

--- a/src/styles/ui.css
+++ b/src/styles/ui.css
@@ -129,7 +129,8 @@
 }
 
 .ce-scroll-locked, .ce-scroll-locked > body {
-  height: 100vh;
+  height: 100vh; /* Fallback for browsers that do not support Custom Properties */
+  height: calc(var(--vh) * 100);
   overflow: hidden;
   /**
    * Mobile Safari fix

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -124,8 +124,7 @@
     }
 
     @media (--can-hover) {
-      &:hover,
-      &--active {
+      &:hover {
         background-color: var(--bg-light);
       }
     }

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -196,8 +196,10 @@
       margin-bottom: 1px;
     }
 
-    &:hover {
-      background-color: var(--bg-light);
+    @media (--can-hover) {
+      &:hover {
+        background-color: var(--bg-light);
+      }
     }
 
     @media (--mobile) {

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -188,7 +188,7 @@
     font-weight: 500;
     cursor: pointer;
     align-items: center;
-    border-radius: 7px;
+    border-radius: 6px;
 
     &:not(:last-of-type){
       margin-bottom: 1px;
@@ -197,6 +197,10 @@
     &:hover {
       background-color: var(--bg-light);
     }
+
+    @media (--mobile) {
+      font-size: 16px;
+    }
   };
 
   /**
@@ -204,8 +208,8 @@
    */
   --tool-icon: {
     display: inline-flex;
-    width: 26px;
-    height: 26px;
+    width: var(--toolbox-buttons-size);
+    height: var(--toolbox-buttons-size);
     border: 1px solid var(--color-gray-border);
     border-radius: 5px;
     align-items: center;
@@ -214,6 +218,12 @@
     box-sizing: border-box;
     flex-shrink: 0;
     margin-right: 10px;
+
+    @media (--mobile) {
+      width: var(--toolbox-buttons-size--mobile);
+      height: var(--toolbox-buttons-size--mobile);
+      border-radius: 8px;
+    }
 
     svg {
       width: 12px;

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -129,7 +129,8 @@
       }
     }
 
-    &--active{
+    &--active {
+      background-color: var(--bg-light);
       animation: bounceIn 0.75s 1;
       animation-fill-mode: forwards;
     }

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -1,3 +1,6 @@
+/**
+ * Updating values in media queries should also include changes in utils.ts@isMobile
+ */
 @custom-media --mobile (width <= 650px);
 @custom-media --not-mobile (width >= 651px);
 @custom-media --can-hover (hover: hover);

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -1,5 +1,6 @@
 @custom-media --mobile (width <= 650px);
 @custom-media --not-mobile (width >= 651px);
+@custom-media --can-hover (hover: hover);
 
 :root {
   /**
@@ -119,9 +120,11 @@
       height: var(--toolbox-buttons-size--mobile);
     }
 
-    &:hover,
-    &--active {
-      background-color: var(--bg-light);
+    @media (--can-hover) {
+      &:hover,
+      &--active {
+        background-color: var(--bg-light);
+      }
     }
 
     &--active{

--- a/test/cypress/tests/block-ids.spec.ts
+++ b/test/cypress/tests/block-ids.spec.ts
@@ -31,7 +31,7 @@ describe.only('Block ids', () => {
       .click();
 
     cy.get('[data-cy=editorjs]')
-      .get('div.ce-popover__item[data-tool=header]')
+      .get('div.ce-popover__item[data-item-name=header]')
       .click();
 
     cy.get('[data-cy=editorjs]')

--- a/test/cypress/tests/block-ids.spec.ts
+++ b/test/cypress/tests/block-ids.spec.ts
@@ -31,7 +31,7 @@ describe.only('Block ids', () => {
       .click();
 
     cy.get('[data-cy=editorjs]')
-      .get('li.ce-toolbox__button[data-tool=header]')
+      .get('div.ce-popover__item[data-tool=header]')
       .click();
 
     cy.get('[data-cy=editorjs]')

--- a/test/cypress/tests/onchange.spec.ts
+++ b/test/cypress/tests/onchange.spec.ts
@@ -173,6 +173,11 @@ describe('onChange callback', () => {
 
     cy.get('[data-cy=editorjs]')
       .get('div.ce-block')
+      .click()
+      .type('some text');
+
+    cy.get('[data-cy=editorjs]')
+      .get('div.ce-block')
       .click();
 
     cy.get('[data-cy=editorjs]')

--- a/test/cypress/tests/onchange.spec.ts
+++ b/test/cypress/tests/onchange.spec.ts
@@ -104,7 +104,7 @@ describe('onChange callback', () => {
       .click();
 
     cy.get('[data-cy=editorjs]')
-      .get('li.ce-toolbox__button[data-tool=header]')
+      .get('div.ce-popover__item[data-tool=header]')
       .click();
 
     cy.get('@onChange').should('be.calledTwice');

--- a/test/cypress/tests/onchange.spec.ts
+++ b/test/cypress/tests/onchange.spec.ts
@@ -171,6 +171,9 @@ describe('onChange callback', () => {
   it('should fire onChange callback when block is removed', () => {
     createEditor();
 
+    /**
+     * The only block does not have Tune menu, so need to create at least 2 blocks to test deleting
+     */
     cy.get('[data-cy=editorjs]')
       .get('div.ce-block')
       .click()

--- a/test/cypress/tests/onchange.spec.ts
+++ b/test/cypress/tests/onchange.spec.ts
@@ -104,7 +104,7 @@ describe('onChange callback', () => {
       .click();
 
     cy.get('[data-cy=editorjs]')
-      .get('div.ce-popover__item[data-tool=header]')
+      .get('div.ce-popover__item[data-item-name=header]')
       .click();
 
     cy.get('@onChange').should('be.calledTwice');


### PR DESCRIPTION
This pull request includes changes related to making toolbox vertical instead of horizontal (mostly done by @neSpecc).
From my side there is an attempt to fix mobile popover positioning by changing the way top position is set to popover (from `transform` to `top`). Also added overlay under popover on mobile and disabled toolbox buttons hover for touch screens.