### PR TITLE
pref: remove range just editorjs'range

### DIFF
--- a/src/components/dom.ts
+++ b/src/components/dom.ts
@@ -634,4 +634,21 @@ export default class Dom {
       right: left + rect.width,
     };
   }
+
+  /**
+   * check element is editorjs's child element
+   * @param el
+   */
+  public static isEditorChild(el: HTMLElement): boolean{
+    if (el === null){
+      return false;
+    }
+    if (el.tagName === 'body'){
+      return false;
+    }
+    if (el.classList.contains('codex-editor')){
+      return true;
+    }
+    return Dom.isEditorChild(el.parentElement);
+  }
 }

--- a/src/components/modules/blockSelection.ts
+++ b/src/components/modules/blockSelection.ts
@@ -14,6 +14,7 @@ import Shortcuts from '../utils/shortcuts';
 import SelectionUtils from '../selection';
 import { SanitizerConfig } from '../../../types/configs';
 import { clean } from '../utils/sanitizer';
+import Dom from "../dom";
 
 /**
  *
@@ -194,8 +195,13 @@ export default class BlockSelection extends Module {
    * @param {boolean} readOnlyEnabled - "read only" state
    */
   public toggleReadOnly(readOnlyEnabled: boolean): void {
-    SelectionUtils.get()
-      .removeAllRanges();
+    const sel = SelectionUtils.get();
+    for (let i = 0; i < sel.rangeCount; i++) {
+      const range = sel.getRangeAt(i);
+      if (Dom.isEditorChild(range.startContainer.parentElement)){
+        sel.removeRange(range);
+      }
+    }
 
     this.allBlocksSelected = false;
   }


### PR DESCRIPTION
I want to pref because this situation:
1. I get a list of editorjs element, and a search input
2. when I search, the editorjs will trigger readonly change,and the range of input is lost!