### PR TITLE
[SOLVED] bug removes last character when drag and drop

### DIFF
--- a/src/components/modules/dragNDrop.ts
+++ b/src/components/modules/dragNDrop.ts
@@ -79,10 +79,6 @@ export default class DragNDrop extends Module {
       block.dropTarget = false;
     });
 
-    if (SelectionUtils.isAtEditor && !SelectionUtils.isCollapsed && this.isStartedAtEditor) {
-      document.execCommand('delete');
-    }
-
     this.isStartedAtEditor = false;
 
     /**


### PR DESCRIPTION
## Context
When we make a drag and drop, the last character of the text dropped is deleted
you can see the issue [here](https://github.com/kommitters/editorjs-drag-drop/issues/79)

https://user-images.githubusercontent.com/98826652/167455391-6f3bfc9c-0c1d-4d0e-ba97-7f06f3b65065.mov

## Objetive
- [x] Fix the bug

https://user-images.githubusercontent.com/98826652/167455559-5e0ff663-9fed-4d9c-a430-497b8f177481.mp4


