### PR TITLE
fix: popover opening direction

### DIFF
--- a/src/components/ui/toolbox.ts
+++ b/src/components/ui/toolbox.ts
@@ -110,12 +110,6 @@ export default class Toolbox extends EventsDispatcher<ToolboxEvent> {
   private clickListenerId: string = null;
 
   /**
-   * Stores popover height.
-   * Allows not to recalculate height on each popover opening
-   */
-  private popoverHeightCached: number | null = null;
-
-  /**
    * Toolbox constructor
    *
    * @param options - available parameters
@@ -207,17 +201,10 @@ export default class Toolbox extends EventsDispatcher<ToolboxEvent> {
     }
 
     /**
-     * Calculate popover height on first open
-     */
-    if (this.popoverHeightCached === null) {
-      this.popoverHeightCached = this.popover.calculateHeight();
-    }
-
-    /**
      * Open popover top if there is not enought available space below it
      */
     if (!this.shouldOpenPopoverBottom) {
-      this.nodes.toolbox.style.setProperty('--popover-height', this.popoverHeightCached + 'px');
+      this.nodes.toolbox.style.setProperty('--popover-height', this.popover.calculateHeight() + 'px');
       this.nodes.toolbox.classList.add(Toolbox.CSS.toolboxOpenedTop);
     }
 
@@ -254,8 +241,9 @@ export default class Toolbox extends EventsDispatcher<ToolboxEvent> {
   private get shouldOpenPopoverBottom(): boolean {
     const toolboxRect = this.nodes.toolbox.getBoundingClientRect();
     const editorElementRect = this.api.ui.nodes.redactor.getBoundingClientRect();
-    const popoverPotentialBottomEdge = toolboxRect.top + this.popoverHeightCached;
-    const popoverPotentialTopEdge = toolboxRect.top - this.popoverHeightCached;
+    const popoverHeight = this.popover.calculateHeight();
+    const popoverPotentialBottomEdge = toolboxRect.top + popoverHeight;
+    const popoverPotentialTopEdge = toolboxRect.top - popoverHeight;
     const bottomEdgeForComparison = Math.min(window.innerHeight, editorElementRect.bottom);
 
     return popoverPotentialTopEdge < editorElementRect.top || popoverPotentialBottomEdge <= bottomEdgeForComparison;

--- a/src/components/ui/toolbox.ts
+++ b/src/components/ui/toolbox.ts
@@ -216,7 +216,7 @@ export default class Toolbox extends EventsDispatcher<ToolboxEvent> {
     /**
      * Open popover top if there is not enought available space below it
      */
-    if (!this.canPopoverOpenBottom) {
+    if (!this.shouldOpenPopoverBottom) {
       this.nodes.toolbox.style.setProperty('--popover-height', this.popoverHeightCached + 'px');
       this.nodes.toolbox.classList.add(Toolbox.CSS.toolboxOpenedTop);
     }
@@ -248,15 +248,17 @@ export default class Toolbox extends EventsDispatcher<ToolboxEvent> {
   }
 
   /**
-   * Checks if there is enough available space to open popover downwards.
+   * Checks if there popover should be opened downwards.
+   * It happens in case there is enough space below or not enough space above
    */
-  private get canPopoverOpenBottom(): boolean {
+  private get shouldOpenPopoverBottom(): boolean {
     const toolboxRect = this.nodes.toolbox.getBoundingClientRect();
-    const popoverBottomEdge = toolboxRect.top + this.popoverHeightCached;
+    const editorElementRect = this.api.ui.nodes.redactor.getBoundingClientRect();
+    const popoverPotentialBottomEdge = toolboxRect.top + this.popoverHeightCached;
+    const popoverPotentialTopEdge = toolboxRect.top - this.popoverHeightCached;
+    const bottomEdgeForComparison = Math.min(window.innerHeight, editorElementRect.bottom);
 
-    debugger;
-
-    return popoverBottomEdge <= window.innerHeight;
+    return popoverPotentialTopEdge < editorElementRect.top || popoverPotentialBottomEdge <= bottomEdgeForComparison;
   }
 
   /**

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -217,6 +217,25 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
   }
 
   /**
+   * Helps to calculate height of popover while it is not displayed on screen.
+   * Renders invisible clone of popover to get actual height.
+   */
+  public calculateHeight(): number {
+    let height = 0;
+    const popoverClone = this.nodes.popover.cloneNode(true) as HTMLElement;
+
+    popoverClone.style.visibility = 'hidden';
+    popoverClone.style.position = 'absolute';
+    popoverClone.style.top = '-1000px';
+    popoverClone.classList.add(Popover.CSS.popoverOpened);
+    document.body.appendChild(popoverClone);
+    height = popoverClone.offsetHeight;
+    popoverClone.remove();
+
+    return height;
+  }
+
+  /**
    * Makes the UI
    */
   private render(): void {

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -3,7 +3,7 @@ import Listeners from './listeners';
 import Flipper from '../flipper';
 import SearchInput from './search-input';
 import EventsDispatcher from './events';
-import { isMobile, keyCodes } from '../utils';
+import { isMobile, keyCodes, cacheable } from '../utils';
 
 /**
  * Describe parameters for rendering the single item of Popover
@@ -220,6 +220,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
    * Helps to calculate height of popover while it is not displayed on screen.
    * Renders invisible clone of popover to get actual height.
    */
+  @cacheable
   public calculateHeight(): number {
     let height = 0;
     const popoverClone = this.nodes.popover.cloneNode(true) as HTMLElement;

--- a/src/styles/toolbox.css
+++ b/src/styles/toolbox.css
@@ -1,8 +1,14 @@
 .ce-toolbox {
+  --gap: 8px;
+
   @media (--not-mobile){
     position: absolute;
-    top: var(--toolbar-buttons-size);
+    top: calc(var(--toolbox-buttons-size) + var(--gap));
     left: 0;
+
+    &--opened-top {
+      top: calc(-1 * (var(--gap) + var(--popover-height)));
+    }
   }
 }
 


### PR DESCRIPTION
Now toolbox popover opening direction is calculated based on amount of available space below and above it. 