### PR TITLE
[Fix] Toolbox prevents text selection

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 2.24.3
+
+- `Fix` — Issue with toolbox preventing text selection fixed
 ### 2.24.2
 
 - `Fix` — Scrolling issue when opening toolbox on mobile fixed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 2.24.3
 
 - `Fix` — Issue with toolbox preventing text selection fixed
+
 ### 2.24.2
 
 - `Fix` — Scrolling issue when opening toolbox on mobile fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/editorjs",
-  "version": "2.24.2",
+  "version": "2.24.3",
   "description": "Editor.js — Native JS, based on API and Open Source",
   "main": "dist/editor.js",
   "types": "./types/index.d.ts",

--- a/src/styles/popover.css
+++ b/src/styles/popover.css
@@ -4,11 +4,13 @@
   will-change: opacity, transform;
   display: flex;
   flex-direction: column;
+  padding: 6px;
   min-width: 200px;
   overflow: hidden;
   box-sizing: border-box;
   flex-shrink: 0;
   max-height: 0;
+  pointer-events: none;
 
   @apply --overlay-pane;
 
@@ -18,7 +20,7 @@
   &--opened {
      opacity: 1;
      max-height: 270px;
-     padding: 6px;
+     pointer-events: auto;
      animation: panelShowing 100ms ease;
 
      @media (--mobile) {

--- a/src/styles/popover.css
+++ b/src/styles/popover.css
@@ -4,7 +4,6 @@
   will-change: opacity, transform;
   display: flex;
   flex-direction: column;
-  padding: 6px;
   min-width: 200px;
   overflow: hidden;
   box-sizing: border-box;
@@ -19,6 +18,7 @@
   &--opened {
      opacity: 1;
      max-height: 270px;
+     padding: 6px;
      animation: panelShowing 100ms ease;
 
      @media (--mobile) {


### PR DESCRIPTION
Padding now is added only to opened toolbox popover. 
Resolves https://github.com/codex-team/editor.js/issues/2049