### PR TITLE
added auto parsing of links within plain texts

### DIFF
--- a/src/components/modules/paste.ts
+++ b/src/components/modules/paste.ts
@@ -189,9 +189,16 @@ export default class Paste extends Module {
       } catch (e) {} // Do nothing and continue execution as usual if error appears
     }
 
-    /**
-     *  If text was drag'n'dropped, wrap content with P tag to insert it as the new Block
-     */
+    // Creates an <a> tag for links within plain texts
+    const values = plainData.split(` `).map((word) => {
+      return ((word.startsWith(`http:`)) || (word.startsWith(`https:`))) ? `<a href="${word}">${word}</a>` : word;
+    });
+
+    htmlData = values.join(` `);
+
+    // /**
+    //  *  If text was drag'n'dropped, wrap content with P tag to insert it as the new Block
+    //  */
     if (isDragNDrop && plainData.trim() && htmlData.trim()) {
       htmlData = '<p>' + (htmlData.trim() ? htmlData : plainData) + '</p>';
     }
@@ -232,6 +239,7 @@ export default class Paste extends Module {
       if (!dataToInsert[0].isBlock) {
         this.processInlinePaste(dataToInsert.pop());
       } else {
+        console.log(`single block`);
         this.processSingleBlock(dataToInsert.pop());
       }
 
@@ -591,6 +599,7 @@ export default class Paste extends Module {
         const content = $.make('div');
 
         content.textContent = text;
+        console.log(content);
 
         const event = this.composePasteEvent('tag', {
           data: content,

--- a/src/components/modules/paste.ts
+++ b/src/components/modules/paste.ts
@@ -239,7 +239,6 @@ export default class Paste extends Module {
       if (!dataToInsert[0].isBlock) {
         this.processInlinePaste(dataToInsert.pop());
       } else {
-        console.log(`single block`);
         this.processSingleBlock(dataToInsert.pop());
       }
 
@@ -599,7 +598,6 @@ export default class Paste extends Module {
         const content = $.make('div');
 
         content.textContent = text;
-        console.log(content);
 
         const event = this.composePasteEvent('tag', {
           data: content,


### PR DESCRIPTION
Fixed bug#2081 - https://github.com/codex-team/editor.js/issues/2081

Added simple parsing to plain texts to imbed Link tags within URLs when they are pasted. Works with both single URLs and imbedded urls within sentences

https://user-images.githubusercontent.com/98195031/174672672-8c063f5a-0de0-412f-9502-bc6f236c2c36.mov


