### PR TITLE
[Fix] removes last character when drag and drop

### DIFF
--- a/src/components/modules/dragNDrop.ts
+++ b/src/components/modules/dragNDrop.ts
@@ -79,10 +79,6 @@ export default class DragNDrop extends Module {
       block.dropTarget = false;
     });
 
-    if (SelectionUtils.isAtEditor && !SelectionUtils.isCollapsed && this.isStartedAtEditor) {
-      document.execCommand('delete');
-    }
-
     this.isStartedAtEditor = false;
 
     /**


### PR DESCRIPTION
## Context
Related to #2058
[editorjs-drag-drop](https://github.com/kommitters/editorjs-drag-drop) v1.1.0
there is a code line when executed "press" a deletion where the cursor is. when you drag and drop the cursor is positioned at the end of the text in the block, when we drag and drop again that block, that line press a deletion at that point.

https://user-images.githubusercontent.com/98826652/168165983-3fbf257b-400c-44f1-bfe3-dba2daab876a.mp4

## Solution
Removes the code line where executes a deletion

https://user-images.githubusercontent.com/98826652/168166093-66eaf629-5480-4236-b900-4adf3d927bf7.mp4


