### PR TITLE
[Fix] Stop jumping to block start on toolbox close

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.24.4
+
+- `Fix` — Keyboard selection by word [2045](https://github.com/codex-team/editor.js/issues/2045)
+
 ### 2.24.3
 
 - `Fix` — Issue with toolbox preventing text selection fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/editorjs",
-  "version": "2.24.3",
+  "version": "2.24.4",
   "description": "Editor.js — Native JS, based on API and Open Source",
   "main": "dist/editor.js",
   "types": "./types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/editorjs",
-  "version": "2.24.4",
+  "version": "2.24.3",
   "description": "Editor.js — Native JS, based on API and Open Source",
   "main": "dist/editor.js",
   "types": "./types/index.d.ts",

--- a/src/components/modules/toolbar/index.ts
+++ b/src/components/modules/toolbar/index.ts
@@ -167,7 +167,6 @@ export default class Toolbar extends Module<ToolbarNodes> {
       opened: this.toolboxInstance.opened,
       close: (): void => {
         this.toolboxInstance.close();
-        this.Editor.Caret.setToBlock(this.Editor.BlockManager.currentBlock);
       },
       open: (): void => {
         /**

--- a/src/components/modules/ui.ts
+++ b/src/components/modules/ui.ts
@@ -544,6 +544,7 @@ export default class UI extends Module<UINodes> {
 
     if (this.Editor.Toolbar.toolbox.opened) {
       this.Editor.Toolbar.toolbox.close();
+      this.Editor.Caret.setToBlock(this.Editor.BlockManager.currentBlock);
     } else if (this.Editor.BlockSettings.opened) {
       this.Editor.BlockSettings.close();
     } else if (this.Editor.ConversionToolbar.opened) {


### PR DESCRIPTION
Fixes problem with text selection from right to left. Moving caret to block start on toolbox close was causing the problem. 

Resolves https://github.com/codex-team/editor.js/issues/2045