### PR TITLE
Block tunes as a popover

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+
+### 2.26.0
+
+- `New` — *UI* — Meet the new Block Tunes look! Vertical menu with simple JSON configuration (and support for legacy way of defining block tunes).
+
 ### 2.25.0
 
 - `New` — *Tools API* — Introducing new feature — toolbox now can have multiple entries for one tool! <br>

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,10 @@
 ### 2.26.0
 
 - `New` — *UI* — Meet the new Block Tunes look! Vertical menu with simple JSON configuration (and support for legacy way of defining block tunes).
+- `New` — *Block Tunes API* — Now `render()` method of a Block Tune can return `TunesMenuConfig` besides `HTMLElement`. This impovement is a key to the new straightforward way of configuring tune's appearance in Block Tunes menu.
+- `New` — *Tools API* — As well as `render()` in `Tunes Api`, Tool's `renderSettings()` now also supports `TunesMenuConfig` return value format.
+- `Deprecated` — *Styles API* — CSS classes `.cdx-settings-button` and `.cdx-settings-button--active` are not recommended to use. Consider configuring your block settings with new JSON API instead.
+- `Fix` — Prevent flipper from handling the event which caused it's instantiating.
 
 ### 2.25.0
 

--- a/example/example-i18n.html
+++ b/example/example-i18n.html
@@ -194,9 +194,11 @@
           "toolbar": {
             "toolbox": {
               "Add": "Добавить",
-              "Filter": "Поиск",
-              "Nothing found": "Ничего не найдено"
             }
+          },
+          "popover": {
+            "Filter": "Поиск",
+            "Nothing found": "Ничего не найдено"
           }
         },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/editorjs",
-  "version": "2.25.0",
+  "version": "2.26.0",
   "description": "Editor.js — Native JS, based on API and Open Source",
   "main": "dist/editor.js",
   "types": "./types/index.d.ts",

--- a/src/components/block-tunes/block-tune-delete.ts
+++ b/src/components/block-tunes/block-tune-delete.ts
@@ -53,6 +53,7 @@ export default class DeleteTune implements BlockTune {
       confirmation: {
         icon: $.svg('cross', 14, 14).outerHTML,
         label: 'Click to delete',
+        name: 'delete',
         onActivate: (item, e): void => this.handleClick(e),
       },
     };

--- a/src/components/block-tunes/block-tune-delete.ts
+++ b/src/components/block-tunes/block-tune-delete.ts
@@ -84,31 +84,6 @@ export default class DeleteTune implements BlockTune {
    * @param {MouseEvent} event - click event
    */
   public handleClick(event: MouseEvent): void {
-    /**
-     * if block is not waiting the confirmation, subscribe on block-settings-closing event to reset
-     * otherwise delete block
-     */
-    // if (!this.needConfirmation) {
-    //   this.setConfirmation(true);
-    //   const button = (event.target as HTMLElement)
-    //     .closest('.' + Popover.CSS.item)
-    //     .querySelector('.' + Popover.CSS.itemIcon);
-
-    //   button.classList.add(this.CSS.buttonDelete);
-    //   button.classList.add(this.CSS.buttonConfirm);
-
-    //   /**
-    //    * Subscribe on event.
-    //    * When toolbar block settings is closed but block deletion is not confirmed,
-    //    * then reset confirmation state
-    //    */
-    //   this.api.events.on('block-settings-closed', this.resetConfirmation);
-    // } else {
-    /**
-     * Unsubscribe from block-settings closing event
-     */
-    // this.api.events.off('block-settings-closed', this.resetConfirmation);
-
     this.api.blocks.delete();
     this.api.toolbar.close();
     this.api.tooltip.hide();
@@ -117,7 +92,6 @@ export default class DeleteTune implements BlockTune {
      * Prevent firing ui~documentClicked that can drop currentBlock pointer
      */
     event.stopPropagation();
-    // }
   }
 
   /**

--- a/src/components/block-tunes/block-tune-delete.ts
+++ b/src/components/block-tunes/block-tune-delete.ts
@@ -51,9 +51,7 @@ export default class DeleteTune implements BlockTune {
       label: this.api.i18n.t('Delete'),
       name: 'delete',
       confirmation: {
-        icon: $.svg('cross', 14, 14).outerHTML,
-        label: 'Click to delete',
-        name: 'delete',
+        label: this.api.i18n.t('Click to delete'),
         onActivate: (item, e): void => this.handleClick(e),
       },
     };

--- a/src/components/block-tunes/block-tune-delete.ts
+++ b/src/components/block-tunes/block-tune-delete.ts
@@ -6,7 +6,7 @@
  */
 import { API, BlockTune } from '../../../types';
 import $ from '../dom';
-import { PopoverItem } from '../utils/popover';
+import Popover, { PopoverItem } from '../utils/popover';
 
 /**
  *
@@ -64,27 +64,7 @@ export default class DeleteTune implements BlockTune {
   }
 
   /**
-   * Create "Delete" button and add click event listener
-   *
-   * @returns {HTMLElement}
-   */
-  public render(): HTMLElement {
-    this.nodes.button = $.make('div', [this.CSS.button, this.CSS.buttonDelete], {});
-    this.nodes.button.appendChild($.svg('cross', 12, 12));
-    this.api.listeners.on(this.nodes.button, 'click', (event: MouseEvent) => this.handleClick(event), false);
-
-    /**
-     * Enable tooltip module
-     */
-    this.api.tooltip.onHover(this.nodes.button, this.api.i18n.t('Delete'), {
-      hidingDelay: 300,
-    });
-
-    return this.nodes.button;
-  }
-
-  /**
-   *
+   * Tune's appearance in block settings menu
    */
   public get blockSettings(): PopoverItem {
     return {
@@ -107,7 +87,9 @@ export default class DeleteTune implements BlockTune {
      */
     if (!this.needConfirmation) {
       this.setConfirmation(true);
-      const button = (event.target as HTMLElement).closest('.ce-popover__item').querySelector('.ce-popover__item-icon');
+      const button = (event.target as HTMLElement)
+        .closest('.' + Popover.CSS.item)
+        .querySelector('.' + Popover.CSS.itemIcon);
 
       button.classList.add(this.CSS.buttonDelete);
       button.classList.add(this.CSS.buttonConfirm);
@@ -142,6 +124,5 @@ export default class DeleteTune implements BlockTune {
    */
   private setConfirmation(state: boolean): void {
     this.needConfirmation = state;
-    // this.nodes.button.classList.add(this.CSS.buttonConfirm);
   }
 }

--- a/src/components/block-tunes/block-tune-delete.ts
+++ b/src/components/block-tunes/block-tune-delete.ts
@@ -6,7 +6,7 @@
  */
 import { API, BlockTune } from '../../../types';
 import $ from '../dom';
-import Popover, { PopoverItem } from '../utils/popover';
+import { PopoverItem } from '../utils/popover';
 
 /**
  *

--- a/src/components/block-tunes/block-tune-delete.ts
+++ b/src/components/block-tunes/block-tune-delete.ts
@@ -91,6 +91,7 @@ export default class DeleteTune implements BlockTune {
       icon: $.svg('cross', 14, 14).outerHTML,
       label: this.api.i18n.t('Delete'),
       onClick: (item, e): void => this.handleClick(e),
+      name: 'delete',
     };
   }
 

--- a/src/components/block-tunes/block-tune-delete.ts
+++ b/src/components/block-tunes/block-tune-delete.ts
@@ -4,9 +4,8 @@
  *
  * @copyright <CodeX Team> 2018
  */
-import { API, BlockTune } from '../../../types';
+import { API, BlockTune, PopoverItem } from '../../../types';
 import $ from '../dom';
-import { PopoverItem } from '../utils/popover';
 
 /**
  *

--- a/src/components/block-tunes/block-tune-delete.ts
+++ b/src/components/block-tunes/block-tune-delete.ts
@@ -24,15 +24,6 @@ export default class DeleteTune implements BlockTune {
   private readonly api: API;
 
   /**
-   * Styles
-   */
-  private CSS = {
-    button: 'ce-settings__button',
-    buttonDelete: 'ce-settings__button--delete',
-    buttonConfirm: 'ce-settings__button--confirm',
-  };
-
-  /**
    * DeleteTune constructor
    *
    * @param {API} api - Editor's API
@@ -63,12 +54,5 @@ export default class DeleteTune implements BlockTune {
    */
   public handleClick(event: MouseEvent): void {
     this.api.blocks.delete();
-    this.api.toolbar.close();
-    this.api.tooltip.hide();
-
-    /**
-     * Prevent firing ui~documentClicked that can drop currentBlock pointer
-     */
-    event.stopPropagation();
   }
 }

--- a/src/components/block-tunes/block-tune-delete.ts
+++ b/src/components/block-tunes/block-tune-delete.ts
@@ -53,7 +53,7 @@ export default class DeleteTune implements BlockTune {
       confirmation: {
         icon: $.svg('cross', 14, 14).outerHTML,
         label: 'Click to delete',
-        onClick: (item, e): void => this.handleClick(e),
+        onActivate: (item, e): void => this.handleClick(e),
       },
     };
   }

--- a/src/components/block-tunes/block-tune-delete.ts
+++ b/src/components/block-tunes/block-tune-delete.ts
@@ -66,7 +66,7 @@ export default class DeleteTune implements BlockTune {
   /**
    * Tune's appearance in block settings menu
    */
-  public get blockSettings(): PopoverItem {
+  public render(): PopoverItem {
     return {
       icon: $.svg('cross', 14, 14).outerHTML,
       label: this.api.i18n.t('Delete'),

--- a/src/components/block-tunes/block-tune-delete.ts
+++ b/src/components/block-tunes/block-tune-delete.ts
@@ -72,6 +72,9 @@ export default class DeleteTune implements BlockTune {
       label: this.api.i18n.t('Delete'),
       onClick: (item, e): void => this.handleClick(e),
       name: 'delete',
+      confirmation: {
+        label: 'Click to delete',
+      },
     };
   }
 
@@ -85,36 +88,36 @@ export default class DeleteTune implements BlockTune {
      * if block is not waiting the confirmation, subscribe on block-settings-closing event to reset
      * otherwise delete block
      */
-    if (!this.needConfirmation) {
-      this.setConfirmation(true);
-      const button = (event.target as HTMLElement)
-        .closest('.' + Popover.CSS.item)
-        .querySelector('.' + Popover.CSS.itemIcon);
+    // if (!this.needConfirmation) {
+    //   this.setConfirmation(true);
+    //   const button = (event.target as HTMLElement)
+    //     .closest('.' + Popover.CSS.item)
+    //     .querySelector('.' + Popover.CSS.itemIcon);
 
-      button.classList.add(this.CSS.buttonDelete);
-      button.classList.add(this.CSS.buttonConfirm);
+    //   button.classList.add(this.CSS.buttonDelete);
+    //   button.classList.add(this.CSS.buttonConfirm);
 
-      /**
-       * Subscribe on event.
-       * When toolbar block settings is closed but block deletion is not confirmed,
-       * then reset confirmation state
-       */
-      this.api.events.on('block-settings-closed', this.resetConfirmation);
-    } else {
-      /**
-       * Unsubscribe from block-settings closing event
-       */
-      this.api.events.off('block-settings-closed', this.resetConfirmation);
+    //   /**
+    //    * Subscribe on event.
+    //    * When toolbar block settings is closed but block deletion is not confirmed,
+    //    * then reset confirmation state
+    //    */
+    //   this.api.events.on('block-settings-closed', this.resetConfirmation);
+    // } else {
+    /**
+     * Unsubscribe from block-settings closing event
+     */
+    // this.api.events.off('block-settings-closed', this.resetConfirmation);
 
-      this.api.blocks.delete();
-      this.api.toolbar.close();
-      this.api.tooltip.hide();
+    this.api.blocks.delete();
+    this.api.toolbar.close();
+    this.api.tooltip.hide();
 
-      /**
-       * Prevent firing ui~documentClicked that can drop currentBlock pointer
-       */
-      event.stopPropagation();
-    }
+    /**
+     * Prevent firing ui~documentClicked that can drop currentBlock pointer
+     */
+    event.stopPropagation();
+    // }
   }
 
   /**

--- a/src/components/block-tunes/block-tune-delete.ts
+++ b/src/components/block-tunes/block-tune-delete.ts
@@ -6,6 +6,7 @@
  */
 import { API, BlockTune } from '../../../types';
 import $ from '../dom';
+import { PopoverItem } from '../utils/popover';
 
 /**
  *
@@ -83,6 +84,17 @@ export default class DeleteTune implements BlockTune {
   }
 
   /**
+   *
+   */
+  public get blockSettings(): PopoverItem {
+    return {
+      icon: $.svg('cross', 14, 14).outerHTML,
+      label: this.api.i18n.t('Delete'),
+      onClick: (item, e): void => this.handleClick(e),
+    };
+  }
+
+  /**
    * Delete block conditions passed
    *
    * @param {MouseEvent} event - click event
@@ -94,6 +106,10 @@ export default class DeleteTune implements BlockTune {
      */
     if (!this.needConfirmation) {
       this.setConfirmation(true);
+      const button = (event.target as HTMLElement).closest('.ce-popover__item').querySelector('.ce-popover__item-icon');
+
+      button.classList.add(this.CSS.buttonDelete);
+      button.classList.add(this.CSS.buttonConfirm);
 
       /**
        * Subscribe on event.

--- a/src/components/block-tunes/block-tune-delete.ts
+++ b/src/components/block-tunes/block-tune-delete.ts
@@ -141,6 +141,6 @@ export default class DeleteTune implements BlockTune {
    */
   private setConfirmation(state: boolean): void {
     this.needConfirmation = state;
-    this.nodes.button.classList.add(this.CSS.buttonConfirm);
+    // this.nodes.button.classList.add(this.CSS.buttonConfirm);
   }
 }

--- a/src/components/block-tunes/block-tune-delete.ts
+++ b/src/components/block-tunes/block-tune-delete.ts
@@ -34,33 +34,12 @@ export default class DeleteTune implements BlockTune {
   };
 
   /**
-   * Delete confirmation
-   */
-  private needConfirmation: boolean;
-
-  /**
-   * set false confirmation state
-   */
-  private readonly resetConfirmation: () => void;
-
-  /**
-   * Tune nodes
-   */
-  private nodes: {button: HTMLElement} = {
-    button: null,
-  };
-
-  /**
    * DeleteTune constructor
    *
    * @param {API} api - Editor's API
    */
   constructor({ api }) {
     this.api = api;
-
-    this.resetConfirmation = (): void => {
-      this.setConfirmation(false);
-    };
   }
 
   /**
@@ -70,10 +49,11 @@ export default class DeleteTune implements BlockTune {
     return {
       icon: $.svg('cross', 14, 14).outerHTML,
       label: this.api.i18n.t('Delete'),
-      onClick: (item, e): void => this.handleClick(e),
       name: 'delete',
       confirmation: {
+        icon: $.svg('cross', 14, 14).outerHTML,
         label: 'Click to delete',
+        onClick: (item, e): void => this.handleClick(e),
       },
     };
   }
@@ -92,14 +72,5 @@ export default class DeleteTune implements BlockTune {
      * Prevent firing ui~documentClicked that can drop currentBlock pointer
      */
     event.stopPropagation();
-  }
-
-  /**
-   * change tune state
-   *
-   * @param {boolean} state - delete confirmation state
-   */
-  private setConfirmation(state: boolean): void {
-    this.needConfirmation = state;
   }
 }

--- a/src/components/block-tunes/block-tune-move-down.ts
+++ b/src/components/block-tunes/block-tune-move-down.ts
@@ -52,7 +52,7 @@ export default class MoveDownTune implements BlockTune {
     return {
       icon: $.svg('arrow-down', 14, 14).outerHTML,
       label: this.api.i18n.t('Move down'),
-      onClick: (item, event): void => this.handleClick(event),
+      onActivate: (item, event): void => this.handleClick(event),
       name: 'move-down',
     };
   }

--- a/src/components/block-tunes/block-tune-move-down.ts
+++ b/src/components/block-tunes/block-tune-move-down.ts
@@ -27,12 +27,8 @@ export default class MoveDownTune implements BlockTune {
 
   /**
    * Styles
-   *
-   * @type {{wrapper: string}}
    */
   private CSS = {
-    button: 'ce-settings__button',
-    wrapper: 'ce-tune-move-down',
     animation: 'wobble',
   };
 
@@ -100,8 +96,5 @@ export default class MoveDownTune implements BlockTune {
     this.api.blocks.move(currentBlockIndex + 1);
 
     this.api.toolbar.toggleBlockSettings(true);
-
-    /** Hide the Tooltip */
-    this.api.tooltip.hide();
   }
 }

--- a/src/components/block-tunes/block-tune-move-down.ts
+++ b/src/components/block-tunes/block-tune-move-down.ts
@@ -7,6 +7,7 @@
 
 import $ from '../dom';
 import { API, BlockTune } from '../../../types';
+import { PopoverItem } from '../utils/popover';
 
 /**
  *
@@ -71,22 +72,33 @@ export default class MoveDownTune implements BlockTune {
   }
 
   /**
+   *
+   */
+  public get blockSettings(): PopoverItem {
+    return {
+      icon: $.svg('arrow-down', 14, 14).outerHTML,
+      label: this.api.i18n.t('Move down'),
+      onClick: (item): void => this.handleClick(),
+    };
+  }
+
+  /**
    * Handle clicks on 'move down' button
    *
    * @param {MouseEvent} event - click event
    * @param {HTMLElement} button - clicked button
    */
-  public handleClick(event: MouseEvent, button: HTMLElement): void {
+  public handleClick(event?: MouseEvent, button?: HTMLElement): void {
     const currentBlockIndex = this.api.blocks.getCurrentBlockIndex();
     const nextBlock = this.api.blocks.getBlockByIndex(currentBlockIndex + 1);
 
     // If Block is last do nothing
     if (!nextBlock) {
-      button.classList.add(this.CSS.animation);
+      // button.classList.add(this.CSS.animation);
 
-      window.setTimeout(() => {
-        button.classList.remove(this.CSS.animation);
-      }, 500);
+      // window.setTimeout(() => {
+      //   button.classList.remove(this.CSS.animation);
+      // }, 500);
 
       return;
     }

--- a/src/components/block-tunes/block-tune-move-down.ts
+++ b/src/components/block-tunes/block-tune-move-down.ts
@@ -7,7 +7,7 @@
 
 import $ from '../dom';
 import { API, BlockTune } from '../../../types';
-import { PopoverItem } from '../utils/popover';
+import Popover, { PopoverItem } from '../utils/popover';
 
 /**
  *
@@ -46,39 +46,13 @@ export default class MoveDownTune implements BlockTune {
   }
 
   /**
-   * Return 'move down' button
-   *
-   * @returns {HTMLElement}
-   */
-  public render(): HTMLElement {
-    const moveDownButton = $.make('div', [this.CSS.button, this.CSS.wrapper], {});
-
-    moveDownButton.appendChild($.svg('arrow-down', 14, 14));
-    this.api.listeners.on(
-      moveDownButton,
-      'click',
-      (event) => this.handleClick(event as MouseEvent, moveDownButton),
-      false
-    );
-
-    /**
-     * Enable tooltip module on button
-     */
-    this.api.tooltip.onHover(moveDownButton, this.api.i18n.t('Move down'), {
-      hidingDelay: 300,
-    });
-
-    return moveDownButton;
-  }
-
-  /**
-   *
+   * Tune's appearance in block settings menu
    */
   public get blockSettings(): PopoverItem {
     return {
       icon: $.svg('arrow-down', 14, 14).outerHTML,
       label: this.api.i18n.t('Move down'),
-      onClick: (item): void => this.handleClick(),
+      onClick: (item, event): void => this.handleClick(event),
       name: 'move-down',
     };
   }
@@ -86,20 +60,23 @@ export default class MoveDownTune implements BlockTune {
   /**
    * Handle clicks on 'move down' button
    *
-   * @param {MouseEvent} event - click event
-   * @param {HTMLElement} button - clicked button
+   * @param event - click event
    */
-  public handleClick(event?: MouseEvent, button?: HTMLElement): void {
+  public handleClick(event: MouseEvent): void {
     const currentBlockIndex = this.api.blocks.getCurrentBlockIndex();
     const nextBlock = this.api.blocks.getBlockByIndex(currentBlockIndex + 1);
 
     // If Block is last do nothing
     if (!nextBlock) {
-      // button.classList.add(this.CSS.animation);
+      const button = (event.target as HTMLElement)
+        .closest('.' + Popover.CSS.item)
+        .querySelector('.' + Popover.CSS.itemIcon);
 
-      // window.setTimeout(() => {
-      //   button.classList.remove(this.CSS.animation);
-      // }, 500);
+      button.classList.add(this.CSS.animation);
+
+      window.setTimeout(() => {
+        button.classList.remove(this.CSS.animation);
+      }, 500);
 
       return;
     }

--- a/src/components/block-tunes/block-tune-move-down.ts
+++ b/src/components/block-tunes/block-tune-move-down.ts
@@ -79,6 +79,7 @@ export default class MoveDownTune implements BlockTune {
       icon: $.svg('arrow-down', 14, 14).outerHTML,
       label: this.api.i18n.t('Move down'),
       onClick: (item): void => this.handleClick(),
+      name: 'move-down',
     };
   }
 

--- a/src/components/block-tunes/block-tune-move-down.ts
+++ b/src/components/block-tunes/block-tune-move-down.ts
@@ -48,7 +48,7 @@ export default class MoveDownTune implements BlockTune {
   /**
    * Tune's appearance in block settings menu
    */
-  public get blockSettings(): PopoverItem {
+  public render(): PopoverItem {
     return {
       icon: $.svg('arrow-down', 14, 14).outerHTML,
       label: this.api.i18n.t('Move down'),

--- a/src/components/block-tunes/block-tune-move-down.ts
+++ b/src/components/block-tunes/block-tune-move-down.ts
@@ -6,8 +6,8 @@
  */
 
 import $ from '../dom';
-import { API, BlockTune } from '../../../types';
-import Popover, { PopoverItem } from '../utils/popover';
+import { API, BlockTune, PopoverItem } from '../../../types';
+import Popover from '../utils/popover';
 
 /**
  *

--- a/src/components/block-tunes/block-tune-move-up.ts
+++ b/src/components/block-tunes/block-tune-move-up.ts
@@ -5,8 +5,8 @@
  * @copyright <CodeX Team> 2018
  */
 import $ from '../dom';
-import { API, BlockTune, BlockAPI } from '../../../types';
-import Popover, { PopoverItem } from '../../components/utils/popover';
+import { API, BlockTune, BlockAPI, PopoverItem } from '../../../types';
+import Popover from '../../components/utils/popover';
 
 /**
  *

--- a/src/components/block-tunes/block-tune-move-up.ts
+++ b/src/components/block-tunes/block-tune-move-up.ts
@@ -51,7 +51,7 @@ export default class MoveUpTune implements BlockTune {
     return {
       icon: $.svg('arrow-up', 14, 14).outerHTML,
       label: this.api.i18n.t('Move up'),
-      onClick: (item, e): void => this.handleClick(e),
+      onActivate: (item, e): void => this.handleClick(e),
       name: 'move-up',
     };
   }

--- a/src/components/block-tunes/block-tune-move-up.ts
+++ b/src/components/block-tunes/block-tune-move-up.ts
@@ -47,7 +47,7 @@ export default class MoveUpTune implements BlockTune {
   /**
    * Tune's appearance in block settings menu
    */
-  public get blockSettings(): PopoverItem {
+  public render(): PopoverItem {
     return {
       icon: $.svg('arrow-up', 14, 14).outerHTML,
       label: this.api.i18n.t('Move up'),

--- a/src/components/block-tunes/block-tune-move-up.ts
+++ b/src/components/block-tunes/block-tune-move-up.ts
@@ -26,12 +26,8 @@ export default class MoveUpTune implements BlockTune {
 
   /**
    * Styles
-   *
-   * @type {{wrapper: string}}
    */
   private CSS = {
-    button: 'ce-settings__button',
-    wrapper: 'ce-tune-move-up',
     animation: 'wobble',
   };
 
@@ -108,8 +104,5 @@ export default class MoveUpTune implements BlockTune {
     this.api.blocks.move(currentBlockIndex - 1);
 
     this.api.toolbar.toggleBlockSettings(true);
-
-    /** Hide the Tooltip */
-    this.api.tooltip.hide();
   }
 }

--- a/src/components/block-tunes/block-tune-move-up.ts
+++ b/src/components/block-tunes/block-tune-move-up.ts
@@ -77,7 +77,7 @@ export default class MoveUpTune implements BlockTune {
     return {
       icon: $.svg('arrow-up', 14, 14).outerHTML,
       label: this.api.i18n.t('Move up'),
-      onClick: (item): void => this.handleClick(),
+      onClick: (item, e): void => this.handleClick(e),
     };
   }
 
@@ -99,7 +99,7 @@ export default class MoveUpTune implements BlockTune {
       //   button.classList.remove(this.CSS.animation);
       // }, 500);
 
-      // return;
+      return;
     }
 
     const currentBlockElement = (currentBlock as BlockAPI).holder;

--- a/src/components/block-tunes/block-tune-move-up.ts
+++ b/src/components/block-tunes/block-tune-move-up.ts
@@ -76,8 +76,8 @@ export default class MoveUpTune implements BlockTune {
       return;
     }
 
-    const currentBlockElement = (currentBlock as BlockAPI).holder;
-    const previousBlockElement = (previousBlock as BlockAPI).holder;
+    const currentBlockElement = currentBlock.holder;
+    const previousBlockElement = previousBlock.holder;
 
     /**
      * Here is two cases:

--- a/src/components/block-tunes/block-tune-move-up.ts
+++ b/src/components/block-tunes/block-tune-move-up.ts
@@ -78,6 +78,7 @@ export default class MoveUpTune implements BlockTune {
       icon: $.svg('arrow-up', 14, 14).outerHTML,
       label: this.api.i18n.t('Move up'),
       onClick: (item, e): void => this.handleClick(e),
+      name: 'move-up',
     };
   }
 

--- a/src/components/block-tunes/block-tune-move-up.ts
+++ b/src/components/block-tunes/block-tune-move-up.ts
@@ -5,7 +5,8 @@
  * @copyright <CodeX Team> 2018
  */
 import $ from '../dom';
-import { API, BlockTune } from '../../../types';
+import { API, BlockTune, BlockAPI } from '../../../types';
+import { PopoverItem } from '../../components/utils/popover';
 
 /**
  *
@@ -70,28 +71,39 @@ export default class MoveUpTune implements BlockTune {
   }
 
   /**
+   *
+   */
+  public get blockSettings(): PopoverItem {
+    return {
+      icon: $.svg('arrow-up', 14, 14).outerHTML,
+      label: this.api.i18n.t('Move up'),
+      onClick: (item): void => this.handleClick(),
+    };
+  }
+
+  /**
    * Move current block up
    *
    * @param {MouseEvent} event - click event
    * @param {HTMLElement} button - clicked button
    */
-  public handleClick(event: MouseEvent, button: HTMLElement): void {
+  public handleClick(event?: MouseEvent, button?: HTMLElement): void {
     const currentBlockIndex = this.api.blocks.getCurrentBlockIndex();
     const currentBlock = this.api.blocks.getBlockByIndex(currentBlockIndex);
     const previousBlock = this.api.blocks.getBlockByIndex(currentBlockIndex - 1);
 
     if (currentBlockIndex === 0 || !currentBlock || !previousBlock) {
-      button.classList.add(this.CSS.animation);
+      // button.classList.add(this.CSS.animation);
 
-      window.setTimeout(() => {
-        button.classList.remove(this.CSS.animation);
-      }, 500);
+      // window.setTimeout(() => {
+      //   button.classList.remove(this.CSS.animation);
+      // }, 500);
 
-      return;
+      // return;
     }
 
-    const currentBlockElement = currentBlock.holder;
-    const previousBlockElement = previousBlock.holder;
+    const currentBlockElement = (currentBlock as BlockAPI).holder;
+    const previousBlockElement = (previousBlock as BlockAPI).holder;
 
     /**
      * Here is two cases:

--- a/src/components/block-tunes/block-tune-move-up.ts
+++ b/src/components/block-tunes/block-tune-move-up.ts
@@ -6,7 +6,7 @@
  */
 import $ from '../dom';
 import { API, BlockTune, BlockAPI } from '../../../types';
-import { PopoverItem } from '../../components/utils/popover';
+import Popover, { PopoverItem } from '../../components/utils/popover';
 
 /**
  *
@@ -45,33 +45,7 @@ export default class MoveUpTune implements BlockTune {
   }
 
   /**
-   * Create "MoveUp" button and add click event listener
-   *
-   * @returns {HTMLElement}
-   */
-  public render(): HTMLElement {
-    const moveUpButton = $.make('div', [this.CSS.button, this.CSS.wrapper], {});
-
-    moveUpButton.appendChild($.svg('arrow-up', 14, 14));
-    this.api.listeners.on(
-      moveUpButton,
-      'click',
-      (event) => this.handleClick(event as MouseEvent, moveUpButton),
-      false
-    );
-
-    /**
-     * Enable tooltip module on button
-     */
-    this.api.tooltip.onHover(moveUpButton, this.api.i18n.t('Move up'), {
-      hidingDelay: 300,
-    });
-
-    return moveUpButton;
-  }
-
-  /**
-   *
+   * Tune's appearance in block settings menu
    */
   public get blockSettings(): PopoverItem {
     return {
@@ -86,19 +60,22 @@ export default class MoveUpTune implements BlockTune {
    * Move current block up
    *
    * @param {MouseEvent} event - click event
-   * @param {HTMLElement} button - clicked button
    */
-  public handleClick(event?: MouseEvent, button?: HTMLElement): void {
+  public handleClick(event: MouseEvent): void {
     const currentBlockIndex = this.api.blocks.getCurrentBlockIndex();
     const currentBlock = this.api.blocks.getBlockByIndex(currentBlockIndex);
     const previousBlock = this.api.blocks.getBlockByIndex(currentBlockIndex - 1);
 
     if (currentBlockIndex === 0 || !currentBlock || !previousBlock) {
-      // button.classList.add(this.CSS.animation);
+      const button = (event.target as HTMLElement)
+        .closest('.' + Popover.CSS.item)
+        .querySelector('.' + Popover.CSS.itemIcon);
 
-      // window.setTimeout(() => {
-      //   button.classList.remove(this.CSS.animation);
-      // }, 500);
+      button.classList.add(this.CSS.animation);
+
+      window.setTimeout(() => {
+        button.classList.remove(this.CSS.animation);
+      }, 500);
 
       return;
     }

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -665,7 +665,8 @@ export default class Block extends EventsDispatcher<BlockEvents> {
    *
    */
   public getTunesItems(): PopoverItem[] {
-    return Array.from(this.defaultTunesInstances.values()).map(tune => tune.blockSettings)
+    return Array.from(this.defaultTunesInstances.values())
+      .map(tune => tune.blockSettings)
       .filter(item => !!item);
   }
 

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -673,9 +673,9 @@ export default class Block extends EventsDispatcher<BlockEvents> {
       if (isHTMLElement) {
         tunesElement.appendChild(rendered);
       } else {
-        const normalized = [ rendered ].flat();
+        const items = Array.isArray(rendered) ? rendered : [ rendered ];
 
-        tunesItems.push(...normalized);
+        tunesItems.push(...items);
       }
     });
 

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -651,13 +651,22 @@ export default class Block extends EventsDispatcher<BlockEvents> {
     const tunesElement = document.createElement('div');
     let tunesItems: PopoverItem[] = [];
 
+    /** Default tunes: Move up, Move down, Delete */
     const defaultTunesInstances = Array.from(this.defaultTunesInstances.values());
+
+    /** Third-party tunes */
     const customTunesInstances = Array.from(this.tunesInstances.values());
+
+    /** Retrieve tunes that may be defined in tool as return value of optional renderSettings function. */
     const tunesDefinedInTool =
       typeof this.toolInstance.renderSettings === 'function'
         ? [ this.toolInstance.renderSettings() ].flat()
         : [];
-    const otherTunes = customTunesInstances.concat(defaultTunesInstances).map(item => item.render());
+
+    /** Combine default and thirid-party tunes and call render() on each to retrieve their controls */
+    const otherTunes = customTunesInstances
+      .concat(defaultTunesInstances)
+      .map(item => item.render());
 
     tunesDefinedInTool.concat(otherTunes).forEach(rendered => {
       const isHTMLElement = rendered.nodeName !== undefined;

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -21,7 +21,6 @@ import { BlockTuneData } from '../../../types/block-tunes/block-tune-data';
 import ToolsCollection from '../tools/collection';
 import EventsDispatcher from '../utils/events';
 import { PopoverItem } from '../utils/popover';
-import { TunesMenuEntry } from '../../../types/tools';
 
 /**
  * Interface describes Block class constructor argument
@@ -647,9 +646,9 @@ export default class Block extends EventsDispatcher<BlockEvents> {
    * Returns data to render in tunes menu.
    * Splits block tunes settings into 2 groups: popover items and custom html.
    */
-  public getTunes(): [TunesMenuEntry[], HTMLElement] {
+  public getTunes(): [PopoverItem[], HTMLElement] {
     const tunesElement = document.createElement('div');
-    let tunesItems: PopoverItem[] = [];
+    const tunesItems: PopoverItem[] = [];
 
     /** Default tunes: Move up, Move down, Delete */
     const defaultTunesInstances = Array.from(this.defaultTunesInstances.values());
@@ -680,7 +679,7 @@ export default class Block extends EventsDispatcher<BlockEvents> {
       }
     });
 
-    tunesItems = tunesItems.filter(item => !item.isActive);
+    // tunesItems = tunesItems.filter(item => !item.isActive);
 
     return [tunesItems, tunesElement];
   }

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -648,9 +648,9 @@ export default class Block extends EventsDispatcher<BlockEvents> {
   public getTunesRendered(): DocumentFragment {
     const tunesElement = document.createDocumentFragment();
 
-    this.tunesInstances.forEach((tune) => {
-      $.append(tunesElement, tune.render());
-    });
+    // this.tunesInstances.forEach((tune) => {
+    //   $.append(tunesElement, tune.render());
+    // });
 
     return tunesElement;
   }
@@ -661,17 +661,42 @@ export default class Block extends EventsDispatcher<BlockEvents> {
   public getTunesList(): PopoverItem[] {
     const customTunesInstances = Array.from(this.tunesInstances.values());
     const defaultTunesInstances = Array.from(this.defaultTunesInstances.values());
-    const tunesDefinedInTool =
-      Array.isArray(this.toolInstance.blockSettings)
-        ? this.toolInstance.blockSettings
-        : [ this.toolInstance.blockSettings ];
+    const tunesDefinedInTool = [ this.toolInstance.render() ].flat();
 
     const otherTunes = customTunesInstances.concat(defaultTunesInstances)
-      .map(tune => tune.blockSettings)
+      .map(tune => tune.render())
       .filter(item => !!item);
 
     // @ts-ignore
     return tunesDefinedInTool.concat(otherTunes).filter(item => !item.isActive);
+  }
+
+  /**
+   *
+   */
+  public getTunes(): [PopoverItem[], HTMLElement] {
+    const tunesElement = document.createElement('div');
+    const tunesItems: PopoverItem[] = [];
+
+    const defaultTunesInstances = Array.from(this.defaultTunesInstances.values());
+    const customTunesInstances = Array.from(this.tunesInstances.values());
+    const tunesDefinedInTool = [ this.toolInstance.renderSettings() ].flat();
+    const otherTunes = customTunesInstances.concat(defaultTunesInstances).map(item => item.render());
+
+    tunesDefinedInTool.concat(otherTunes).forEach(rendered => {
+      if (rendered instanceof HTMLElement) {
+        tunesElement.appendChild(rendered);
+      } else {
+        const normalized = [ rendered ].flat();
+
+        tunesItems.push(...normalized);
+      }
+    });
+
+    // @ts-ignore
+    // tunesItems = tunesItems.filter(item => !item.isActive);
+
+    return [tunesItems, tunesElement];
   }
 
   /**
@@ -744,23 +769,11 @@ export default class Block extends EventsDispatcher<BlockEvents> {
    * Call Tool instance renderSettings method
    */
   public renderSettings(): HTMLElement | undefined {
-    if (_.isFunction(this.toolInstance.renderSettings)) {
-      return this.toolInstance.renderSettings();
-    }
+    return undefined;
+    // if (_.isFunction(this.toolInstance.renderSettings)) {
+    //   return this.toolInstance.renderSettings();
+    // }
   }
-
-  /**
-   *
-   */
-  // public get blockSettings(): PopoverItem | PopoverItem[] {
-  //   if (_.isFunction(this.toolInstance.blockSettings)) {
-  //     return this.toolInstance.blockSettings();
-  //   }
-  // }
-
-  // public async getActiveTunesEntry() {
-
-  // }
 
   /**
    * Tool could specify several entries to be displayed at the Toolbox (for example, "Heading 1", "Heading 2", "Heading 3")

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -643,7 +643,20 @@ export default class Block extends EventsDispatcher<BlockEvents> {
   }
 
   /**
-   * Returns list of tunes available for block
+   * Returns rendered custom block tunes
+   */
+  public getTunesRendered(): DocumentFragment {
+    const tunesElement = document.createDocumentFragment();
+
+    this.tunesInstances.forEach((tune) => {
+      $.append(tunesElement, tune.render());
+    });
+
+    return tunesElement;
+  }
+
+  /**
+   * Returns list of tunes available for block as popover items
    */
   public getTunesList(): PopoverItem[] {
     const tunes = Array.from(this.tunesInstances.values());

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -650,36 +650,22 @@ export default class Block extends EventsDispatcher<BlockEvents> {
     const tunesElement = document.createElement('div');
     const tunesItems: PopoverItem[] = [];
 
-    /** Default tunes: Move up, Move down, Delete */
-    const defaultTunesInstances = Array.from(this.defaultTunesInstances.values());
+    /** Tool's tunes: may be defined as return value of optional renderSettings method */
+    const tunesDefinedInTool = typeof this.toolInstance.renderSettings === 'function' && this.toolInstance.renderSettings();
 
-    /** Third-party tunes */
-    const customTunesInstances = Array.from(this.tunesInstances.values());
+    /** Common tunes: combination of default tunes (move up, move down, delete) and third-party tunes connected via tunes api */
+    const commonTunes = [
+      ...this.defaultTunesInstances.values(),
+      ...this.tunesInstances.values(),
+    ].map(tuneInstance => tuneInstance.render());
 
-    /** Retrieve tunes that may be defined in tool as return value of optional renderSettings function. */
-    const tunesDefinedInTool =
-      typeof this.toolInstance.renderSettings === 'function'
-        ? [ this.toolInstance.renderSettings() ].flat()
-        : [];
-
-    /** Combine default and thirid-party tunes and call render() on each to retrieve their controls */
-    const otherTunes = customTunesInstances
-      .concat(defaultTunesInstances)
-      .map(item => item.render());
-
-    tunesDefinedInTool.concat(otherTunes).forEach(rendered => {
-      const isHTMLElement = rendered.nodeName !== undefined;
-
-      if (isHTMLElement) {
+    [tunesDefinedInTool, commonTunes].flat().forEach(rendered => {
+      if ($.isElement(rendered)) {
         tunesElement.appendChild(rendered);
       } else {
-        const items = Array.isArray(rendered) ? rendered : [ rendered ];
-
-        tunesItems.push(...items);
+        tunesItems.push(rendered);
       }
     });
-
-    // tunesItems = tunesItems.filter(item => !item.isActive);
 
     return [tunesItems, tunesElement];
   }

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -672,7 +672,8 @@ export default class Block extends EventsDispatcher<BlockEvents> {
   }
 
   /**
-   *
+   * Returns data to render in tunes menu.
+   * Splits block tunes settings into 2 groups: popover items and custom html.
    */
   public getTunes(): [TunesMenuEntry[], HTMLElement] {
     const tunesElement = document.createElement('div');
@@ -680,7 +681,10 @@ export default class Block extends EventsDispatcher<BlockEvents> {
 
     const defaultTunesInstances = Array.from(this.defaultTunesInstances.values());
     const customTunesInstances = Array.from(this.tunesInstances.values());
-    const tunesDefinedInTool = [ this.toolInstance.renderSettings() ].flat();
+    const tunesDefinedInTool =
+      typeof this.toolInstance.renderSettings === 'function'
+        ? [ this.toolInstance.renderSettings() ].flat()
+        : [];
     const otherTunes = customTunesInstances.concat(defaultTunesInstances).map(item => item.render());
 
     tunesDefinedInTool.concat(otherTunes).forEach(rendered => {

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -21,6 +21,7 @@ import { BlockTuneData } from '../../../types/block-tunes/block-tune-data';
 import ToolsCollection from '../tools/collection';
 import EventsDispatcher from '../utils/events';
 import { PopoverItem } from '../utils/popover';
+import { TunesMenuEntry } from '../../../types/tools';
 
 /**
  * Interface describes Block class constructor argument
@@ -667,16 +668,15 @@ export default class Block extends EventsDispatcher<BlockEvents> {
       .map(tune => tune.render())
       .filter(item => !!item);
 
-    // @ts-ignore
     return tunesDefinedInTool.concat(otherTunes).filter(item => !item.isActive);
   }
 
   /**
    *
    */
-  public getTunes(): [PopoverItem[], HTMLElement] {
+  public getTunes(): [TunesMenuEntry[], HTMLElement] {
     const tunesElement = document.createElement('div');
-    const tunesItems: PopoverItem[] = [];
+    let tunesItems: PopoverItem[] = [];
 
     const defaultTunesInstances = Array.from(this.defaultTunesInstances.values());
     const customTunesInstances = Array.from(this.tunesInstances.values());
@@ -693,8 +693,7 @@ export default class Block extends EventsDispatcher<BlockEvents> {
       }
     });
 
-    // @ts-ignore
-    // tunesItems = tunesItems.filter(item => !item.isActive);
+    tunesItems = tunesItems.filter(item => !item.isActive);
 
     return [tunesItems, tunesElement];
   }

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -651,7 +651,7 @@ export default class Block extends EventsDispatcher<BlockEvents> {
     const tunesItems: PopoverItem[] = [];
 
     /** Tool's tunes: may be defined as return value of optional renderSettings method */
-    const tunesDefinedInTool = typeof this.toolInstance.renderSettings === 'function' && this.toolInstance.renderSettings();
+    const tunesDefinedInTool = typeof this.toolInstance.renderSettings === 'function' ? this.toolInstance.renderSettings() : [];
 
     /** Common tunes: combination of default tunes (move up, move down, delete) and third-party tunes connected via tunes api */
     const commonTunes = [

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -5,7 +5,8 @@ import {
   BlockTune as IBlockTune,
   SanitizerConfig,
   ToolConfig,
-  ToolboxConfigEntry
+  ToolboxConfigEntry,
+  PopoverItem
 } from '../../../types';
 
 import { SavedData } from '../../../types/data-formats';
@@ -20,7 +21,6 @@ import BlockTune from '../tools/tune';
 import { BlockTuneData } from '../../../types/block-tunes/block-tune-data';
 import ToolsCollection from '../tools/collection';
 import EventsDispatcher from '../utils/events';
-import { PopoverItem } from '../utils/popover';
 
 /**
  * Interface describes Block class constructor argument

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -662,6 +662,8 @@ export default class Block extends EventsDispatcher<BlockEvents> {
     [tunesDefinedInTool, commonTunes].flat().forEach(rendered => {
       if ($.isElement(rendered)) {
         customHtmlTunesContainer.appendChild(rendered);
+      } else if (Array.isArray(rendered)) {
+        tunesItems.push(...rendered);
       } else {
         tunesItems.push(rendered);
       }

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -643,29 +643,13 @@ export default class Block extends EventsDispatcher<BlockEvents> {
   }
 
   /**
-   * Enumerates initialized tunes and returns fragment that can be appended to the toolbars area
-   *
-   * @returns {DocumentFragment[]}
+   * Returns list of tunes available for block
    */
-  public renderTunes(): [DocumentFragment, DocumentFragment] {
-    const tunesElement = document.createDocumentFragment();
-    const defaultTunesElement = document.createDocumentFragment();
+  public getTunesList(): PopoverItem[] {
+    const tunes = Array.from(this.tunesInstances.values());
+    const defaultTunes = Array.from(this.defaultTunesInstances.values());
 
-    this.tunesInstances.forEach((tune) => {
-      $.append(tunesElement, tune.render());
-    });
-    this.defaultTunesInstances.forEach((tune) => {
-      $.append(defaultTunesElement, tune.render());
-    });
-
-    return [tunesElement, defaultTunesElement];
-  }
-
-  /**
-   *
-   */
-  public getTunesItems(): PopoverItem[] {
-    return Array.from(this.defaultTunesInstances.values())
+    return tunes.concat(defaultTunes)
       .map(tune => tune.blockSettings)
       .filter(item => !!item);
   }

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -20,6 +20,7 @@ import BlockTune from '../tools/tune';
 import { BlockTuneData } from '../../../types/block-tunes/block-tune-data';
 import ToolsCollection from '../tools/collection';
 import EventsDispatcher from '../utils/events';
+import { PopoverItem } from '../utils/popover';
 
 /**
  * Interface describes Block class constructor argument
@@ -658,6 +659,14 @@ export default class Block extends EventsDispatcher<BlockEvents> {
     });
 
     return [tunesElement, defaultTunesElement];
+  }
+
+  /**
+   *
+   */
+  public getTunesItems(): PopoverItem[] {
+    return Array.from(this.defaultTunesInstances.values()).map(tune => tune.blockSettings)
+      .filter(item => !!item);
   }
 
   /**

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -647,7 +647,7 @@ export default class Block extends EventsDispatcher<BlockEvents> {
    * Splits block tunes settings into 2 groups: popover items and custom html.
    */
   public getTunes(): [PopoverItem[], HTMLElement] {
-    const tunesElement = document.createElement('div');
+    const customHtmlTunesContainer = document.createElement('div');
     const tunesItems: PopoverItem[] = [];
 
     /** Tool's tunes: may be defined as return value of optional renderSettings method */
@@ -661,13 +661,13 @@ export default class Block extends EventsDispatcher<BlockEvents> {
 
     [tunesDefinedInTool, commonTunes].flat().forEach(rendered => {
       if ($.isElement(rendered)) {
-        tunesElement.appendChild(rendered);
+        customHtmlTunesContainer.appendChild(rendered);
       } else {
         tunesItems.push(rendered);
       }
     });
 
-    return [tunesItems, tunesElement];
+    return [tunesItems, customHtmlTunesContainer];
   }
 
   /**

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -656,15 +656,22 @@ export default class Block extends EventsDispatcher<BlockEvents> {
   }
 
   /**
-   * Returns list of tunes available for block as popover items
+   * Returns list of tunes available for block in popover format
    */
   public getTunesList(): PopoverItem[] {
-    const tunes = Array.from(this.tunesInstances.values());
-    const defaultTunes = Array.from(this.defaultTunesInstances.values());
+    const customTunesInstances = Array.from(this.tunesInstances.values());
+    const defaultTunesInstances = Array.from(this.defaultTunesInstances.values());
+    const tunesDefinedInTool =
+      Array.isArray(this.toolInstance.blockSettings)
+        ? this.toolInstance.blockSettings
+        : [ this.toolInstance.blockSettings ];
 
-    return tunes.concat(defaultTunes)
+    const otherTunes = customTunesInstances.concat(defaultTunesInstances)
       .map(tune => tune.blockSettings)
       .filter(item => !!item);
+
+    // @ts-ignore
+    return tunesDefinedInTool.concat(otherTunes).filter(item => !item.isActive);
   }
 
   /**
@@ -741,6 +748,19 @@ export default class Block extends EventsDispatcher<BlockEvents> {
       return this.toolInstance.renderSettings();
     }
   }
+
+  /**
+   *
+   */
+  // public get blockSettings(): PopoverItem | PopoverItem[] {
+  //   if (_.isFunction(this.toolInstance.blockSettings)) {
+  //     return this.toolInstance.blockSettings();
+  //   }
+  // }
+
+  // public async getActiveTunesEntry() {
+
+  // }
 
   /**
    * Tool could specify several entries to be displayed at the Toolbox (for example, "Heading 1", "Heading 2", "Heading 3")

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -644,34 +644,6 @@ export default class Block extends EventsDispatcher<BlockEvents> {
   }
 
   /**
-   * Returns rendered custom block tunes
-   */
-  public getTunesRendered(): DocumentFragment {
-    const tunesElement = document.createDocumentFragment();
-
-    // this.tunesInstances.forEach((tune) => {
-    //   $.append(tunesElement, tune.render());
-    // });
-
-    return tunesElement;
-  }
-
-  /**
-   * Returns list of tunes available for block in popover format
-   */
-  public getTunesList(): PopoverItem[] {
-    const customTunesInstances = Array.from(this.tunesInstances.values());
-    const defaultTunesInstances = Array.from(this.defaultTunesInstances.values());
-    const tunesDefinedInTool = [ this.toolInstance.render() ].flat();
-
-    const otherTunes = customTunesInstances.concat(defaultTunesInstances)
-      .map(tune => tune.render())
-      .filter(item => !!item);
-
-    return tunesDefinedInTool.concat(otherTunes).filter(item => !item.isActive);
-  }
-
-  /**
    * Returns data to render in tunes menu.
    * Splits block tunes settings into 2 groups: popover items and custom html.
    */
@@ -688,7 +660,9 @@ export default class Block extends EventsDispatcher<BlockEvents> {
     const otherTunes = customTunesInstances.concat(defaultTunesInstances).map(item => item.render());
 
     tunesDefinedInTool.concat(otherTunes).forEach(rendered => {
-      if (rendered instanceof HTMLElement) {
+      const isHTMLElement = rendered.nodeName !== undefined;
+
+      if (isHTMLElement) {
         tunesElement.appendChild(rendered);
       } else {
         const normalized = [ rendered ].flat();
@@ -766,16 +740,6 @@ export default class Block extends EventsDispatcher<BlockEvents> {
     if (_.isFunction(this.toolInstance.destroy)) {
       this.toolInstance.destroy();
     }
-  }
-
-  /**
-   * Call Tool instance renderSettings method
-   */
-  public renderSettings(): HTMLElement | undefined {
-    return undefined;
-    // if (_.isFunction(this.toolInstance.renderSettings)) {
-    //   return this.toolInstance.renderSettings();
-    // }
   }
 
   /**

--- a/src/components/domIterator.ts
+++ b/src/components/domIterator.ts
@@ -67,6 +67,7 @@ export default class DomIterator {
    */
   public setCursor(cursorPosition: number): void {
     if (cursorPosition < this.items.length && cursorPosition >= -1) {
+      this.dropCursor();
       this.cursor = cursorPosition;
       this.items[this.cursor].classList.add(this.focusedCssClass);
     }

--- a/src/components/domIterator.ts
+++ b/src/components/domIterator.ts
@@ -61,6 +61,18 @@ export default class DomIterator {
   }
 
   /**
+   * Sets cursor to specified position
+   *
+   * @param cursorPosition - new cursor position
+   */
+  public setCursor(cursorPosition: number): void {
+    if (cursorPosition < this.items.length && cursorPosition >= -1) {
+      this.cursor = cursorPosition;
+      this.items[this.cursor].classList.add(this.focusedCssClass);
+    }
+  }
+
+  /**
    * Sets items. Can be used when iterable items changed dynamically
    *
    * @param {HTMLElement[]} nodeList - nodes to iterate

--- a/src/components/flipper.ts
+++ b/src/components/flipper.ts
@@ -123,6 +123,10 @@ export default class Flipper {
      * Listening all keydowns on document and react on TAB/Enter press
      * TAB will leaf iterator items
      * ENTER will click the focused item
+     *
+     * Note: the event should be handled in capturing mode on following reasons:
+     * - prevents plugins inner keydown handlers from being called while keyboard navigation
+     * - otherwise this handler will be called at the moment it is attached which causes false flipper firing (see https://techread.me/js-addeventlistener-fires-for-past-events/)
      */
     document.addEventListener('keydown', this.onKeyDown, true);
   }

--- a/src/components/flipper.ts
+++ b/src/components/flipper.ts
@@ -41,6 +41,13 @@ export interface FlipperOptions {
  */
 export default class Flipper {
   /**
+   * True if flipper is currently activated
+   */
+  public get isActivated(): boolean {
+    return this.activated;
+  }
+
+  /**
    * Instance of flipper iterator
    *
    * @type {DomIterator|null}

--- a/src/components/flipper.ts
+++ b/src/components/flipper.ts
@@ -124,7 +124,7 @@ export default class Flipper {
      * TAB will leaf iterator items
      * ENTER will click the focused item
      */
-    document.addEventListener('keydown', this.onKeyDown);
+    document.addEventListener('keydown', this.onKeyDown, true);
   }
 
   /**

--- a/src/components/flipper.ts
+++ b/src/components/flipper.ts
@@ -93,13 +93,18 @@ export default class Flipper {
   /**
    * Active tab/arrows handling by flipper
    *
-   * @param {HTMLElement[]} items - Some modules (like, InlineToolbar, BlockSettings) might refresh buttons dynamically
+   * @param items - Some modules (like, InlineToolbar, BlockSettings) might refresh buttons dynamically
+   * @param cursorPosition - index of the item that should be focused once flipper is activated
    */
-  public activate(items?: HTMLElement[]): void {
+  public activate(items?: HTMLElement[], cursorPosition?: number): void {
     this.activated = true;
 
     if (items) {
       this.iterator.setItems(items);
+    }
+
+    if (cursorPosition !== undefined) {
+      this.iterator.setCursor(cursorPosition);
     }
 
     /**

--- a/src/components/flipper.ts
+++ b/src/components/flipper.ts
@@ -72,6 +72,11 @@ export default class Flipper {
   private readonly activateCallback: (item: HTMLElement) => void;
 
   /**
+   * Contains list of callbacks to be executed on each flip
+   */
+  private flipCallbacks: Array<() => void> = []
+
+  /**
    * @param {FlipperOptions} options - different constructing settings
    */
   constructor(options: FlipperOptions) {
@@ -161,6 +166,24 @@ export default class Flipper {
    */
   public hasFocus(): boolean {
     return !!this.iterator.currentItem;
+  }
+
+  /**
+   * Registeres function that should be executed on each navigation action
+   *
+   * @param cb - function to execute
+   */
+  public onFlip(cb: () => void): void {
+    this.flipCallbacks.push(cb);
+  }
+
+  /**
+   * Unregisteres function that is executed on each navigation action
+   *
+   * @param cb - function to stop executing
+   */
+  public removeOnFlip(cb: () => void): void {
+    this.flipCallbacks = this.flipCallbacks.filter(fn => fn !== cb);
   }
 
   /**
@@ -270,5 +293,7 @@ export default class Flipper {
     if (this.iterator.currentItem) {
       this.iterator.currentItem.scrollIntoViewIfNeeded();
     }
+
+    this.flipCallbacks.forEach(cb => cb());
   }
 }

--- a/src/components/i18n/locales/en/messages.json
+++ b/src/components/i18n/locales/en/messages.json
@@ -37,7 +37,8 @@
   },
   "blockTunes": {
     "delete": {
-      "Delete": ""
+      "Delete": "",
+      "Click to delete": ""
     },
     "moveUp": {
       "Move up": ""

--- a/src/components/i18n/locales/en/messages.json
+++ b/src/components/i18n/locales/en/messages.json
@@ -13,10 +13,12 @@
     },
     "toolbar": {
       "toolbox": {
-        "Add": "",
-        "Filter": "",
-        "Nothing found": ""
+        "Add": ""
       }
+    },
+    "popover": {
+      "Filter": "",
+      "Nothing found": ""
     }
   },
   "toolNames": {

--- a/src/components/modules/api/blocks.ts
+++ b/src/components/modules/api/blocks.ts
@@ -23,7 +23,7 @@ export default class BlocksAPI extends Module {
       delete: (index?: number): void => this.delete(index),
       swap: (fromIndex: number, toIndex: number): void => this.swap(fromIndex, toIndex),
       move: (toIndex: number, fromIndex?: number): void => this.move(toIndex, fromIndex),
-      getBlockByIndex: (index: number): BlockAPIInterface | void => this.getBlockByIndex(index),
+      getBlockByIndex: (index: number): BlockAPIInterface | undefined => this.getBlockByIndex(index),
       getById: (id: string): BlockAPIInterface | null => this.getById(id),
       getCurrentBlockIndex: (): number => this.getCurrentBlockIndex(),
       getBlockIndex: (id: string): number => this.getBlockIndex(id),
@@ -77,7 +77,7 @@ export default class BlocksAPI extends Module {
    *
    * @param {number} index - index to get
    */
-  public getBlockByIndex(index: number): BlockAPIInterface | void {
+  public getBlockByIndex(index: number): BlockAPIInterface | undefined {
     const block = this.Editor.BlockManager.getBlockByIndex(index);
 
     if (block === undefined) {

--- a/src/components/modules/blockEvents.ts
+++ b/src/components/modules/blockEvents.ts
@@ -129,18 +129,21 @@ export default class BlockEvents extends Module {
     const canOpenToolbox = currentBlock.tool.isDefault && isEmptyBlock;
     const conversionToolbarOpened = !isEmptyBlock && ConversionToolbar.opened;
     const inlineToolbarOpened = !isEmptyBlock && !SelectionUtils.isCollapsed && InlineToolbar.opened;
+    const canOpenBlockTunes = !conversionToolbarOpened && !inlineToolbarOpened;
 
     /**
      * For empty Blocks we show Plus button via Toolbox only for default Blocks
      */
     if (canOpenToolbox) {
       this.activateToolbox();
-    } else if (!conversionToolbarOpened && !inlineToolbarOpened) {
+    } else if (canOpenBlockTunes) {
       this.activateBlockSettings();
     }
 
-    /** Prevent event being handled inside opened popover */
-    event.stopPropagation();
+    if (canOpenToolbox || canOpenBlockTunes) {
+      /** Prevent event being handled inside opened popover */
+      event.stopPropagation();
+    }
   }
 
   /**

--- a/src/components/modules/blockEvents.ts
+++ b/src/components/modules/blockEvents.ts
@@ -139,11 +139,6 @@ export default class BlockEvents extends Module {
     } else if (canOpenBlockTunes) {
       this.activateBlockSettings();
     }
-
-    if (canOpenToolbox || canOpenBlockTunes) {
-      /** Prevent event being handled inside opened popover */
-      event.stopPropagation();
-    }
   }
 
   /**

--- a/src/components/modules/blockEvents.ts
+++ b/src/components/modules/blockEvents.ts
@@ -138,6 +138,9 @@ export default class BlockEvents extends Module {
     } else if (!conversionToolbarOpened && !inlineToolbarOpened) {
       this.activateBlockSettings();
     }
+
+    /** Prevent event being handled inside opened popover */
+    event.stopPropagation();
   }
 
   /**

--- a/src/components/modules/toolbar/blockSettings.ts
+++ b/src/components/modules/toolbar/blockSettings.ts
@@ -109,7 +109,7 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
       searchable: true,
       filterLabel: I18n.ui(I18nInternalNS.ui.toolbar.toolbox, 'Filter'),
       nothingFoundLabel: I18n.ui(I18nInternalNS.ui.toolbar.toolbox, 'Nothing found'),
-      items: targetBlock.getTunesItems(),
+      items: targetBlock.getTunesList(),
       customContent: this.nodes.toolSettings,
       api: this.Editor.API.methods,
     });

--- a/src/components/modules/toolbar/blockSettings.ts
+++ b/src/components/modules/toolbar/blockSettings.ts
@@ -110,8 +110,8 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
     this.popover = new Popover({
       className: this.CSS.settings,
       searchable: true,
-      filterLabel: I18n.ui(I18nInternalNS.ui.toolbar.toolbox, 'Filter'),
-      nothingFoundLabel: I18n.ui(I18nInternalNS.ui.toolbar.toolbox, 'Nothing found'),
+      filterLabel: I18n.ui(I18nInternalNS.ui.popover, 'Filter'),
+      nothingFoundLabel: I18n.ui(I18nInternalNS.ui.popover, 'Nothing found'),
       items: this.prepareTunesItems(tunesItems),
       customContent: this.nodes.renderedTunes,
       api: this.Editor.API.methods,

--- a/src/components/modules/toolbar/blockSettings.ts
+++ b/src/components/modules/toolbar/blockSettings.ts
@@ -97,7 +97,9 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
     /**
      * Fill Tool's settings
      */
-    this.nodes.renderedTunes = this.composeRenderedTunes(targetBlock);
+    const [tunesItems, tunesElement] = targetBlock.getTunes();
+
+    this.nodes.renderedTunes = tunesElement;
 
     /** Tell to subscribers that block settings is opened */
     this.eventsDispatcher.emit(this.events.opened);
@@ -109,7 +111,7 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
       searchable: true,
       filterLabel: I18n.ui(I18nInternalNS.ui.toolbar.toolbox, 'Filter'),
       nothingFoundLabel: I18n.ui(I18nInternalNS.ui.toolbar.toolbox, 'Nothing found'),
-      items: targetBlock.getTunesList(),
+      items: tunesItems,
       customContent: this.nodes.renderedTunes,
       api: this.Editor.API.methods,
     });
@@ -166,24 +168,6 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
       this.popover.destroy();
       this.popover.getElement().remove();
     }
-  }
-
-  /**
-   * Combines rendered tool settings with custom block tunes
-   *
-   * @param targetBlock - block tunes belong to
-   */
-  private composeRenderedTunes(targetBlock: Block): HTMLElement | undefined {
-    const toolSettings = targetBlock.renderSettings();
-    const customBlockTunes = targetBlock.getTunesRendered();
-    const container = document.createElement('div');
-
-    if (!toolSettings && !customBlockTunes) {
-      return;
-    }
-    container.append(toolSettings, customBlockTunes);
-
-    return container;
   }
 
   /**

--- a/src/components/modules/toolbar/blockSettings.ts
+++ b/src/components/modules/toolbar/blockSettings.ts
@@ -118,7 +118,7 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
       filterLabel: 'Filter',
       nothingFoundLabel: 'Nothing found',
       items: targetBlock.getTunesItems(),
-      htmlContent: this.nodes.toolSettings,
+      customContent: this.nodes.toolSettings,
     });
 
     this.nodes.wrapper.append(this.popover.getElement());

--- a/src/components/modules/toolbar/blockSettings.ts
+++ b/src/components/modules/toolbar/blockSettings.ts
@@ -97,9 +97,9 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
     /**
      * Fill Tool's settings
      */
-    const [tunesItems, tunesElement] = targetBlock.getTunes();
+    const [tunesItemsConfig, addiitionalTunesContainer] = targetBlock.getTunes();
 
-    this.nodes.renderedTunes = tunesElement;
+    this.nodes.renderedTunes = addiitionalTunesContainer;
 
     /** Tell to subscribers that block settings is opened */
     this.eventsDispatcher.emit(this.events.opened);
@@ -111,9 +111,9 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
       searchable: true,
       filterLabel: I18n.ui(I18nInternalNS.ui.popover, 'Filter'),
       nothingFoundLabel: I18n.ui(I18nInternalNS.ui.popover, 'Nothing found'),
-      items: tunesItems,
+      items: tunesItemsConfig,
       customContent: this.nodes.renderedTunes,
-      editorElement: this.Editor.API.methods.ui.nodes.redactor,
+      scopeElement: this.Editor.API.methods.ui.nodes.redactor,
     });
     this.popover.on(PopoverEvent.OverlayClicked, this.onOverlayClicked);
 

--- a/src/components/modules/toolbar/blockSettings.ts
+++ b/src/components/modules/toolbar/blockSettings.ts
@@ -3,9 +3,10 @@ import $ from '../../dom';
 import * as _ from '../../utils';
 import SelectionUtils from '../../selection';
 import Block from '../../block';
-import Popover, { PopoverEvent } from '../../utils/popover';
+import Popover, { PopoverEvent, PopoverItem } from '../../utils/popover';
 import I18n from '../../i18n';
 import { I18nInternalNS } from '../../i18n/namespace-internal';
+import { TunesMenuEntry } from '../../../../types/tools';
 
 /**
  * HTML Elements that used for BlockSettings
@@ -111,7 +112,7 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
       searchable: true,
       filterLabel: I18n.ui(I18nInternalNS.ui.toolbar.toolbox, 'Filter'),
       nothingFoundLabel: I18n.ui(I18nInternalNS.ui.toolbar.toolbox, 'Nothing found'),
-      items: tunesItems,
+      items: this.prepareTunesItems(tunesItems),
       customContent: this.nodes.renderedTunes,
       api: this.Editor.API.methods,
     });
@@ -168,6 +169,23 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
       this.popover.destroy();
       this.popover.getElement().remove();
     }
+  }
+
+  /**
+   * Adds ability to close popover on item activation if corresponding flag is specified
+   *
+   * @param tunesItems - tunes configuration
+   */
+  private prepareTunesItems(tunesItems: TunesMenuEntry[]): PopoverItem[] {
+    return tunesItems.map(tunesItem => ({
+      ...tunesItem,
+      onClick: (item, event): void => {
+        tunesItem.onClick(item, event);
+        if (tunesItem.closeOnActivate) {
+          this.close();
+        }
+      },
+    }));
   }
 
   /**

--- a/src/components/modules/toolbar/blockSettings.ts
+++ b/src/components/modules/toolbar/blockSettings.ts
@@ -122,7 +122,6 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
       customContent: this.nodes.renderedTunes,
       customContentFlippableItems: this.getControls(this.nodes.renderedTunes),
       scopeElement: this.Editor.API.methods.ui.nodes.redactor,
-      shouldHighlightActivated: true,
     });
     this.popover.on(PopoverEvent.OverlayClicked, this.onOverlayClicked);
 

--- a/src/components/modules/toolbar/blockSettings.ts
+++ b/src/components/modules/toolbar/blockSettings.ts
@@ -3,7 +3,7 @@ import $ from '../../dom';
 import * as _ from '../../utils';
 import SelectionUtils from '../../selection';
 import Block from '../../block';
-import Popover from '../../utils/popover';
+import Popover, { PopoverEvent } from '../../utils/popover';
 import I18n from '../../i18n';
 import { I18nInternalNS } from '../../i18n/namespace-internal';
 
@@ -35,13 +35,11 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
 
   /**
    * Block Settings CSS
-   *
-   * @returns {{wrapper}}
    */
   public get CSS(): { [name: string]: string } {
     return {
-      // Settings Panel
-      wrapper: 'ce-settings',
+      settings: 'ce-settings',
+      settingsOpenedTop: 'ce-settings--opened-top',
     };
   }
 
@@ -66,7 +64,7 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
    *  - Default Settings [Move, Remove, etc]
    */
   public make(): void {
-    this.nodes.wrapper = $.make('div', this.CSS.wrapper);
+    this.nodes.wrapper = $.make('div');
   }
 
   /**
@@ -107,12 +105,15 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
     this.makeToolTunesButtonsNavigatable();
 
     this.popover = new Popover({
+      className: this.CSS.settings,
       searchable: true,
       filterLabel: I18n.ui(I18nInternalNS.ui.toolbar.toolbox, 'Filter'),
       nothingFoundLabel: I18n.ui(I18nInternalNS.ui.toolbar.toolbox, 'Nothing found'),
       items: targetBlock.getTunesItems(),
       customContent: this.nodes.toolSettings,
+      api: this.Editor.API.methods,
     });
+    this.popover.on(PopoverEvent.OverlayClicked, this.onOverlayClicked);
 
     this.nodes.wrapper.append(this.popover.getElement());
 
@@ -161,6 +162,7 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
     this.eventsDispatcher.emit(this.events.closed);
 
     if (this.popover) {
+      this.popover.off(PopoverEvent.OverlayClicked, this.onOverlayClicked);
       this.popover.destroy();
       this.popover.getElement().remove();
     }
@@ -184,5 +186,12 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
     toolSettings.forEach((item) => {
       item.classList.add(Popover.CSS.itemFlippable);
     });
+  }
+
+  /**
+   * Handles overlay click
+   */
+  private onOverlayClicked = (): void => {
+    this.close();
   }
 }

--- a/src/components/modules/toolbar/blockSettings.ts
+++ b/src/components/modules/toolbar/blockSettings.ts
@@ -13,7 +13,6 @@ import Flipper from '../../flipper';
  */
 interface BlockSettingsNodes {
   wrapper: HTMLElement;
-  renderedTunes: HTMLElement;
 }
 
 /**
@@ -54,7 +53,7 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
    * @todo remove once BlockSettings becomes standalone non-module class
    */
   public get flipper(): Flipper {
-    return this.popover?.flipper;
+    return this.popover.flipper;
   }
 
   /**
@@ -106,9 +105,7 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
     /**
      * Fill Tool's settings
      */
-    const [tunesItemsConfig, additionalTunesContainer] = targetBlock.getTunes();
-
-    this.nodes.renderedTunes = additionalTunesContainer;
+    const [tunesItems, customHtmlTunesContainer] = targetBlock.getTunes();
 
     /** Tell to subscribers that block settings is opened */
     this.eventsDispatcher.emit(this.events.opened);
@@ -118,9 +115,9 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
       searchable: true,
       filterLabel: I18n.ui(I18nInternalNS.ui.popover, 'Filter'),
       nothingFoundLabel: I18n.ui(I18nInternalNS.ui.popover, 'Nothing found'),
-      items: tunesItemsConfig,
-      customContent: this.nodes.renderedTunes,
-      customContentFlippableItems: this.getControls(this.nodes.renderedTunes),
+      items: tunesItems,
+      customContent: customHtmlTunesContainer,
+      customContentFlippableItems: this.getControls(customHtmlTunesContainer),
       scopeElement: this.Editor.API.methods.ui.nodes.redactor,
     });
     this.popover.on(PopoverEvent.OverlayClicked, this.onOverlayClicked);

--- a/src/components/modules/toolbar/blockSettings.ts
+++ b/src/components/modules/toolbar/blockSettings.ts
@@ -4,6 +4,8 @@ import * as _ from '../../utils';
 import SelectionUtils from '../../selection';
 import Block from '../../block';
 import Popover from '../../utils/popover';
+import I18n from '../../i18n';
+import { I18nInternalNS } from '../../i18n/namespace-internal';
 
 /**
  * HTML Elements that used for BlockSettings
@@ -15,14 +17,6 @@ interface BlockSettingsNodes {
 
 /**
  * Block Settings
- *
- *   ____ Settings Panel ____
- *  | ...................... |
- *  | .   Tool Settings    . |
- *  | ...................... |
- *  | .  Default Settings  . |
- *  | ...................... |
- *  |________________________|
  *
  *  @todo Make Block Settings no-module but a standalone class, like Toolbox
  */
@@ -113,10 +107,9 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
     this.makeToolTunesButtonsNavigatable();
 
     this.popover = new Popover({
-      className: '',
       searchable: true,
-      filterLabel: 'Filter',
-      nothingFoundLabel: 'Nothing found',
+      filterLabel: I18n.ui(I18nInternalNS.ui.toolbar.toolbox, 'Filter'),
+      nothingFoundLabel: I18n.ui(I18nInternalNS.ui.toolbar.toolbox, 'Nothing found'),
       items: targetBlock.getTunesItems(),
       customContent: this.nodes.toolSettings,
     });
@@ -168,6 +161,7 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
     this.eventsDispatcher.emit(this.events.closed);
 
     if (this.popover) {
+      this.popover.destroy();
       this.popover.getElement().remove();
     }
   }

--- a/src/components/modules/toolbar/blockSettings.ts
+++ b/src/components/modules/toolbar/blockSettings.ts
@@ -176,8 +176,8 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
    */
   private makeToolTunesButtonsNavigatable(): void {
     const { StylesAPI } = this.Editor;
+    /** Query buttons and inputs inside tunes html */
     const toolSettings = this.nodes.renderedTunes?.querySelectorAll(
-      // Select buttons and inputs
       `.${StylesAPI.classes.settingsButton}, ${$.allInputsSelector}`
     );
 

--- a/src/components/modules/toolbar/blockSettings.ts
+++ b/src/components/modules/toolbar/blockSettings.ts
@@ -6,7 +6,6 @@ import Block from '../../block';
 import Popover, { PopoverEvent, PopoverItem } from '../../utils/popover';
 import I18n from '../../i18n';
 import { I18nInternalNS } from '../../i18n/namespace-internal';
-import { TunesMenuEntry } from '../../../../types/tools';
 
 /**
  * HTML Elements that used for BlockSettings
@@ -112,7 +111,7 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
       searchable: true,
       filterLabel: I18n.ui(I18nInternalNS.ui.popover, 'Filter'),
       nothingFoundLabel: I18n.ui(I18nInternalNS.ui.popover, 'Nothing found'),
-      items: this.prepareTunesItems(tunesItems),
+      items: tunesItems,
       customContent: this.nodes.renderedTunes,
       api: this.Editor.API.methods,
     });
@@ -169,23 +168,6 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
       this.popover.destroy();
       this.popover.getElement().remove();
     }
-  }
-
-  /**
-   * Adds ability to close popover on item activation if corresponding flag is specified
-   *
-   * @param tunesItems - tunes configuration
-   */
-  private prepareTunesItems(tunesItems: TunesMenuEntry[]): PopoverItem[] {
-    return tunesItems.map(tunesItem => ({
-      ...tunesItem,
-      onClick: (item, event): void => {
-        tunesItem.onClick(item, event);
-        if (tunesItem.closeOnActivate) {
-          this.close();
-        }
-      },
-    }));
   }
 
   /**

--- a/src/components/modules/toolbar/blockSettings.ts
+++ b/src/components/modules/toolbar/blockSettings.ts
@@ -39,7 +39,6 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
   public get CSS(): { [name: string]: string } {
     return {
       settings: 'ce-settings',
-      settingsOpenedTop: 'ce-settings--opened-top',
     };
   }
 
@@ -97,14 +96,12 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
     /**
      * Fill Tool's settings
      */
-    const [tunesItemsConfig, addiitionalTunesContainer] = targetBlock.getTunes();
+    const [tunesItemsConfig, additionalTunesContainer] = targetBlock.getTunes();
 
-    this.nodes.renderedTunes = addiitionalTunesContainer;
+    this.nodes.renderedTunes = additionalTunesContainer;
 
     /** Tell to subscribers that block settings is opened */
     this.eventsDispatcher.emit(this.events.opened);
-
-    const customContentFlippableItems = this.getControls(this.nodes.renderedTunes);
 
     this.popover = new Popover({
       className: this.CSS.settings,
@@ -113,7 +110,7 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
       nothingFoundLabel: I18n.ui(I18nInternalNS.ui.popover, 'Nothing found'),
       items: tunesItemsConfig,
       customContent: this.nodes.renderedTunes,
-      customContentFlippableItems,
+      customContentFlippableItems: this.getControls(this.nodes.renderedTunes),
       scopeElement: this.Editor.API.methods.ui.nodes.redactor,
     });
     this.popover.on(PopoverEvent.OverlayClicked, this.onOverlayClicked);

--- a/src/components/modules/toolbar/blockSettings.ts
+++ b/src/components/modules/toolbar/blockSettings.ts
@@ -163,11 +163,6 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
       this.Editor.BlockManager.currentBlock.selected = false;
     }
 
-    /** Clear settings */
-    if (this.nodes.renderedTunes) {
-      this.nodes.renderedTunes.innerHTML = '';
-    }
-
     /** Tell to subscribers that block settings is closed */
     this.eventsDispatcher.emit(this.events.closed);
 

--- a/src/components/modules/toolbar/blockSettings.ts
+++ b/src/components/modules/toolbar/blockSettings.ts
@@ -6,6 +6,7 @@ import Block from '../../block';
 import Popover, { PopoverEvent } from '../../utils/popover';
 import I18n from '../../i18n';
 import { I18nInternalNS } from '../../i18n/namespace-internal';
+import Flipper from '../../flipper';
 
 /**
  * HTML Elements that used for BlockSettings
@@ -46,6 +47,15 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
    * Opened state
    */
   public opened = false;
+
+  /**
+   * Getter for inner popover's flipper instance
+   *
+   * @todo remove once BlockSettings becomes standalone non-module class
+   */
+  public get flipper(): Flipper {
+    return this.popover?.flipper;
+  }
 
   /**
    * Page selection utils

--- a/src/components/modules/toolbar/blockSettings.ts
+++ b/src/components/modules/toolbar/blockSettings.ts
@@ -122,6 +122,7 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
       customContent: this.nodes.renderedTunes,
       customContentFlippableItems: this.getControls(this.nodes.renderedTunes),
       scopeElement: this.Editor.API.methods.ui.nodes.redactor,
+      shouldHighlightActivated: true,
     });
     this.popover.on(PopoverEvent.OverlayClicked, this.onOverlayClicked);
 

--- a/src/components/modules/toolbar/blockSettings.ts
+++ b/src/components/modules/toolbar/blockSettings.ts
@@ -113,7 +113,7 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
       nothingFoundLabel: I18n.ui(I18nInternalNS.ui.popover, 'Nothing found'),
       items: tunesItems,
       customContent: this.nodes.renderedTunes,
-      api: this.Editor.API.methods,
+      editorElement: this.Editor.API.methods.ui.nodes.redactor,
     });
     this.popover.on(PopoverEvent.OverlayClicked, this.onOverlayClicked);
 

--- a/src/components/modules/toolbar/blockSettings.ts
+++ b/src/components/modules/toolbar/blockSettings.ts
@@ -12,7 +12,7 @@ import { I18nInternalNS } from '../../i18n/namespace-internal';
  */
 interface BlockSettingsNodes {
   wrapper: HTMLElement;
-  toolSettings: HTMLElement;
+  renderedTunes: HTMLElement;
 }
 
 /**
@@ -97,7 +97,7 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
     /**
      * Fill Tool's settings
      */
-    this.nodes.toolSettings = targetBlock.renderSettings();
+    this.nodes.renderedTunes = this.composeRenderedTunes(targetBlock);
 
     /** Tell to subscribers that block settings is opened */
     this.eventsDispatcher.emit(this.events.opened);
@@ -110,7 +110,7 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
       filterLabel: I18n.ui(I18nInternalNS.ui.toolbar.toolbox, 'Filter'),
       nothingFoundLabel: I18n.ui(I18nInternalNS.ui.toolbar.toolbox, 'Nothing found'),
       items: targetBlock.getTunesList(),
-      customContent: this.nodes.toolSettings,
+      customContent: this.nodes.renderedTunes,
       api: this.Editor.API.methods,
     });
     this.popover.on(PopoverEvent.OverlayClicked, this.onOverlayClicked);
@@ -154,8 +154,8 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
     }
 
     /** Clear settings */
-    if (this.nodes.toolSettings) {
-      this.nodes.toolSettings.innerHTML = '';
+    if (this.nodes.renderedTunes) {
+      this.nodes.renderedTunes.innerHTML = '';
     }
 
     /** Tell to subscribers that block settings is closed */
@@ -169,12 +169,30 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
   }
 
   /**
+   * Combines rendered tool settings with custom block tunes
+   *
+   * @param targetBlock - block tunes belong to
+   */
+  private composeRenderedTunes(targetBlock: Block): HTMLElement | undefined {
+    const toolSettings = targetBlock.renderSettings();
+    const customBlockTunes = targetBlock.getTunesRendered();
+    const container = document.createElement('div');
+
+    if (!toolSettings && !customBlockTunes) {
+      return;
+    }
+    container.append(toolSettings, customBlockTunes);
+
+    return container;
+  }
+
+  /**
    * Adds special class to rendered tool settings signalising that button should
    * be available for keyboard navigation
    */
   private makeToolTunesButtonsNavigatable(): void {
     const { StylesAPI } = this.Editor;
-    const toolSettings = this.nodes.toolSettings?.querySelectorAll(
+    const toolSettings = this.nodes.renderedTunes?.querySelectorAll(
       // Select buttons and inputs
       `.${StylesAPI.classes.settingsButton}, ${$.allInputsSelector}`
     );

--- a/src/components/modules/toolbar/blockSettings.ts
+++ b/src/components/modules/toolbar/blockSettings.ts
@@ -121,6 +121,7 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
       scopeElement: this.Editor.API.methods.ui.nodes.redactor,
     });
     this.popover.on(PopoverEvent.OverlayClicked, this.onOverlayClicked);
+    this.popover.on(PopoverEvent.Close, () => this.close());
 
     this.nodes.wrapper.append(this.popover.getElement());
 
@@ -167,6 +168,7 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
       this.popover.off(PopoverEvent.OverlayClicked, this.onOverlayClicked);
       this.popover.destroy();
       this.popover.getElement().remove();
+      this.popover = null;
     }
   }
 

--- a/src/components/modules/toolbar/blockSettings.ts
+++ b/src/components/modules/toolbar/blockSettings.ts
@@ -3,7 +3,7 @@ import $ from '../../dom';
 import * as _ from '../../utils';
 import SelectionUtils from '../../selection';
 import Block from '../../block';
-import Popover, { PopoverEvent, PopoverItem } from '../../utils/popover';
+import Popover, { PopoverEvent } from '../../utils/popover';
 import I18n from '../../i18n';
 import { I18nInternalNS } from '../../i18n/namespace-internal';
 

--- a/src/components/modules/toolbar/blockSettings.ts
+++ b/src/components/modules/toolbar/blockSettings.ts
@@ -104,7 +104,7 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
     /** Tell to subscribers that block settings is opened */
     this.eventsDispatcher.emit(this.events.opened);
 
-    this.makeToolTunesButtonsNavigatable();
+    const customContentFlippableItems = this.getControls(this.nodes.renderedTunes);
 
     this.popover = new Popover({
       className: this.CSS.settings,
@@ -113,6 +113,7 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
       nothingFoundLabel: I18n.ui(I18nInternalNS.ui.popover, 'Nothing found'),
       items: tunesItemsConfig,
       customContent: this.nodes.renderedTunes,
+      customContentFlippableItems,
       scopeElement: this.Editor.API.methods.ui.nodes.redactor,
     });
     this.popover.on(PopoverEvent.OverlayClicked, this.onOverlayClicked);
@@ -171,23 +172,18 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
   }
 
   /**
-   * Adds special class to rendered tool settings signalising that button should
-   * be available for keyboard navigation
+   * Returns list of buttons and inputs inside specified container
+   *
+   * @param container - container to query controls inside of
    */
-  private makeToolTunesButtonsNavigatable(): void {
+  private getControls(container: HTMLElement): HTMLElement[] {
     const { StylesAPI } = this.Editor;
     /** Query buttons and inputs inside tunes html */
-    const toolSettings = this.nodes.renderedTunes?.querySelectorAll(
+    const controls = container.querySelectorAll<HTMLElement>(
       `.${StylesAPI.classes.settingsButton}, ${$.allInputsSelector}`
     );
 
-    if (!toolSettings) {
-      return;
-    }
-
-    toolSettings.forEach((item) => {
-      item.classList.add(Popover.CSS.itemFlippable);
-    });
+    return Array.from(controls);
   }
 
   /**

--- a/src/components/modules/toolbar/index.ts
+++ b/src/components/modules/toolbar/index.ts
@@ -388,7 +388,7 @@ export default class Toolbar extends Module<ToolbarNodes> {
      * Appending Toolbar components to itself
      */
     $.append(this.nodes.actions, this.makeToolbox());
-    $.append(this.nodes.actions, this.Editor.BlockSettings.nodes.wrapper);
+    $.append(this.nodes.actions, this.Editor.BlockSettings.getElement());
 
     /**
      * Append toolbar to the Editor

--- a/src/components/modules/toolbar/index.ts
+++ b/src/components/modules/toolbar/index.ts
@@ -407,8 +407,8 @@ export default class Toolbar extends Module<ToolbarNodes> {
       api: this.Editor.API.methods,
       tools: this.Editor.Tools.blockTools,
       i18nLabels: {
-        filter: I18n.ui(I18nInternalNS.ui.toolbar.toolbox, 'Filter'),
-        nothingFound: I18n.ui(I18nInternalNS.ui.toolbar.toolbox, 'Nothing found'),
+        filter: I18n.ui(I18nInternalNS.ui.popover, 'Filter'),
+        nothingFound: I18n.ui(I18nInternalNS.ui.popover, 'Nothing found'),
       },
     });
 

--- a/src/components/ui/toolbox.ts
+++ b/src/components/ui/toolbox.ts
@@ -99,7 +99,6 @@ export default class Toolbox extends EventsDispatcher<ToolboxEvent> {
   private static get CSS(): { [name: string]: string } {
     return {
       toolbox: 'ce-toolbox',
-      toolboxOpenedTop: 'ce-toolbox--opened-top',
     };
   }
 
@@ -128,6 +127,7 @@ export default class Toolbox extends EventsDispatcher<ToolboxEvent> {
    */
   public make(): Element {
     this.popover = new Popover({
+      api: this.api,
       className: Toolbox.CSS.toolbox,
       searchable: true,
       filterLabel: this.i18nLabels.filter,
@@ -189,15 +189,6 @@ export default class Toolbox extends EventsDispatcher<ToolboxEvent> {
       return;
     }
 
-    /**
-     * Open the popover above the button
-     * if there is not enough available space below it
-     */
-    if (!this.shouldOpenPopoverBottom) {
-      this.nodes.toolbox.style.setProperty('--popover-height', this.popover.calculateHeight() + 'px');
-      this.nodes.toolbox.classList.add(Toolbox.CSS.toolboxOpenedTop);
-    }
-
     this.popover.show();
     this.opened = true;
     this.emit(ToolboxEvent.Opened);
@@ -209,7 +200,6 @@ export default class Toolbox extends EventsDispatcher<ToolboxEvent> {
   public close(): void {
     this.popover.hide();
     this.opened = false;
-    this.nodes.toolbox.classList.remove(Toolbox.CSS.toolboxOpenedTop);
     this.emit(ToolboxEvent.Closed);
   }
 
@@ -222,21 +212,6 @@ export default class Toolbox extends EventsDispatcher<ToolboxEvent> {
     } else {
       this.close();
     }
-  }
-
-  /**
-   * Checks if there popover should be opened downwards.
-   * It happens in case there is enough space below or not enough space above
-   */
-  private get shouldOpenPopoverBottom(): boolean {
-    const toolboxRect = this.nodes.toolbox.getBoundingClientRect();
-    const editorElementRect = this.api.ui.nodes.redactor.getBoundingClientRect();
-    const popoverHeight = this.popover.calculateHeight();
-    const popoverPotentialBottomEdge = toolboxRect.top + popoverHeight;
-    const popoverPotentialTopEdge = toolboxRect.top - popoverHeight;
-    const bottomEdgeForComparison = Math.min(window.innerHeight, editorElementRect.bottom);
-
-    return popoverPotentialTopEdge < editorElementRect.top || popoverPotentialBottomEdge <= bottomEdgeForComparison;
   }
 
   /**

--- a/src/components/ui/toolbox.ts
+++ b/src/components/ui/toolbox.ts
@@ -3,9 +3,9 @@ import { BlockToolAPI } from '../block';
 import Shortcuts from '../utils/shortcuts';
 import BlockTool from '../tools/block';
 import ToolsCollection from '../tools/collection';
-import { API, BlockToolData, ToolboxConfigEntry } from '../../../types';
+import { API, BlockToolData, ToolboxConfigEntry, PopoverItem } from '../../../types';
 import EventsDispatcher from '../utils/events';
-import Popover, { PopoverEvent, PopoverItem } from '../utils/popover';
+import Popover, { PopoverEvent } from '../utils/popover';
 import I18n from '../i18n';
 import { I18nInternalNS } from '../i18n/namespace-internal';
 

--- a/src/components/ui/toolbox.ts
+++ b/src/components/ui/toolbox.ts
@@ -127,7 +127,7 @@ export default class Toolbox extends EventsDispatcher<ToolboxEvent> {
    */
   public make(): Element {
     this.popover = new Popover({
-      editorElement: this.api.ui.nodes.redactor,
+      scopeElement: this.api.ui.nodes.redactor,
       className: Toolbox.CSS.toolbox,
       searchable: true,
       filterLabel: this.i18nLabels.filter,

--- a/src/components/ui/toolbox.ts
+++ b/src/components/ui/toolbox.ts
@@ -127,7 +127,7 @@ export default class Toolbox extends EventsDispatcher<ToolboxEvent> {
    */
   public make(): Element {
     this.popover = new Popover({
-      api: this.api,
+      editorElement: this.api.ui.nodes.redactor,
       className: Toolbox.CSS.toolbox,
       searchable: true,
       filterLabel: this.i18nLabels.filter,

--- a/src/components/ui/toolbox.ts
+++ b/src/components/ui/toolbox.ts
@@ -259,7 +259,7 @@ export default class Toolbox extends EventsDispatcher<ToolboxEvent> {
         icon: toolboxItem.icon,
         label: I18n.t(I18nInternalNS.toolNames, toolboxItem.title || _.capitalize(tool.name)),
         name: tool.name,
-        onClick: (e): void => {
+        onActivate: (e): void => {
           this.toolButtonActivated(tool.name, toolboxItem.data);
         },
         secondaryLabel: tool.shortcut ? _.beautifyShortcut(tool.shortcut) : '',

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -50,7 +50,7 @@ interface PopoverItemWithConfirmation extends PopoverItemBase {
    * Item parameters that should be applied on item activation.
    * May be used to ask user for confirmation before executing popover item activation handler.
    */
-  confirmation: PopoverItem;
+  confirmation: Partial<PopoverItem>;
 
   onActivate?: never;
 }
@@ -505,8 +505,19 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
       if (this.itemRequiringConfirmation === null) {
         this.itemRequiringConfirmation = clickedItem;
       }
-      this.items[itemIndex] = clickedItem.confirmation;
-      const confirmationStateItemEl = this.createItem(clickedItem.confirmation as PopoverItem);
+      const newItemData = {
+        ...clickedItem,
+        ...clickedItem.confirmation,
+      } as PopoverItem;
+
+      /** Prevent confirmation loop */
+      if (newItemData.confirmation === clickedItem.confirmation) {
+        delete newItemData.confirmation;
+      }
+
+      this.items[itemIndex] = newItemData;
+
+      const confirmationStateItemEl = this.createItem(newItemData as PopoverItem);
 
       confirmationStateItemEl.classList.add(Popover.CSS.itemConfirmation);
       itemEl.parentElement.replaceChild(confirmationStateItemEl, itemEl);

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -52,7 +52,7 @@ interface PopoverItemWithConfirmation extends PopoverItemBase {
    */
   confirmation: PopoverItem;
 
-  onClick?: never;
+  onActivate?: never;
 }
 
 /**
@@ -62,11 +62,11 @@ interface PopoverItemWithoutConfirmation extends PopoverItemBase {
   confirmation?: never;
 
   /**
-   * Item click handler
+   * Item activation handler
    *
-   * @param item - clicked item
+   * @param item - activated item
    */
-  onClick: (item: PopoverItem, event?: MouseEvent) => void;
+  onActivate: (item: PopoverItem, event?: MouseEvent) => void;
 }
 
 export type PopoverItem = PopoverItemWithConfirmation | PopoverItemWithoutConfirmation
@@ -519,7 +519,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
       return;
     }
 
-    clickedItem.onClick(clickedItem, event);
+    clickedItem.onActivate(clickedItem, event);
 
     if (clickedItem.closeOnActivate) {
       this.hide();

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -43,6 +43,11 @@ export interface PopoverItem {
    * True if item should be highlighted as active
    */
   isActive?: boolean;
+
+  /**
+   * True if popover should close once item is activated
+   */
+  closeOnActivate?: boolean;
 }
 
 /**
@@ -137,6 +142,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
     itemHidden: string;
     itemFlippable: string;
     itemFocused: string;
+    itemActive: string;
     itemLabel: string;
     itemIcon: string;
     itemSecondaryLabel: string;
@@ -155,6 +161,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
       itemHidden: 'ce-popover__item--hidden',
       itemFlippable: 'ce-popover__item--flippable',
       itemFocused: 'ce-popover__item--focused',
+      itemActive: 'ce-popover__item--active',
       itemLabel: 'ce-popover__item-label',
       itemIcon: 'ce-popover__item-icon',
       itemSecondaryLabel: 'ce-popover__item-secondary-label',
@@ -435,6 +442,10 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
       }));
     }
 
+    if (item.isActive) {
+      el.classList.add(Popover.CSS.itemActive);
+    }
+
     return el;
   }
 
@@ -450,6 +461,10 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
     const clickedItem = this.items[itemIndex];
 
     clickedItem.onClick(clickedItem, event);
+
+    if (clickedItem.closeOnActivate) {
+      this.hide();
+    }
   }
 
   /**

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -234,7 +234,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
 
     this.nodes.popover.classList.add(Popover.CSS.popoverOpened);
     this.nodes.overlay.classList.remove(Popover.CSS.popoverOverlayHidden);
-    this.flipper.activate();
+    this.flipper.activate(this.flippableElements);
 
     if (this.searchable) {
       setTimeout(() => {

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -189,9 +189,9 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
   private scrollLocker = new ScrollLocker()
 
   /**
-   * Editor API
+   * Editor container element
    */
-  private api: API;
+  private editorElement: HTMLElement;
 
   /**
    * Reference to popover item that was clicked but requires second click to confirm action
@@ -207,15 +207,16 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
    * @param options.filterLabel - label for the search Field
    * @param options.nothingFoundLabel - label of the 'nothing found' message
    * @param options.customContent - arbitrary html element to be inserted before items list
+   * @param options.editorElement - editor container element
    */
-  constructor({ items, className, searchable, filterLabel, nothingFoundLabel, customContent, api }: {
+  constructor({ items, className, searchable, filterLabel, nothingFoundLabel, customContent, editorElement }: {
     items: PopoverItem[];
     className?: string;
     searchable?: boolean;
     filterLabel: string;
     nothingFoundLabel: string;
     customContent?: HTMLElement;
-    api: API;
+    editorElement: HTMLElement;
   }) {
     super();
     this.items = items;
@@ -223,7 +224,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
     this.className = className || '';
     this.searchable = searchable;
     this.listeners = new Listeners();
-    this.api = api;
+    this.editorElement = editorElement;
 
     this.filterLabel = filterLabel;
     this.nothingFoundLabel = nothingFoundLabel;
@@ -605,7 +606,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
    */
   private get shouldOpenPopoverBottom(): boolean {
     const toolboxRect = this.nodes.wrapper.getBoundingClientRect();
-    const editorElementRect = this.api.ui.nodes.redactor.getBoundingClientRect();
+    const editorElementRect = this.editorElement.getBoundingClientRect();
     const popoverHeight = this.calculateHeight();
     const popoverPotentialBottomEdge = toolboxRect.top + popoverHeight;
     const popoverPotentialTopEdge = toolboxRect.top - popoverHeight;

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -205,7 +205,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
   /**
    * Editor container element
    */
-  private editorElement: HTMLElement;
+  private scopeElement: HTMLElement;
 
   /**
    * Reference to popover item that was clicked but requires second click to confirm action
@@ -221,16 +221,16 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
    * @param options.filterLabel - label for the search Field
    * @param options.nothingFoundLabel - label of the 'nothing found' message
    * @param options.customContent - arbitrary html element to be inserted before items list
-   * @param options.editorElement - editor container element
+   * @param options.scopeElement - editor container element
    */
-  constructor({ items, className, searchable, filterLabel, nothingFoundLabel, customContent, editorElement }: {
+  constructor({ items, className, searchable, filterLabel, nothingFoundLabel, customContent, scopeElement }: {
     items: PopoverItem[];
     className?: string;
     searchable?: boolean;
     filterLabel: string;
     nothingFoundLabel: string;
     customContent?: HTMLElement;
-    editorElement: HTMLElement;
+    scopeElement: HTMLElement;
   }) {
     super();
     this.items = items;
@@ -238,7 +238,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
     this.className = className || '';
     this.searchable = searchable;
     this.listeners = new Listeners();
-    this.editorElement = editorElement;
+    this.scopeElement = scopeElement;
 
     this.filterLabel = filterLabel;
     this.nothingFoundLabel = nothingFoundLabel;
@@ -611,17 +611,17 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
   }
 
   /**
-   * Checks if there popover should be opened up.
-   * It happens in case there is enough space below or not enough space above
+   * Checks if popover should be opened bottom.
+   * It should happen when there is enough space below or not enough space above
    */
   private get shouldOpenPopoverBottom(): boolean {
     const toolboxRect = this.nodes.wrapper.getBoundingClientRect();
-    const editorElementRect = this.editorElement.getBoundingClientRect();
+    const scopeElementRect = this.scopeElement.getBoundingClientRect();
     const popoverHeight = this.calculateHeight();
     const popoverPotentialBottomEdge = toolboxRect.top + popoverHeight;
     const popoverPotentialTopEdge = toolboxRect.top - popoverHeight;
-    const bottomEdgeForComparison = Math.min(window.innerHeight, editorElementRect.bottom);
+    const bottomEdgeForComparison = Math.min(window.innerHeight, scopeElementRect.bottom);
 
-    return popoverPotentialTopEdge < editorElementRect.top || popoverPotentialBottomEdge <= bottomEdgeForComparison;
+    return popoverPotentialTopEdge < scopeElementRect.top || popoverPotentialBottomEdge <= bottomEdgeForComparison;
   }
 }

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -529,6 +529,12 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
 
         confirmationStateItemEl.classList.add(Popover.CSS.itemConfirmation);
         itemEl.parentElement.replaceChild(confirmationStateItemEl, itemEl);
+
+        /**
+         * Reactivate flipper to make navigation work with new element
+         */
+        this.flipper.deactivate();
+        this.flipper.activate(this.flippableElements);
       } else {
         /**
          * Otherwise just add confirmation highlighting
@@ -559,6 +565,12 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
     confirmationStateItemEl.parentElement.replaceChild(defaultStateItemEl, confirmationStateItemEl);
     defaultStateItemEl.classList.remove(Popover.CSS.itemConfirmation);
     this.itemAwaitngConfirmation = null;
+
+    /**
+     * Reactivate flipper to make navigation work with new element
+     */
+    this.flipper.deactivate();
+    this.flipper.activate(this.flippableElements);
   }
 
   /**

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -15,6 +15,11 @@ export enum PopoverEvent {
    * When popover overlay is clicked
    */
   OverlayClicked = 'overlay-clicked',
+
+  /**
+   * When popover closes
+   */
+  Close = 'close'
 }
 
 /**
@@ -272,6 +277,8 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
     confirmationStateItems.forEach((itemEl: HTMLElement) => this.cleanUpConfirmationStateForItem(itemEl));
 
     this.disableSpecialHoverAndFocusBehavior();
+
+    this.emit(PopoverEvent.Close);
   }
 
   /**

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -61,7 +61,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
   /**
    * Arbitrary html element to be inserted before items list
    */
-  private readonly htmlContent: HTMLElement;
+  private readonly customContent: HTMLElement;
 
   /**
    * Stores the visibility state.
@@ -138,6 +138,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
     noFoundMessageShown: string;
     popoverOverlay: string;
     popoverOverlayHidden: string;
+    customContent: string;
     customContentHidden: string;
     } {
     return {
@@ -155,6 +156,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
       noFoundMessageShown: 'ce-popover__no-found--shown',
       popoverOverlay: 'ce-popover__overlay',
       popoverOverlayHidden: 'ce-popover__overlay--hidden',
+      customContent: 'ce-popover__custom-content',
       customContentHidden: 'ce-popover__custom-content--hidden',
     };
   }
@@ -172,19 +174,19 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
    * @param options.className - additional class name to be added to the popover wrapper
    * @param options.filterLabel - label for the search Field
    * @param options.nothingFoundLabel - label of the 'nothing found' message
-   * @param options.htmlContent - arbitrary html element to be inserted before items list
+   * @param options.customContent - arbitrary html element to be inserted before items list
    */
-  constructor({ items, className, searchable, filterLabel, nothingFoundLabel, htmlContent }: {
+  constructor({ items, className, searchable, filterLabel, nothingFoundLabel, customContent }: {
     items: PopoverItem[];
     className?: string;
     searchable?: boolean;
     filterLabel: string;
     nothingFoundLabel: string;
-    htmlContent?: HTMLElement;
+    customContent?: HTMLElement;
   }) {
     super();
     this.items = items;
-    this.htmlContent = htmlContent;
+    this.customContent = customContent;
     this.className = className || '';
     this.searchable = searchable;
     this.listeners = new Listeners();
@@ -305,8 +307,9 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
       this.addSearch(this.nodes.popover);
     }
 
-    if (this.htmlContent) {
-      this.nodes.popover.appendChild(this.htmlContent);
+    if (this.customContent) {
+      this.customContent.classList.add(Popover.CSS.customContent);
+      this.nodes.popover.appendChild(this.customContent);
     }
 
     this.nodes.items = Dom.make('div', Popover.CSS.itemsWrapper);
@@ -362,8 +365,8 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
         const allItemsDisdplayed = filteredItems.length === this.items.length;
         const flippableItems = allItemsDisdplayed ? this.flippableItems : itemsVisible;
 
-        if (this.htmlContent) {
-          this.htmlContent.classList.toggle(Popover.CSS.customContentHidden, !allItemsDisdplayed);
+        if (this.customContent) {
+          this.customContent.classList.toggle(Popover.CSS.customContentHidden, !allItemsDisdplayed);
         }
 
         /**
@@ -445,7 +448,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
    */
   private get flippableItems(): HTMLElement[] {
     const popoverItems = Array.from(this.nodes.wrapper.querySelectorAll(`.${Popover.CSS.item}`)) as HTMLElement[];
-    const customItems = this.htmlContent ? Array.from(this.htmlContent.querySelectorAll(
+    const customItems = this.customContent ? Array.from(this.customContent.querySelectorAll(
       `.${Popover.CSS.itemFlippable}`
     )) as HTMLElement[] : [];
 

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -274,6 +274,10 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
   public destroy(): void {
     this.flipper.deactivate();
     this.listeners.removeAll();
+
+    if (isMobileScreen()) {
+      this.scrollLocker.unlock();
+    }
   }
 
   /**

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -417,7 +417,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
    * Item click handler
    *
    * @param itemEl - clicked item
-   * @param event
+   * @param event - click event
    */
   private itemClicked(itemEl: HTMLElement, event: MouseEvent): void {
     const allItems = this.nodes.wrapper.querySelectorAll(`.${Popover.CSS.item}`);

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -505,22 +505,34 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
        */
       this.itemAwaitngConfirmation = clickedItem;
 
-      const itemData = {
-        ...clickedItem,
-        ...clickedItem.confirmation as PopoverItem,
-        confirmation: false,
-      };
-      const confirmationStateItemEl = this.createItem(itemData);
+      /**
+       * If special confirmation state (with different label, icon and so on) configured for the item,
+       * apply it and add highlighting
+       */
+      if (typeof clickedItem.confirmation === 'object') {
+        const itemData = {
+          ...clickedItem,
+          ...clickedItem.confirmation as PopoverItem,
+          confirmation: false,
+        };
 
-      confirmationStateItemEl.classList.add(Popover.CSS.itemConfirmation);
-      itemEl.parentElement.replaceChild(confirmationStateItemEl, itemEl);
+        const confirmationStateItemEl = this.createItem(itemData);
+
+        confirmationStateItemEl.classList.add(Popover.CSS.itemConfirmation);
+        itemEl.parentElement.replaceChild(confirmationStateItemEl, itemEl);
+      } else {
+        /**
+         * Otherwise just add confirmation highlighting
+         */
+        itemEl.classList.add(Popover.CSS.itemConfirmation);
+      }
 
       return true;
     }
 
     /**
      * If item requiring confirmation is clicked for the second time or any other item is clicked,
-     * get rid of confirmation state on item
+     * get rid of confirmation state
      */
     this.cleanUpConfirmationState();
   }

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -446,6 +446,10 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
 
     if (clickedItem.closeOnActivate) {
       this.hide();
+    } else {
+      /** If popover is not intended to close once item is activated, we need to update active state of activated item */
+      clickedItem.isActive = !clickedItem.isActive;
+      itemEl.classList.toggle(Popover.CSS.itemActive);
     }
   }
 

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -261,6 +261,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
    * Clears memory
    */
   public destroy(): void {
+    this.flipper.deactivate();
     this.listeners.removeAll();
   }
 

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -414,7 +414,9 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
   private createItem(item: PopoverItem): HTMLElement {
     const el = Dom.make('div', Popover.CSS.item);
 
-    el.dataset.itemName = item.name;
+    if (item.name) {
+      el.dataset.itemName = item.name;
+    }
     const label = Dom.make('div', Popover.CSS.itemLabel, {
       innerHTML: item.label,
     });

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -7,7 +7,7 @@ import { isMobileScreen, keyCodes, cacheable } from '../utils';
 import ScrollLocker from './scroll-locker';
 
 /**
- * Describe parameters for rendering a single popover item
+ * Common parameters for both types of popover items: with or without confirmation
  */
 export interface PopoverItemBase {
   /**
@@ -47,7 +47,7 @@ export interface PopoverItemBase {
  */
 interface PopoverItemWithConfirmation extends PopoverItemBase {
   /**
-   * Item parameters that should be applied on item activation.
+   * Popover item parameters that should be applied on item activation.
    * May be used to ask user for confirmation before executing popover item activation handler.
    */
   confirmation: Partial<PopoverItem>;
@@ -62,13 +62,17 @@ interface PopoverItemWithoutConfirmation extends PopoverItemBase {
   confirmation?: never;
 
   /**
-   * Item activation handler
+   * Popover item activation handler
    *
    * @param item - activated item
+   * @param event - click event
    */
   onActivate: (item: PopoverItem, event?: MouseEvent) => void;
 }
 
+/**
+ * Represents single popover item
+ */
 export type PopoverItem = PopoverItemWithConfirmation | PopoverItemWithoutConfirmation
 
 /**

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -38,6 +38,11 @@ export interface PopoverItem {
    * @param item - clicked item
    */
   onClick: (item: PopoverItem, event?: MouseEvent) => void;
+
+  /**
+   * True if item should be highlighted as active
+   */
+  isActive?: boolean;
 }
 
 /**

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -32,6 +32,11 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
   private readonly customContent: HTMLElement;
 
   /**
+   * List of html elements inside custom content area that should be available for keyboard navigation
+   */
+  private readonly customContentFlippableItems: HTMLElement[] = [];
+
+  /**
    * Stores the visibility state.
    */
   private isShown = false;
@@ -97,7 +102,6 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
     itemsWrapper: string;
     item: string;
     itemHidden: string;
-    itemFlippable: string;
     itemFocused: string;
     itemActive: string;
     itemDisabled: string;
@@ -118,7 +122,6 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
       itemsWrapper: 'ce-popover__items',
       item: 'ce-popover__item',
       itemHidden: 'ce-popover__item--hidden',
-      itemFlippable: 'ce-popover__item--flippable',
       itemFocused: 'ce-popover__item--focused',
       itemActive: 'ce-popover__item--active',
       itemDisabled: 'ce-popover__item--disabled',
@@ -146,7 +149,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
   private scopeElement: HTMLElement;
 
   /**
-   *
+   * Stores data on popover items that are in confirmation state
    */
   private itemsRequiringConfirmation: {[itemIndex: number]: PopoverItem} = {};
 
@@ -159,20 +162,23 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
    * @param options.filterLabel - label for the search Field
    * @param options.nothingFoundLabel - label of the 'nothing found' message
    * @param options.customContent - arbitrary html element to be inserted before items list
+   * @param options.customContentFlippableItems - list of html elements inside custom content area that should be available for keyboard navigation
    * @param options.scopeElement - editor container element
    */
-  constructor({ items, className, searchable, filterLabel, nothingFoundLabel, customContent, scopeElement }: {
+  constructor({ items, className, searchable, filterLabel, nothingFoundLabel, customContent, customContentFlippableItems, scopeElement }: {
     items: PopoverItem[];
     className?: string;
     searchable?: boolean;
     filterLabel: string;
     nothingFoundLabel: string;
     customContent?: HTMLElement;
+    customContentFlippableItems?: HTMLElement[];
     scopeElement: HTMLElement;
   }) {
     super();
     this.items = items;
     this.customContent = customContent;
+    this.customContentFlippableItems = customContentFlippableItems;
     this.className = className || '';
     this.searchable = searchable;
     this.listeners = new Listeners();
@@ -572,17 +578,12 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
      */
     const popoverItemsElements = Array.from(this.nodes.wrapper.querySelectorAll(`.${Popover.CSS.item}`)) as HTMLElement[];
 
-    /**
-     * Select html elements inside custom content that are marked with special css class to be available for keyboard navigation
-     */
-    const customContentElements = this.customContent ? Array.from(this.customContent.querySelectorAll(
-      `.${Popover.CSS.itemFlippable}`
-    )) as HTMLElement[] : [];
+    const customContentControlsElements = this.customContentFlippableItems || [];
 
     /**
-     * Combine both lists and return
+     * Combine elements inside custom content area with popover items elements
      */
-    return customContentElements.concat(popoverItemsElements);
+    return customContentControlsElements.concat(popoverItemsElements);
   }
 
   /**

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -158,11 +158,6 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
   private itemsRequiringConfirmation: { [itemIndex: number]: PopoverItem } = {};
 
   /**
-   * If true, activated item should be highlighted as active once clicked.
-   */
-  private shouldHighlightActivated: boolean;
-
-  /**
    * Creates the Popover
    *
    * @param options - config
@@ -173,9 +168,8 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
    * @param options.customContent - arbitrary html element to be inserted before items list
    * @param options.customContentFlippableItems - list of html elements inside custom content area that should be available for keyboard navigation
    * @param options.scopeElement - editor container element
-   * @param shouldHighlightActivated - If true, activated item should be highlighted as active once clicked.
    */
-  constructor({ items, className, searchable, filterLabel, nothingFoundLabel, customContent, customContentFlippableItems, scopeElement, shouldHighlightActivated = false }: {
+  constructor({ items, className, searchable, filterLabel, nothingFoundLabel, customContent, customContentFlippableItems, scopeElement }: {
     items: PopoverItem[];
     className?: string;
     searchable?: boolean;
@@ -184,7 +178,6 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
     customContent?: HTMLElement;
     customContentFlippableItems?: HTMLElement[];
     scopeElement: HTMLElement;
-    shouldHighlightActivated?: boolean;
   }) {
     super();
     this.items = items;
@@ -194,7 +187,6 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
     this.searchable = searchable;
     this.listeners = new Listeners();
     this.scopeElement = scopeElement;
-    this.shouldHighlightActivated = shouldHighlightActivated;
 
     this.filterLabel = filterLabel;
     this.nothingFoundLabel = nothingFoundLabel;
@@ -493,8 +485,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
     }
     clickedItem.onActivate(clickedItem, event);
 
-    if (this.shouldHighlightActivated) {
-      /** If popover is not intended to close once item is activated, we need to update active state of activated item */
+    if (clickedItem.toggle) {
       clickedItem.isActive = !clickedItem.isActive;
       itemEl.classList.toggle(Popover.CSS.itemActive);
     }

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -22,6 +22,11 @@ export enum PopoverEvent {
  */
 export default class Popover extends EventsDispatcher<PopoverEvent> {
   /**
+   * Flipper - module for keyboard iteration between elements
+   */
+  public flipper: Flipper;
+
+  /**
    * Items list to be displayed
    */
   private readonly items: PopoverItem[];
@@ -67,11 +72,6 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
    * Listeners util instance
    */
   private listeners: Listeners;
-
-  /**
-   * Flipper - module for keyboard iteration between elements
-   */
-  private flipper: Flipper;
 
   /**
    * Pass true to enable local search field

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -385,11 +385,11 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
 
         this.nodes.nothingFound.classList.toggle(Popover.CSS.noFoundMessageShown, itemsVisible.length === 0);
 
-        const allItemsDisdplayed = filteredItems.length === this.items.length;
-        const flippableItems = allItemsDisdplayed ? this.flippableItems : itemsVisible;
+        const allItemsDisplayed = filteredItems.length === this.items.length;
+        const flippableItems = allItemsDisplayed ? this.flippableItems : itemsVisible;
 
         if (this.customContent) {
-          this.customContent.classList.toggle(Popover.CSS.customContentHidden, !allItemsDisdplayed);
+          this.customContent.classList.toggle(Popover.CSS.customContentHidden, !allItemsDisplayed);
         }
 
         /**

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -100,6 +100,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
     itemFlippable: string;
     itemFocused: string;
     itemActive: string;
+    itemDisabled: string;
     itemLabel: string;
     itemIcon: string;
     itemSecondaryLabel: string;
@@ -120,6 +121,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
       itemFlippable: 'ce-popover__item--flippable',
       itemFocused: 'ce-popover__item--focused',
       itemActive: 'ce-popover__item--active',
+      itemDisabled: 'ce-popover__item--disabled',
       itemConfirmation: 'ce-popover__item--confirmation',
       itemLabel: 'ce-popover__item-label',
       itemIcon: 'ce-popover__item-icon',
@@ -420,6 +422,10 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
       el.classList.add(Popover.CSS.itemActive);
     }
 
+    if (item.isDisabled) {
+      el.classList.add(Popover.CSS.itemDisabled);
+    }
+
     return el;
   }
 
@@ -433,6 +439,10 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
     const allItems = this.nodes.wrapper.querySelectorAll(`.${Popover.CSS.item}`);
     const itemIndex = Array.from(allItems).indexOf(itemEl);
     const clickedItem = this.items[itemIndex];
+
+    if (clickedItem.isDisabled) {
+      return;
+    }
 
     this.cleanUpConfirmationState();
 

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -36,7 +36,7 @@ export interface PopoverItem {
    *
    * @param item - clicked item
    */
-  onClick: (item: PopoverItem) => void;
+  onClick: (item: PopoverItem, event?: MouseEvent) => void;
 }
 
 /**
@@ -306,7 +306,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
       const clickedItem = (event.target as HTMLElement).closest(`.${Popover.CSS.item}`) as HTMLElement;
 
       if (clickedItem) {
-        this.itemClicked(clickedItem);
+        this.itemClicked(clickedItem, event as MouseEvent);
       }
     });
 
@@ -388,13 +388,14 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
    * Item click handler
    *
    * @param itemEl - clicked item
+   * @param event
    */
-  private itemClicked(itemEl: HTMLElement): void {
+  private itemClicked(itemEl: HTMLElement, event: MouseEvent): void {
     const allItems = this.nodes.wrapper.querySelectorAll(`.${Popover.CSS.item}`);
     const itemIndex = Array.from(allItems).indexOf(itemEl);
     const clickedItem = this.items[itemIndex];
 
-    clickedItem.onClick(clickedItem);
+    clickedItem.onClick(clickedItem, event);
   }
 
   /**

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -577,16 +577,26 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
   }
 
   /**
-   * Returns list of items available for keyboard navigation.
+   * Returns list of elements available for keyboard navigation.
    * Contains both usual popover items elements and custom html content.
    */
   private get flippableElements(): HTMLElement[] {
-    const popoverItems = Array.from(this.nodes.wrapper.querySelectorAll(`.${Popover.CSS.item}`)) as HTMLElement[];
-    const customItems = this.customContent ? Array.from(this.customContent.querySelectorAll(
+    /**
+     * Select html elements of popover items
+     */
+    const popoverItemsElements = Array.from(this.nodes.wrapper.querySelectorAll(`.${Popover.CSS.item}`)) as HTMLElement[];
+
+    /**
+     * Select html elements inside custom content that are marked with special css class to be available for keyboard navigation
+     */
+    const customContentElements = this.customContent ? Array.from(this.customContent.querySelectorAll(
       `.${Popover.CSS.itemFlippable}`
     )) as HTMLElement[] : [];
 
-    return customItems.concat(popoverItems);
+    /**
+     * Combine both lists and return
+     */
+    return customContentElements.concat(popoverItemsElements);
   }
 
   /**

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -237,9 +237,9 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
     this.flipper.activate();
 
     if (this.searchable) {
-      window.requestAnimationFrame(() => {
+      setTimeout(() => {
         this.search.focus();
-      });
+      }, 100);
     }
 
     if (isMobileScreen()) {

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -32,7 +32,7 @@ export interface PopoverItem {
   secondaryLabel?: string;
 
   /**
-   * Itm click handler
+   * Item click handler
    *
    * @param item - clicked item
    */

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -158,6 +158,11 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
   private itemsRequiringConfirmation: { [itemIndex: number]: PopoverItem } = {};
 
   /**
+   * If true, activated item should be highlighted as active once clicked.
+   */
+  private shouldHighlightActivated: boolean;
+
+  /**
    * Creates the Popover
    *
    * @param options - config
@@ -168,8 +173,9 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
    * @param options.customContent - arbitrary html element to be inserted before items list
    * @param options.customContentFlippableItems - list of html elements inside custom content area that should be available for keyboard navigation
    * @param options.scopeElement - editor container element
+   * @param shouldHighlightActivated - If true, activated item should be highlighted as active once clicked.
    */
-  constructor({ items, className, searchable, filterLabel, nothingFoundLabel, customContent, customContentFlippableItems, scopeElement }: {
+  constructor({ items, className, searchable, filterLabel, nothingFoundLabel, customContent, customContentFlippableItems, scopeElement, shouldHighlightActivated = false }: {
     items: PopoverItem[];
     className?: string;
     searchable?: boolean;
@@ -178,6 +184,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
     customContent?: HTMLElement;
     customContentFlippableItems?: HTMLElement[];
     scopeElement: HTMLElement;
+    shouldHighlightActivated?: boolean;
   }) {
     super();
     this.items = items;
@@ -187,6 +194,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
     this.searchable = searchable;
     this.listeners = new Listeners();
     this.scopeElement = scopeElement;
+    this.shouldHighlightActivated = shouldHighlightActivated;
 
     this.filterLabel = filterLabel;
     this.nothingFoundLabel = nothingFoundLabel;
@@ -485,12 +493,14 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
     }
     clickedItem.onActivate(clickedItem, event);
 
-    if (clickedItem.closeOnActivate) {
-      this.hide();
-    } else {
+    if (this.shouldHighlightActivated) {
       /** If popover is not intended to close once item is activated, we need to update active state of activated item */
       clickedItem.isActive = !clickedItem.isActive;
       itemEl.classList.toggle(Popover.CSS.itemActive);
+    }
+
+    if (clickedItem.closeOnActivate) {
+      this.hide();
     }
   }
 

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -271,7 +271,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
 
     confirmationStateItems.forEach((itemEl: HTMLElement) => this.cleanUpConfirmationStateForItem(itemEl));
 
-    this.flipper.removeOnFlip(this.onFlip);
+    this.disableSpecialHoverAndFocusBehavior();
   }
 
   /**
@@ -280,7 +280,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
   public destroy(): void {
     this.flipper.deactivate();
     this.listeners.removeAll();
-    this.flipper.removeOnFlip(this.onFlip);
+    this.disableSpecialHoverAndFocusBehavior();
 
     if (isMobileScreen()) {
       this.scrollLocker.unlock();
@@ -550,7 +550,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
     delete this.itemsRequiringConfirmation[index];
 
     itemEl.removeEventListener('mouseleave', this.removeSpecialHoverBehavior);
-    this.flipper.removeOnFlip(this.onFlip);
+    this.disableSpecialHoverAndFocusBehavior();
 
     this.reactivateFlipper(
       this.flippableElements,
@@ -570,6 +570,16 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
 
     item.addEventListener('mouseleave', this.removeSpecialHoverBehavior, { once: true });
     this.flipper.onFlip(this.onFlip);
+  }
+
+  /**
+   * Disables special focus and hover behavior.
+   */
+  private disableSpecialHoverAndFocusBehavior(): void {
+    this.removeSpecialFocusBehavior();
+    this.removeSpecialHoverBehavior();
+
+    this.flipper.removeOnFlip(this.onFlip);
   }
 
   /**
@@ -602,10 +612,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
    * Called on flipper navigation
    */
   private onFlip = (): void => {
-    this.removeSpecialFocusBehavior();
-    this.removeSpecialHoverBehavior();
-
-    this.flipper.removeOnFlip(this.onFlip);
+    this.disableSpecialHoverAndFocusBehavior();
   }
 
   /**

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -5,75 +5,7 @@ import SearchInput from './search-input';
 import EventsDispatcher from './events';
 import { isMobileScreen, keyCodes, cacheable } from '../utils';
 import ScrollLocker from './scroll-locker';
-
-/**
- * Common parameters for both types of popover items: with or without confirmation
- */
-export interface PopoverItemBase {
-  /**
-   * Item icon to be appeared near a title
-   */
-  icon: string;
-
-  /**
-   * Displayed text
-   */
-  label: string;
-
-  /**
-   * Item name
-   * Used in data attributes needed for cypress tests
-   */
-  name?: string;
-
-  /**
-   * Additional displayed text
-   */
-  secondaryLabel?: string;
-
-  /**
-   * True if item should be highlighted as active
-   */
-  isActive?: boolean;
-
-  /**
-   * True if popover should close once item is activated
-   */
-  closeOnActivate?: boolean;
-}
-
-/**
- * Represents popover item with confirmation state configuration
- */
-interface PopoverItemWithConfirmation extends PopoverItemBase {
-  /**
-   * Popover item parameters that should be applied on item activation.
-   * May be used to ask user for confirmation before executing popover item activation handler.
-   */
-  confirmation: Partial<PopoverItem>;
-
-  onActivate?: never;
-}
-
-/**
- * Represents default popover item without confirmation state configuration
- */
-interface PopoverItemWithoutConfirmation extends PopoverItemBase {
-  confirmation?: never;
-
-  /**
-   * Popover item activation handler
-   *
-   * @param item - activated item
-   * @param event - event that initiated item activation
-   */
-  onActivate: (item: PopoverItem, event?: PointerEvent) => void;
-}
-
-/**
- * Represents single popover item
- */
-export type PopoverItem = PopoverItemWithConfirmation | PopoverItemWithoutConfirmation
+import { PopoverItem, PopoverItemWithConfirmation } from '../../../types';
 
 /**
  * Event that can be triggered by the Popover

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -392,11 +392,13 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
           this.customContent.classList.toggle(Popover.CSS.customContentHidden, !allItemsDisplayed);
         }
 
-        /**
-         * Update flipper items with only visible
-         */
-        this.reactivateFlipper(flippableElements);
-        this.flipper.focusFirst();
+        if (this.flipper.isActivated) {
+          /**
+           * Update flipper items with only visible
+           */
+          this.reactivateFlipper(flippableElements);
+          this.flipper.focusFirst();
+        }
       },
     });
 

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -503,32 +503,9 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
     const clickedItem = this.items[itemIndex];
 
     this.cleanUpConfirmationState();
+
     if (clickedItem.confirmation) {
-      /** Save root item requiring confirmation to restore original state on popover hide */
-      if (this.itemRequiringConfirmation === null) {
-        this.itemRequiringConfirmation = clickedItem;
-      }
-      const newItemData = {
-        ...clickedItem,
-        ...clickedItem.confirmation,
-      } as PopoverItem;
-
-      /** Prevent confirmation loop */
-      if (newItemData.confirmation === clickedItem.confirmation) {
-        delete newItemData.confirmation;
-      }
-
-      this.items[itemIndex] = newItemData;
-
-      const confirmationStateItemEl = this.createItem(newItemData as PopoverItem);
-
-      confirmationStateItemEl.classList.add(Popover.CSS.itemConfirmation);
-      itemEl.parentElement.replaceChild(confirmationStateItemEl, itemEl);
-
-      this.reactivateFlipper(
-        this.flippableElements,
-        this.flippableElements.indexOf(confirmationStateItemEl)
-      );
+      this.enableConfirmationStateForItem(clickedItem as PopoverItemWithConfirmation, itemEl, itemIndex);
 
       return;
     }
@@ -538,6 +515,42 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
     if (clickedItem.closeOnActivate) {
       this.hide();
     }
+  }
+
+  /**
+   * Enables confirmation state for specified item.
+   * Replaces item element in popover so that is becomes highlighted in a special way
+   *
+   * @param item - item to enable confirmation state for
+   * @param itemEl - html element corresponding to the item
+   * @param itemIndex - index of the item in all items list
+   */
+  private enableConfirmationStateForItem(item: PopoverItemWithConfirmation, itemEl: HTMLElement, itemIndex: number): void {
+    /** Save root item requiring confirmation to restore original state on popover hide */
+    if (this.itemRequiringConfirmation === null) {
+      this.itemRequiringConfirmation = item;
+    }
+    const newItemData = {
+      ...item,
+      ...item.confirmation,
+    } as PopoverItem;
+
+    /** Prevent confirmation loop */
+    if (newItemData.confirmation === item.confirmation) {
+      delete newItemData.confirmation;
+    }
+
+    this.items[itemIndex] = newItemData;
+
+    const confirmationStateItemEl = this.createItem(newItemData as PopoverItem);
+
+    confirmationStateItemEl.classList.add(Popover.CSS.itemConfirmation);
+    itemEl.parentElement.replaceChild(confirmationStateItemEl, itemEl);
+
+    this.reactivateFlipper(
+      this.flippableElements,
+      this.flippableElements.indexOf(confirmationStateItemEl)
+    );
   }
 
   /**

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -155,7 +155,7 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
   /**
    * Stores data on popover items that are in confirmation state
    */
-  private itemsRequiringConfirmation: {[itemIndex: number]: PopoverItem} = {};
+  private itemsRequiringConfirmation: { [itemIndex: number]: PopoverItem } = {};
 
   /**
    * Creates the Popover
@@ -572,100 +572,100 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
     this.flipper.onFlip(this.onFlip);
   }
 
-    /**
-     * Removes class responsible for special hover behavior on an item
-     */
-    private removeSpecialHoverBehavior = (): void => {
-      const el = this.nodes.items.querySelector(`.${Popover.CSS.itemNoHover}`);
+  /**
+   * Removes class responsible for special hover behavior on an item
+   */
+  private removeSpecialHoverBehavior = (): void => {
+    const el = this.nodes.items.querySelector(`.${Popover.CSS.itemNoHover}`);
 
-      if (!el) {
-        return;
-      }
-
-      el.classList.remove(Popover.CSS.itemNoHover);
+    if (!el) {
+      return;
     }
 
-    /**
-     * Removes class responsible for special focus behavior on an item
-     */
-    private removeSpecialFocusBehavior(): void {
-      const el = this.nodes.items.querySelector(`.${Popover.CSS.itemNoFocus}`);
+    el.classList.remove(Popover.CSS.itemNoHover);
+  }
 
-      if (!el) {
-        return;
-      }
+  /**
+   * Removes class responsible for special focus behavior on an item
+   */
+  private removeSpecialFocusBehavior(): void {
+    const el = this.nodes.items.querySelector(`.${Popover.CSS.itemNoFocus}`);
 
-      el.classList.remove(Popover.CSS.itemNoFocus);
+    if (!el) {
+      return;
     }
 
-    /**
-     * Called on flipper navigation
-     */
-    private onFlip = (): void => {
-      this.removeSpecialFocusBehavior();
-      this.removeSpecialHoverBehavior();
+    el.classList.remove(Popover.CSS.itemNoFocus);
+  }
 
-      this.flipper.removeOnFlip(this.onFlip);
-    }
+  /**
+   * Called on flipper navigation
+   */
+  private onFlip = (): void => {
+    this.removeSpecialFocusBehavior();
+    this.removeSpecialHoverBehavior();
 
-    /**
-     * Reactivates flipper instance.
-     * Should be used if popover items html elements get replaced to preserve workability of keyboard navigation
-     *
-     * @param items - html elements to navigate through
-     * @param focusedIndex - index of element to be focused
-     */
-    private reactivateFlipper(items: HTMLElement[], focusedIndex?: number): void {
-      this.flipper.deactivate();
-      this.flipper.activate(items, focusedIndex);
-    }
+    this.flipper.removeOnFlip(this.onFlip);
+  }
 
-    /**
-     * Creates Flipper instance to be able to leaf tools
-     */
-    private enableFlipper(): void {
-      this.flipper = new Flipper({
-        items: this.flippableElements,
-        focusedItemClass: Popover.CSS.itemFocused,
-        allowedKeys: [
-          keyCodes.TAB,
-          keyCodes.UP,
-          keyCodes.DOWN,
-          keyCodes.ENTER,
-        ],
-      });
-    }
+  /**
+   * Reactivates flipper instance.
+   * Should be used if popover items html elements get replaced to preserve workability of keyboard navigation
+   *
+   * @param items - html elements to navigate through
+   * @param focusedIndex - index of element to be focused
+   */
+  private reactivateFlipper(items: HTMLElement[], focusedIndex?: number): void {
+    this.flipper.deactivate();
+    this.flipper.activate(items, focusedIndex);
+  }
 
-    /**
-     * Returns list of elements available for keyboard navigation.
-     * Contains both usual popover items elements and custom html content.
-     */
-    private get flippableElements(): HTMLElement[] {
+  /**
+   * Creates Flipper instance to be able to leaf tools
+   */
+  private enableFlipper(): void {
+    this.flipper = new Flipper({
+      items: this.flippableElements,
+      focusedItemClass: Popover.CSS.itemFocused,
+      allowedKeys: [
+        keyCodes.TAB,
+        keyCodes.UP,
+        keyCodes.DOWN,
+        keyCodes.ENTER,
+      ],
+    });
+  }
+
+  /**
+   * Returns list of elements available for keyboard navigation.
+   * Contains both usual popover items elements and custom html content.
+   */
+  private get flippableElements(): HTMLElement[] {
     /**
      * Select html elements of popover items
      */
-      const popoverItemsElements = Array.from(this.nodes.wrapper.querySelectorAll(`.${Popover.CSS.item}`)) as HTMLElement[];
+    const popoverItemsElements = Array.from(this.nodes.wrapper.querySelectorAll(`.${Popover.CSS.item}`)) as HTMLElement[];
 
-      const customContentControlsElements = this.customContentFlippableItems || [];
-
-      /**
-       * Combine elements inside custom content area with popover items elements
-       */
-      return customContentControlsElements.concat(popoverItemsElements);
-    }
+    const customContentControlsElements = this.customContentFlippableItems || [];
 
     /**
-     * Checks if popover should be opened bottom.
-     * It should happen when there is enough space below or not enough space above
+     * Combine elements inside custom content area with popover items elements
      */
-    private get shouldOpenPopoverBottom(): boolean {
-      const toolboxRect = this.nodes.wrapper.getBoundingClientRect();
-      const scopeElementRect = this.scopeElement.getBoundingClientRect();
-      const popoverHeight = this.calculateHeight();
-      const popoverPotentialBottomEdge = toolboxRect.top + popoverHeight;
-      const popoverPotentialTopEdge = toolboxRect.top - popoverHeight;
-      const bottomEdgeForComparison = Math.min(window.innerHeight, scopeElementRect.bottom);
+    return customContentControlsElements.concat(popoverItemsElements);
+  }
 
-      return popoverPotentialTopEdge < scopeElementRect.top || popoverPotentialBottomEdge <= bottomEdgeForComparison;
-    }
+  /**
+   * Checks if popover should be opened bottom.
+   * It should happen when there is enough space below or not enough space above
+   */
+  private get shouldOpenPopoverBottom(): boolean {
+    const toolboxRect = this.nodes.wrapper.getBoundingClientRect();
+    const scopeElementRect = this.scopeElement.getBoundingClientRect();
+    const popoverHeight = this.calculateHeight();
+    const popoverPotentialBottomEdge = toolboxRect.top + popoverHeight;
+    const popoverPotentialTopEdge = toolboxRect.top - popoverHeight;
+    const bottomEdgeForComparison = Math.min(window.innerHeight, scopeElementRect.bottom);
+
+    return popoverPotentialTopEdge < scopeElementRect.top || popoverPotentialBottomEdge <= bottomEdgeForComparison;
+  }
 }

--- a/src/components/utils/popover.ts
+++ b/src/components/utils/popover.ts
@@ -65,9 +65,9 @@ interface PopoverItemWithoutConfirmation extends PopoverItemBase {
    * Popover item activation handler
    *
    * @param item - activated item
-   * @param event - click event
+   * @param event - event that initiated item activation
    */
-  onActivate: (item: PopoverItem, event?: MouseEvent) => void;
+  onActivate: (item: PopoverItem, event?: PointerEvent) => void;
 }
 
 /**
@@ -389,11 +389,11 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
 
     this.nodes.popover.appendChild(this.nodes.nothingFound);
 
-    this.listeners.on(this.nodes.popover, 'click', (event: KeyboardEvent|MouseEvent) => {
+    this.listeners.on(this.nodes.popover, 'click', (event: PointerEvent) => {
       const clickedItem = (event.target as HTMLElement).closest(`.${Popover.CSS.item}`) as HTMLElement;
 
       if (clickedItem) {
-        this.itemClicked(clickedItem, event as MouseEvent);
+        this.itemClicked(clickedItem, event as PointerEvent);
       }
     });
 
@@ -497,13 +497,12 @@ export default class Popover extends EventsDispatcher<PopoverEvent> {
    * @param itemEl - clicked item
    * @param event - click event
    */
-  private itemClicked(itemEl: HTMLElement, event: MouseEvent): void {
+  private itemClicked(itemEl: HTMLElement, event: PointerEvent): void {
     const allItems = this.nodes.wrapper.querySelectorAll(`.${Popover.CSS.item}`);
     const itemIndex = Array.from(allItems).indexOf(itemEl);
     const clickedItem = this.items[itemIndex];
 
     this.cleanUpConfirmationState();
-
     if (clickedItem.confirmation) {
       /** Save root item requiring confirmation to restore original state on popover hide */
       if (this.itemRequiringConfirmation === null) {

--- a/src/styles/export.css
+++ b/src/styles/export.css
@@ -36,17 +36,10 @@
 
 /**
  * Settings
+ * @deprecated - use tunes config instead of creating html element with controls
  */
 .cdx-settings-button {
   @apply --toolbar-button;
-
-  &:not(:nth-child(3n+3)) {
-    margin-right: 3px;
-  }
-
-  &:nth-child(n+4) {
-    margin-top: 3px;
-  }
 
   &--active {
     color: var(--color-active-icon);

--- a/src/styles/popover.css
+++ b/src/styles/popover.css
@@ -76,6 +76,25 @@
       @apply --button-active;
     }
 
+    &--confirmation {
+      background: var(--color-confirm);
+
+      @media (--can-hover) {
+        &:hover {
+          background: #ce4343;
+        }
+      }
+
+      .ce-popover__item-icon {
+        color: var(--color-confirm);
+      }
+
+      .ce-popover__item-label {
+        color: white;
+      }
+
+    }
+
     &-icon {
       @apply --tool-icon;
     }

--- a/src/styles/popover.css
+++ b/src/styles/popover.css
@@ -74,10 +74,18 @@
 
     &--active {
       @apply --button-active;
+
+      .ce-popover__item-icon {
+        border: 1px solid var(--color-line-active);
+      }
     }
 
     &--disabled {
       @apply --button-disabled;
+
+      .ce-popover__item-icon {
+        border: 1px solid var(--color-line-gray);
+      }
     }
 
     &--confirmation {

--- a/src/styles/popover.css
+++ b/src/styles/popover.css
@@ -85,6 +85,10 @@
         }
       }
 
+      &.ce-popover__item--focused {
+        background: #ce4343 !important;
+      }
+
       .ce-popover__item-icon {
         color: var(--color-confirm);
       }

--- a/src/styles/popover.css
+++ b/src/styles/popover.css
@@ -142,7 +142,7 @@
     visibility: hidden;
   }
 
-  &__custom-content {
+  &__custom-content:not(:empty) {
     padding: 4px;
 
     @media (--not-mobile) {

--- a/src/styles/popover.css
+++ b/src/styles/popover.css
@@ -141,4 +141,8 @@
     opacity: 0;
     visibility: hidden;
   }
+
+  &__custom-content--hidden {
+    display: none;
+  }
 }

--- a/src/styles/popover.css
+++ b/src/styles/popover.css
@@ -142,6 +142,12 @@
     visibility: hidden;
   }
 
+  &__custom-content {
+    @media (--not-mobile) {
+      margin-top: 5px;
+    }
+  }
+
   &__custom-content--hidden {
     display: none;
   }

--- a/src/styles/popover.css
+++ b/src/styles/popover.css
@@ -72,6 +72,10 @@
       display: none;
     }
 
+    &--active {
+      @apply --button-active;
+    }
+
     &-icon {
       @apply --tool-icon;
     }

--- a/src/styles/popover.css
+++ b/src/styles/popover.css
@@ -67,6 +67,11 @@
 
     @media (--can-hover) {
       &:hover {
+
+        &:not(.ce-popover__item--no-visible-hover) {
+          background-color: var(--bg-light);
+        }
+
         .ce-popover__item-icon {
           box-shadow: none;
         }
@@ -82,7 +87,9 @@
     }
 
     &--focused {
-      @apply --button-focused;
+      &:not(.ce-popover__item--no-visible-focus) {
+        @apply --button-focused;
+      }
     }
 
     &--hidden {
@@ -93,20 +100,8 @@
       @apply --button-active;
     }
 
-  
-
     &--confirmation {
       background: var(--color-confirm);
-
-      @media (--can-hover) {
-        &:hover {
-          background: var(--color-confirm-hover);
-        }
-      }
-
-      &.ce-popover__item--focused {
-        background: var(--color-confirm-hover) !important;
-      }
 
       .ce-popover__item-icon {
         color: var(--color-confirm);
@@ -114,6 +109,20 @@
 
       .ce-popover__item-label {
         color: white;
+      }
+
+      &:not(.ce-popover__item--no-visible-hover) {
+        @media (--can-hover) {
+          &:hover {
+            background: var(--color-confirm-hover);
+          }
+        }
+      }
+
+      &:not(.ce-popover__item--no-visible-focus) {
+        &.ce-popover__item--focused {
+          background: var(--color-confirm-hover) !important;
+        }
       }
 
     }
@@ -167,9 +176,9 @@
       display: block;
     }
 
-    &:hover {
+    /* &:hover {
       background-color: transparent;
-    }
+    } */
   }
 
   @media (--mobile) {

--- a/src/styles/popover.css
+++ b/src/styles/popover.css
@@ -64,19 +64,11 @@
   &__item {
     @apply --popover-button;
 
-    &--focused {
-      @apply --button-focused;
-    }
-
-    &--hidden {
-      display: none;
-    }
-
-    &--active {
-      @apply --button-active;
-
-      .ce-popover__item-icon {
-        border: 1px solid var(--color-line-active);
+    @media (--can-hover) {
+      &:hover {
+        .ce-popover__item-icon {
+          border: none;
+        }
       }
     }
 
@@ -87,6 +79,20 @@
         border: 1px solid var(--color-line-gray);
       }
     }
+
+    &--focused {
+      @apply --button-focused;
+    }
+
+    &--hidden {
+      display: none;
+    }
+
+    &--active {
+      @apply --button-active;
+    }
+
+  
 
     &--confirmation {
       background: var(--color-confirm);
@@ -135,6 +141,12 @@
 
       @media (--mobile){
         display: none;
+      }
+    }
+
+    &--confirmation, &--active, &--focused {
+      .ce-popover__item-icon {
+        border: none;
       }
     }
   }

--- a/src/styles/popover.css
+++ b/src/styles/popover.css
@@ -143,8 +143,11 @@
   }
 
   &__custom-content {
+    padding: 4px;
+
     @media (--not-mobile) {
       margin-top: 5px;
+      padding: 0;
     }
   }
 

--- a/src/styles/popover.css
+++ b/src/styles/popover.css
@@ -43,12 +43,14 @@
   }
 
   @media (--mobile) {
+    --offset: 5px;
+
     position: fixed;
     max-width: none;
-    min-width: auto;
-    left: 5px;
-    right: 5px;
-    bottom: calc(5px + env(safe-area-inset-bottom));
+    min-width: calc(100% - var(--offset) * 2);
+    left: var(--offset);
+    right: var(--offset);
+    bottom: calc(var(--offset) + env(safe-area-inset-bottom));
     top: auto;
     border-radius: 10px;
   }
@@ -175,10 +177,6 @@
     &--shown {
       display: block;
     }
-
-    /* &:hover {
-      background-color: transparent;
-    } */
   }
 
   @media (--mobile) {

--- a/src/styles/popover.css
+++ b/src/styles/popover.css
@@ -6,6 +6,7 @@
   flex-direction: column;
   padding: 6px;
   min-width: 200px;
+  width: 200px;
   overflow: hidden;
   box-sizing: border-box;
   flex-shrink: 0;
@@ -122,6 +123,10 @@
     }
 
     &-label {
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+
       &::after {
         content: '';
         width: 25px;

--- a/src/styles/popover.css
+++ b/src/styles/popover.css
@@ -81,12 +81,12 @@
 
       @media (--can-hover) {
         &:hover {
-          background: #ce4343;
+          background: var(--color-confirm-hover);
         }
       }
 
       &.ce-popover__item--focused {
-        background: #ce4343 !important;
+        background: var(--color-confirm-hover) !important;
       }
 
       .ce-popover__item-icon {

--- a/src/styles/popover.css
+++ b/src/styles/popover.css
@@ -68,7 +68,7 @@
     @media (--can-hover) {
       &:hover {
         .ce-popover__item-icon {
-          border: none;
+          box-shadow: none;
         }
       }
     }
@@ -77,7 +77,7 @@
       @apply --button-disabled;
 
       .ce-popover__item-icon {
-        border: 1px solid var(--color-line-gray);
+        box-shadow: 0 0 0 1px var(--color-line-gray);
       }
     }
 
@@ -151,7 +151,7 @@
 
     &--confirmation, &--active, &--focused {
       .ce-popover__item-icon {
-        border: none;
+        box-shadow: none;
       }
     }
   }

--- a/src/styles/popover.css
+++ b/src/styles/popover.css
@@ -76,6 +76,10 @@
       @apply --button-active;
     }
 
+    &--disabled {
+      @apply --button-disabled;
+    }
+
     &--confirmation {
       background: var(--color-confirm);
 

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -1,45 +1,7 @@
 .ce-settings {
-  @apply --overlay-pane;
+  position: absolute;
+  z-index: 2;
   top: var(--toolbar-buttons-size);
-  left: 0;
-  min-width: 114px;
-  box-sizing: content-box;
-
-  @media (--mobile){
-    bottom: 40px;
-    right: auto;
-    top: auto;
-  }
-
-  &::before{
-    left: auto;
-    right: 12px;
-
-    @media (--mobile){
-      bottom: -5px;
-      top: auto;
-    }
-  }
-
-  display: none;
-
-  &--opened {
-    display: block;
-    animation-duration: 0.1s;
-    animation-name: panelShowing;
-  }
-
-  &__plugin-zone {
-    &:not(:empty){
-      padding: 3px 3px 0;
-    }
-  }
-
-  &__default-zone {
-    &:not(:empty){
-      padding: 3px;
-    }
-  }
 
   &__button {
     @apply --toolbar-button;

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -1,7 +1,17 @@
 .ce-settings {
   position: absolute;
   z-index: 2;
-  top: var(--toolbar-buttons-size);
+  --gap: 8px;
+
+  @media (--not-mobile){
+    position: absolute;
+    top: calc(var(--toolbox-buttons-size) + var(--gap));
+    left: 0;
+
+    &--opened-top {
+      top: calc(-1 * (var(--gap) + var(--popover-height)));
+    }
+  }
 
   &__button {
     @apply --toolbar-button;

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -110,6 +110,13 @@
     color:  var(--color-active-icon);
   };
 
+  --button-disabled: {
+    color: var(--grayText);
+    cursor: default;
+    background: rgba(232,232,235,0.49);
+    opacity: 0.5;
+  }
+
   /**
    * Styles for Toolbox Buttons and Plus Button
    */

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -104,6 +104,11 @@
     background: rgba(34, 186, 255, 0.08) !important;
   };
 
+  --button-active: {
+    background: rgba(56, 138, 229, 0.1);
+    color:  #388AE5;
+  };
+
   /**
    * Styles for Toolbox Buttons and Plus Button
    */

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -71,7 +71,6 @@
   --color-confirm: #E24A4A;
   --color-confirm-hover: #CE4343;
 
-  --color-line-active: #D8E8FA;
   --color-line-gray: #EFF0F1;
 
   --overlay-pane: {

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -230,12 +230,12 @@
     display: inline-flex;
     width: var(--toolbox-buttons-size);
     height: var(--toolbox-buttons-size);
-    border: 1px solid var(--color-gray-border);
+    box-shadow: 0 0 0 1px var(--color-gray-border);
     border-radius: 5px;
     align-items: center;
     justify-content: center;
     background: #fff;
-    box-sizing: border-box;
+    box-sizing: content-box;
     flex-shrink: 0;
     margin-right: 10px;
 

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -69,6 +69,7 @@
    * Confirm deletion bg
    */
   --color-confirm: #E24A4A;
+  --color-confirm-hover: #CE4343;
 
   --overlay-pane: {
     position: absolute;

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -71,6 +71,9 @@
   --color-confirm: #E24A4A;
   --color-confirm-hover: #CE4343;
 
+  --color-line-active: #D8E8FA;
+  --color-line-gray: #EFF0F1;
+
   --overlay-pane: {
     position: absolute;
     background-color: #FFFFFF;
@@ -113,8 +116,7 @@
   --button-disabled: {
     color: var(--grayText);
     cursor: default;
-    background: rgba(232,232,235,0.49);
-    opacity: 0.5;
+    pointer-events: none;
   }
 
   /**

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -106,7 +106,7 @@
 
   --button-active: {
     background: rgba(56, 138, 229, 0.1);
-    color:  #388AE5;
+    color:  var(--color-active-icon);
   };
 
   /**

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -34,6 +34,7 @@
 
   /**
    * Gray border, loaders
+   * @deprecated — use --color-line-gray instead
    */
   --color-gray-border: rgba(201, 201, 204, 0.48);
 

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -211,12 +211,6 @@
       margin-bottom: 1px;
     }
 
-    @media (--can-hover) {
-      &:hover {
-        background-color: var(--bg-light);
-      }
-    }
-
     @media (--mobile) {
       font-size: 16px;
       padding: 4px;

--- a/test/cypress/tests/api/tools.spec.ts
+++ b/test/cypress/tests/api/tools.spec.ts
@@ -1,4 +1,7 @@
 import { ToolboxConfig, BlockToolData, ToolboxConfigEntry } from '../../../../types';
+import { TunesMenuConfig } from '../../../../types/tools';
+
+/* eslint-disable @typescript-eslint/no-empty-function */
 
 const ICON = '<svg width="17" height="15" viewBox="0 0 336 276" xmlns="http://www.w3.org/2000/svg"><path d="M291 150V79c0-19-15-34-34-34H79c-19 0-34 15-34 34v42l67-44 81 72 56-29 42 30zm0 52l-43-30-56 30-81-67-66 39v23c0 19 15 34 34 34h178c17 0 31-13 34-29zM79 0h178c44 0 79 35 79 79v118c0 44-35 79-79 79H79c-44 0-79-35-79-79V79C0 35 35 0 79 0z"></path></svg>';
 
@@ -264,6 +267,227 @@ describe('Editor Tools Api', () => {
         .get('div.ce-popover__item[data-item-name=testTool]')
         .should('have.length', 1)
         .should('not.contain', skippedEntryTitle);
+    });
+  });
+
+  context('Tunes', () => {
+    it('should contain a single block tune configured in tool\'s renderSettings() method', () => {
+      /** Tool with single tunes menu entry configured */
+      class TestTool {
+        /** Returns toolbox config as list of entries */
+        public static get toolbox(): ToolboxConfigEntry {
+          return {
+            title: 'Test tool',
+            icon: ICON,
+          };
+        }
+
+        /** Returns configuration for block tunes menu */
+        public renderSettings(): TunesMenuConfig {
+          return {
+            label: 'Test tool tune',
+            icon: ICON,
+            name: 'testToolTune',
+
+            onActivate: (): void => {},
+          };
+        }
+
+        /** Save method stub */
+        public save(): void {}
+
+        /** Renders a block */
+        public render(): HTMLElement {
+          const element = document.createElement('div');
+
+          element.contentEditable = 'true';
+          element.setAttribute('data-name', 'testBlock');
+
+          return element;
+        }
+      }
+
+      cy.createEditor({
+        tools: {
+          testTool: TestTool,
+        },
+      }).as('editorInstance');
+
+      cy.get('[data-cy=editorjs]')
+        .get('div.ce-block')
+        .click();
+
+      cy.get('[data-cy=editorjs]')
+        .get('div.ce-toolbar__plus')
+        .click();
+
+      // Insert test tool block
+      cy.get('[data-cy=editorjs]')
+        .get(`[data-item-name="testTool"]`)
+        .click();
+
+      cy.get('[data-cy=editorjs]')
+        .get('[data-name=testBlock]')
+        .type('some text')
+        .click();
+
+      // Open block tunes
+      cy.get('[data-cy=editorjs]')
+        .get('.ce-toolbar__settings-btn')
+        .click();
+
+      // Expect preconfigured tune to exist in tunes menu
+      cy.get('[data-item-name=testToolTune]').should('exist');
+    });
+
+    it('should contain multiple block tunes if configured in tool\'s renderSettings() method', () => {
+      /** Tool with single tunes menu entry configured */
+      class TestTool {
+        /** Returns toolbox config as list of entries */
+        public static get toolbox(): ToolboxConfigEntry {
+          return {
+            title: 'Test tool',
+            icon: ICON,
+          };
+        }
+
+        /** Returns configuration for block tunes menu */
+        public renderSettings(): TunesMenuConfig {
+          return [
+            {
+              label: 'Test tool tune 1',
+              icon: ICON,
+              name: 'testToolTune1',
+
+              onActivate: (): void => {},
+            },
+            {
+              label: 'Test tool tune 2',
+              icon: ICON,
+              name: 'testToolTune2',
+
+              onActivate: (): void => {},
+            },
+          ];
+        }
+
+        /** Save method stub */
+        public save(): void {}
+
+        /** Renders a block */
+        public render(): HTMLElement {
+          const element = document.createElement('div');
+
+          element.contentEditable = 'true';
+          element.setAttribute('data-name', 'testBlock');
+
+          return element;
+        }
+      }
+
+      cy.createEditor({
+        tools: {
+          testTool: TestTool,
+        },
+      }).as('editorInstance');
+
+      cy.get('[data-cy=editorjs]')
+        .get('div.ce-block')
+        .click();
+
+      cy.get('[data-cy=editorjs]')
+        .get('div.ce-toolbar__plus')
+        .click();
+
+      // Insert test tool block
+      cy.get('[data-cy=editorjs]')
+        .get(`[data-item-name="testTool"]`)
+        .click();
+
+      cy.get('[data-cy=editorjs]')
+        .get('[data-name=testBlock]')
+        .type('some text')
+        .click();
+
+      // Open block tunes
+      cy.get('[data-cy=editorjs]')
+        .get('.ce-toolbar__settings-btn')
+        .click();
+
+      // Expect preconfigured tunes to exist in tunes menu
+      cy.get('[data-item-name=testToolTune1]').should('exist');
+      cy.get('[data-item-name=testToolTune2]').should('exist');
+    });
+
+    it('should contain block tunes represented as custom html if so configured in tool\'s renderSettings() method', () => {
+      const sampleText = 'sample text';
+
+      /** Tool with single tunes menu entry configured */
+      class TestTool {
+        /** Returns toolbox config as list of entries */
+        public static get toolbox(): ToolboxConfigEntry {
+          return {
+            title: 'Test tool',
+            icon: ICON,
+          };
+        }
+
+        /** Returns configuration for block tunes menu */
+        public renderSettings(): HTMLElement {
+          const element = document.createElement('div');
+
+          element.textContent = sampleText;
+
+          return element;
+        }
+
+        /** Save method stub */
+        public save(): void {}
+
+        /** Renders a block */
+        public render(): HTMLElement {
+          const element = document.createElement('div');
+
+          element.contentEditable = 'true';
+          element.setAttribute('data-name', 'testBlock');
+
+          return element;
+        }
+      }
+
+      cy.createEditor({
+        tools: {
+          testTool: TestTool,
+        },
+      }).as('editorInstance');
+
+      cy.get('[data-cy=editorjs]')
+        .get('div.ce-block')
+        .click();
+
+      cy.get('[data-cy=editorjs]')
+        .get('div.ce-toolbar__plus')
+        .click();
+
+      // Insert test tool block
+      cy.get('[data-cy=editorjs]')
+        .get(`[data-item-name="testTool"]`)
+        .click();
+
+      cy.get('[data-cy=editorjs]')
+        .get('[data-name=testBlock]')
+        .type('some text')
+        .click();
+
+      // Open block tunes
+      cy.get('[data-cy=editorjs]')
+        .get('.ce-toolbar__settings-btn')
+        .click();
+
+      // Expect preconfigured custom html tunes to exist in tunes menu
+      cy.get('[data-cy=editorjs]')
+        .get('.ce-popover')
+        .should('contain.text', sampleText);
     });
   });
 });

--- a/test/cypress/tests/api/tunes.spec.ts
+++ b/test/cypress/tests/api/tunes.spec.ts
@@ -1,0 +1,136 @@
+import { TunesMenuConfig } from '../../../../types/tools';
+
+/* eslint-disable @typescript-eslint/no-empty-function */
+
+describe('Editor Tunes Api', () => {
+  it('should render a popover entry for block tune if configured', () => {
+    /** Test tune that should appear be rendered in block tunes menu */
+    class TestTune {
+      /** Set Tool is Tune */
+      public static readonly isTune = true;
+
+      /** Tune's appearance in block settings menu */
+      public render(): TunesMenuConfig {
+        return {
+          icon: 'ICON',
+          label: 'Test tune',
+          name: 'testTune',
+
+          onActivate: (): void => { },
+        };
+      }
+
+      /** Save method stub */
+      public save(): void {}
+    }
+
+    cy.createEditor({
+      tools: {
+        testTune: TestTune,
+      },
+      tunes: [ 'testTune' ],
+    }).as('editorInstance');
+
+    cy.get('[data-cy=editorjs]')
+      .get('div.ce-block')
+      .type('some text')
+      .click();
+
+    cy.get('[data-cy=editorjs]')
+      .get('.ce-toolbar__settings-btn')
+      .click();
+
+    cy.get('[data-item-name=testTune]').should('exist');
+  });
+
+  it('should render several popover entries for block tune if configured', () => {
+    /** Test tune that should appear be rendered in block tunes menu */
+    class TestTune {
+      /** Set Tool is Tune */
+      public static readonly isTune = true;
+
+      /** Tune's appearance in block settings menu */
+      public render(): TunesMenuConfig {
+        return [
+          {
+            icon: 'ICON1',
+            label: 'Tune entry 1',
+            name: 'testTune1',
+
+            onActivate: (): void => { },
+          }, {
+            icon: 'ICON2',
+            label: 'Tune entry 2',
+            name: 'testTune2',
+
+            onActivate: (): void => { },
+          },
+        ];
+      }
+
+      /** Save method stub */
+      public save(): void {}
+    }
+
+    cy.createEditor({
+      tools: {
+        testTune: TestTune,
+      },
+      tunes: [ 'testTune' ],
+    }).as('editorInstance');
+
+    cy.get('[data-cy=editorjs]')
+      .get('div.ce-block')
+      .type('some text')
+      .click();
+
+    cy.get('[data-cy=editorjs]')
+      .get('.ce-toolbar__settings-btn')
+      .click();
+
+    cy.get('[data-item-name=testTune1]').should('exist');
+    cy.get('[data-item-name=testTune2]').should('exist');
+  });
+
+  it('should display custom html returned by tune\'s render() method inside tunes menu', () => {
+    const sampleText = 'sample text';
+
+    /** Test tune that should appear be rendered in block tunes menu  */
+    class TestTune {
+      /** Set Tool is Tune */
+      public static readonly isTune = true;
+
+      /** Tune's appearance in block settings menu */
+      public render(): HTMLElement {
+        const element = document.createElement('div');
+
+        element.textContent = sampleText;
+
+        return element;
+      }
+
+      /** Save method stub */
+      public save(): void {}
+    }
+
+    cy.createEditor({
+      tools: {
+        testTune: TestTune,
+      },
+      tunes: [ 'testTune' ],
+    }).as('editorInstance');
+
+    cy.get('[data-cy=editorjs]')
+      .get('div.ce-block')
+      .type('some text')
+      .click();
+
+    cy.get('[data-cy=editorjs]')
+      .get('.ce-toolbar__settings-btn')
+      .click();
+
+    cy.get('[data-cy=editorjs]')
+      .get('.ce-popover')
+      .should('contain.text', sampleText);
+  });
+});

--- a/test/cypress/tests/onchange.spec.ts
+++ b/test/cypress/tests/onchange.spec.ts
@@ -262,7 +262,7 @@ describe('onChange callback', () => {
       .click();
 
     cy.get('[data-cy=editorjs]')
-      .get('div.ce-settings__button--delete')
+      .get('div[data-item-name=delete]')
       .click()
       .click();
 
@@ -292,7 +292,7 @@ describe('onChange callback', () => {
       .click();
 
     cy.get('[data-cy=editorjs]')
-      .get('div.ce-tune-move-up')
+      .get('div[data-item-name=move-up]')
       .click();
 
     cy.get('@onChange').should('be.calledWithMatch', EditorJSApiMock, Cypress.sinon.match({

--- a/test/cypress/tests/onchange.spec.ts
+++ b/test/cypress/tests/onchange.spec.ts
@@ -263,7 +263,11 @@ describe('onChange callback', () => {
 
     cy.get('[data-cy=editorjs]')
       .get('div[data-item-name=delete]')
-      .click()
+      .click();
+
+    /** Second click for confirmation */
+    cy.get('[data-cy=editorjs]')
+      .get('div[data-item-name=delete]')
       .click();
 
     cy.get('@onChange').should('be.calledWithMatch', EditorJSApiMock, Cypress.sinon.match({

--- a/test/cypress/tests/utils/flipper.spec.ts
+++ b/test/cypress/tests/utils/flipper.spec.ts
@@ -75,9 +75,18 @@ describe('Flipper', () => {
       .get('.cdx-some-plugin')
       // Open tunes menu
       .trigger('keydown', { keyCode: TAB_KEY_CODE })
-      // Navigate to delete button
+      // Navigate to delete button (the second button)
       .trigger('keydown', { keyCode: ARROW_DOWN_KEY_CODE })
-      .trigger('keydown', { keyCode: ARROW_DOWN_KEY_CODE })
+      .trigger('keydown', { keyCode: ARROW_DOWN_KEY_CODE });
+
+    /**
+     * Check whether we focus the Delete Tune or not
+     */
+    cy.get('[data-item-name="delete"]')
+      .should('have.class', 'ce-popover__item--focused');
+
+    cy.get('[data-cy=editorjs]')
+      .get('.cdx-some-plugin')
       // Click delete
       .trigger('keydown', { keyCode: ENTER_KEY_CODE })
       // // Confirm delete

--- a/test/cypress/tests/utils/flipper.spec.ts
+++ b/test/cypress/tests/utils/flipper.spec.ts
@@ -1,0 +1,88 @@
+import { PopoverItem } from '../../../../types/index.js';
+
+/**
+ * Mock of some Block Tool
+ */
+class SomePlugin {
+  /**
+   * Event handler to be spyed in test
+   */
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  public static pluginInternalKeydownHandler(): void {}
+
+  /**
+   * Mocked render method
+   */
+  public render(): HTMLElement {
+    const wrapper = document.createElement('div');
+
+    wrapper.classList.add('cdx-some-plugin');
+    wrapper.contentEditable = 'true';
+    wrapper.addEventListener('keydown', SomePlugin.pluginInternalKeydownHandler);
+
+    return wrapper;
+  }
+
+  /**
+   * Used to display our tool in the Toolboz
+   */
+  public static get toolbox(): PopoverItem {
+    return {
+      icon: '₷',
+      label: 'Some tool',
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      onActivate: (): void => {},
+    };
+  }
+}
+
+describe('Flipper', () => {
+  beforeEach(() => {
+    if (this && this.editorInstance) {
+      this.editorInstance.destroy();
+    } else {
+      cy.createEditor({
+        tools: {
+          sometool: SomePlugin,
+        },
+      }).as('editorInstance');
+    }
+  });
+
+  it('should prevent plugins event handlers from being called while keyboard navigation', () => {
+    const TAB_KEY_CODE = 9;
+    const ARROW_DOWN_KEY_CODE = 40;
+    const ENTER_KEY_CODE = 13;
+
+    const sampleText = 'sample text';
+
+    cy.spy(SomePlugin, 'pluginInternalKeydownHandler');
+
+    // Insert sometool block and enter sample text
+    cy.get('[data-cy=editorjs]')
+      .get('div.ce-block')
+      .trigger('keydown', { keyCode: TAB_KEY_CODE });
+
+    cy.get('[data-item-name=sometool]').click();
+
+    cy.get('[data-cy=editorjs]')
+      .get('.cdx-some-plugin')
+      .focus()
+      .type(sampleText);
+
+    // Try to delete the block via keyboard
+    cy.get('[data-cy=editorjs]')
+      .get('.cdx-some-plugin')
+      // Open tunes menu
+      .trigger('keydown', { keyCode: TAB_KEY_CODE })
+      // Navigate to delete button
+      .trigger('keydown', { keyCode: ARROW_DOWN_KEY_CODE })
+      .trigger('keydown', { keyCode: ARROW_DOWN_KEY_CODE })
+      // Click delete
+      .trigger('keydown', { keyCode: ENTER_KEY_CODE })
+      // // Confirm delete
+      .trigger('keydown', { keyCode: ENTER_KEY_CODE });
+
+    expect(SomePlugin.pluginInternalKeydownHandler).to.have.not.been.called;
+  });
+});

--- a/test/cypress/tests/utils/popover.spec.ts
+++ b/test/cypress/tests/utils/popover.spec.ts
@@ -1,0 +1,66 @@
+import Popover from '../../../../src/components/utils/popover';
+import { PopoverItem } from '../../../../types';
+
+describe('Popover', () => {
+  it('should ', () => {
+    const actionIcon = 'Icon 1';
+    const actionLabel = 'Action';
+    const confirmActionIcon = 'Icon 2';
+    const confirmActionLabel = 'Confirm action';
+
+    const confirmation = {
+      icon: confirmActionIcon,
+      label: confirmActionLabel,
+      onActivate: cy.stub(),
+    };
+
+    const items: PopoverItem[] = [
+      {
+        icon: actionIcon,
+        label: actionLabel,
+        name: 'testItem',
+        confirmation,
+      },
+    ];
+
+    const popover = new Popover({
+      items,
+      filterLabel: '',
+      nothingFoundLabel: '',
+      scopeElement: null,
+    });
+
+    cy.document().then(doc => {
+      doc.body.append(popover.getElement());
+
+      cy.get('[data-item-name=testItem]')
+        .get('.ce-popover__item-icon')
+        .should('have.text', actionIcon);
+
+      cy.get('[data-item-name=testItem]')
+        .get('.ce-popover__item-label')
+        .should('have.text', actionLabel);
+
+      // First click
+      cy.get('[data-item-name=testItem]').click();
+
+      // Check icon has changed
+      cy.get('[data-item-name=testItem]')
+        .get('.ce-popover__item-icon')
+        .should('have.text', confirmActionIcon);
+
+      // Check label has changed
+      cy.get('[data-item-name=testItem]')
+        .get('.ce-popover__item-label')
+        .should('have.text', confirmActionLabel);
+
+      // Second click
+      cy.get('[data-item-name=testItem]')
+        .click()
+        .then(() => {
+          // Check onActivate callback has been called
+          expect(confirmation.onActivate).to.have.been.calledOnce;
+        });
+    });
+  });
+});

--- a/test/cypress/tests/utils/popover.spec.ts
+++ b/test/cypress/tests/utils/popover.spec.ts
@@ -1,13 +1,19 @@
 import Popover from '../../../../src/components/utils/popover';
 import { PopoverItem } from '../../../../types';
 
+/* eslint-disable @typescript-eslint/no-empty-function */
+
 describe('Popover', () => {
-  it('should ', () => {
+  it('should support confirmation chains', () => {
     const actionIcon = 'Icon 1';
     const actionLabel = 'Action';
     const confirmActionIcon = 'Icon 2';
     const confirmActionLabel = 'Confirm action';
 
+    /**
+     * Confirmation is moved to separate variable to be able to test it's callback execution.
+     * (Inside popover null value is set to confirmation property, so, object becomes unavailable otherwise)
+     */
     const confirmation = {
       icon: confirmActionIcon,
       label: confirmActionLabel,
@@ -41,7 +47,7 @@ describe('Popover', () => {
         .get('.ce-popover__item-label')
         .should('have.text', actionLabel);
 
-      // First click
+      // First click on item
       cy.get('[data-item-name=testItem]').click();
 
       // Check icon has changed
@@ -61,6 +67,122 @@ describe('Popover', () => {
           // Check onActivate callback has been called
           expect(confirmation.onActivate).to.have.been.calledOnce;
         });
+    });
+  });
+
+  it('should render the items with true isActive property value as active', () => {
+    const items: PopoverItem[] = [
+      {
+        icon: 'Icon',
+        label: 'Label',
+        isActive: true,
+        name: 'testItem',
+        onActivate: (): void => {},
+      },
+    ];
+
+    const popover = new Popover({
+      items,
+      filterLabel: '',
+      nothingFoundLabel: '',
+      scopeElement: null,
+    });
+
+    cy.document().then(doc => {
+      doc.body.append(popover.getElement());
+
+      /* Check item has active class */
+      cy.get('[data-item-name=testItem]')
+        .should('have.class', 'ce-popover__item--active');
+    });
+  });
+
+  it('should not execute item\'s onActivate callback if the item is disabled', () => {
+    const items: PopoverItem[] = [
+      {
+        icon: 'Icon',
+        label: 'Label',
+        isDisabled: true,
+        name: 'testItem',
+        onActivate: cy.stub(),
+      },
+    ];
+
+    const popover = new Popover({
+      items,
+      filterLabel: '',
+      nothingFoundLabel: '',
+      scopeElement: null,
+    });
+
+    cy.document().then(doc => {
+      doc.body.append(popover.getElement());
+
+      /* Check item has disabled class */
+      cy.get('[data-item-name=testItem]')
+        .should('have.class', 'ce-popover__item--disabled')
+        .click()
+        .then(() => {
+          // Check onActivate callback has never been called
+          expect(items[0].onActivate).to.have.not.been.called;
+        });
+    });
+  });
+
+  it('should close once item with closeOnActivate property set to true is activated', () => {
+    const items: PopoverItem[] = [
+      {
+        icon: 'Icon',
+        label: 'Label',
+        closeOnActivate: true,
+        name: 'testItem',
+        onActivate: (): void => {},
+      },
+    ];
+    const popover = new Popover({
+      items,
+      filterLabel: '',
+      nothingFoundLabel: '',
+      scopeElement: null,
+    });
+
+    cy.spy(popover, 'hide');
+
+    cy.document().then(doc => {
+      doc.body.append(popover.getElement());
+
+      cy.get('[data-item-name=testItem]')
+        .click()
+        .then(() => {
+          expect(popover.hide).to.have.been.called;
+        });
+    });
+  });
+
+  it('should highlight as active the item with toggle property set to true once activated', () => {
+    const items: PopoverItem[] = [
+      {
+        icon: 'Icon',
+        label: 'Label',
+        toggle: true,
+        name: 'testItem',
+        onActivate: (): void => {},
+      },
+    ];
+    const popover = new Popover({
+      items,
+      filterLabel: '',
+      nothingFoundLabel: '',
+      scopeElement: null,
+    });
+
+    cy.document().then(doc => {
+      doc.body.append(popover.getElement());
+
+      /* Check item has active class */
+      cy.get('[data-item-name=testItem]')
+        .click()
+        .should('have.class', 'ce-popover__item--active');
     });
   });
 });

--- a/test/cypress/tsconfig.json
+++ b/test/cypress/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
       "target": "es2017",
-      "lib": ["dom", "es2017", "es2018"],
+      "lib": ["dom", "es2017", "es2018", "es2019"],
       "moduleResolution": "node",
       "resolveJsonModule": true,
       "allowSyntheticDefaultImports": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "es2017",
     "declaration": false,
     "moduleResolution": "node", // This resolution strategy attempts to mimic the Node.js module resolution mechanism at runtime
-    "lib": ["dom", "es2017", "es2018"],
+    "lib": ["dom", "es2017", "es2018", "es2019"],
 
     // allows to import .json files for i18n
     "resolveJsonModule": true,

--- a/types/api/blocks.d.ts
+++ b/types/api/blocks.d.ts
@@ -52,7 +52,7 @@ export interface Blocks {
    * Returns Block API object by passed Block index
    * @param {number} index
    */
-  getBlockByIndex(index: number): BlockAPI | void;
+  getBlockByIndex(index: number): BlockAPI | undefined;
 
   /**
    * Returns Block API object by passed Block id

--- a/types/block-tunes/block-tune.d.ts
+++ b/types/block-tunes/block-tune.d.ts
@@ -1,6 +1,7 @@
 import {API, BlockAPI, SanitizerConfig, ToolConfig} from '../index';
 import { BlockTuneData } from './block-tune-data';
 import { PopoverItem } from '../../src/components/utils/popover';
+import { TunesMenuConfig } from '../tools';
 
 /**
  * Describes BLockTune blueprint
@@ -8,10 +9,8 @@ import { PopoverItem } from '../../src/components/utils/popover';
 export interface BlockTune {
   /**
    * Returns block tune HTMLElement
-   *
-   * @return {HTMLElement}
    */
-  render?(): HTMLElement;
+  render(): HTMLElement | TunesMenuConfig;
 
   /**
    * Method called on Tool render. Pass Tool content as an argument.
@@ -30,11 +29,6 @@ export interface BlockTune {
    * @return {BlockTuneData}
    */
   save?(): BlockTuneData;
-
-  /**
-   * Tune's appearance in block settings menu
-   */
-  blockSettings?: PopoverItem
 }
 
 /**

--- a/types/block-tunes/block-tune.d.ts
+++ b/types/block-tunes/block-tune.d.ts
@@ -1,6 +1,5 @@
 import {API, BlockAPI, SanitizerConfig, ToolConfig} from '../index';
 import { BlockTuneData } from './block-tune-data';
-import { PopoverItem } from '../../src/components/utils/popover';
 import { TunesMenuConfig } from '../tools';
 
 /**

--- a/types/block-tunes/block-tune.d.ts
+++ b/types/block-tunes/block-tune.d.ts
@@ -11,7 +11,7 @@ export interface BlockTune {
    *
    * @return {HTMLElement}
    */
-  render(): HTMLElement;
+  render?(): HTMLElement;
 
   /**
    * Method called on Tool render. Pass Tool content as an argument.
@@ -32,7 +32,7 @@ export interface BlockTune {
   save?(): BlockTuneData;
 
   /**
-   * 
+   * Tune's appearance in block settings menu
    */
   blockSettings?: PopoverItem
 }

--- a/types/block-tunes/block-tune.d.ts
+++ b/types/block-tunes/block-tune.d.ts
@@ -1,5 +1,6 @@
 import {API, BlockAPI, SanitizerConfig, ToolConfig} from '../index';
 import { BlockTuneData } from './block-tune-data';
+import { PopoverItem } from '../../src/components/utils/popover';
 
 /**
  * Describes BLockTune blueprint
@@ -29,6 +30,11 @@ export interface BlockTune {
    * @return {BlockTuneData}
    */
   save?(): BlockTuneData;
+
+  /**
+   * 
+   */
+  blockSettings?: PopoverItem
 }
 
 /**

--- a/types/configs/index.d.ts
+++ b/types/configs/index.d.ts
@@ -1,3 +1,5 @@
+import { fromCallback } from 'cypress/types/bluebird';
+
 export * from './editor-config';
 export * from './sanitizer-config';
 export * from './paste-config';
@@ -5,3 +7,4 @@ export * from './conversion-config';
 export * from './log-levels';
 export * from './i18n-config';
 export * from './i18n-dictionary';
+export * from './popover'

--- a/types/configs/popover.d.ts
+++ b/types/configs/popover.d.ts
@@ -22,7 +22,6 @@ interface PopoverItemBase {
    */
   isActive?: boolean;
 
-
   /**
    * True if item should be disabled
    */

--- a/types/configs/popover.d.ts
+++ b/types/configs/popover.d.ts
@@ -1,0 +1,69 @@
+/**
+ * Common parameters for both types of popover items: with or without confirmation
+ */
+interface PopoverItemBase {
+  /**
+   * Item icon to be appeared near a title
+   */
+  icon: string;
+
+  /**
+   * Displayed text
+   */
+  label: string;
+
+  /**
+   * Item name
+   * Used in data attributes needed for cypress tests
+   */
+  name?: string;
+
+  /**
+   * Additional displayed text
+   */
+  secondaryLabel?: string;
+
+  /**
+   * True if item should be highlighted as active
+   */
+  isActive?: boolean;
+
+  /**
+   * True if popover should close once item is activated
+   */
+  closeOnActivate?: boolean;
+}
+
+/**
+ * Represents popover item with confirmation state configuration
+ */
+export interface PopoverItemWithConfirmation extends PopoverItemBase {
+  /**
+   * Popover item parameters that should be applied on item activation.
+   * May be used to ask user for confirmation before executing popover item activation handler.
+   */
+  confirmation: Partial<PopoverItem>;
+
+  onActivate?: never;
+}
+
+/**
+ * Represents default popover item without confirmation state configuration
+ */
+export interface PopoverItemWithoutConfirmation extends PopoverItemBase {
+  confirmation?: never;
+
+  /**
+   * Popover item activation handler
+   *
+   * @param item - activated item
+   * @param event - event that initiated item activation
+   */
+  onActivate: (item: PopoverItem, event?: PointerEvent) => void;
+}
+
+/**
+ * Represents single popover item
+ */
+export type PopoverItem = PopoverItemWithConfirmation | PopoverItemWithoutConfirmation
+

--- a/types/configs/popover.d.ts
+++ b/types/configs/popover.d.ts
@@ -13,12 +13,6 @@ interface PopoverItemBase {
   label: string;
 
   /**
-   * Item name
-   * Used in data attributes needed for cypress tests
-   */
-  name?: string;
-
-  /**
    * Additional displayed text
    */
   secondaryLabel?: string;
@@ -38,6 +32,12 @@ interface PopoverItemBase {
    * True if popover should close once item is activated
    */
   closeOnActivate?: boolean;
+
+  /**
+   * Item name
+   * Used in data attributes needed for cypress tests
+   */
+  name?: string;
 }
 
 /**

--- a/types/configs/popover.d.ts
+++ b/types/configs/popover.d.ts
@@ -37,6 +37,11 @@ interface PopoverItemBase {
    * Used in data attributes needed for cypress tests
    */
   name?: string;
+
+  /**
+   * True if item should be highlighted once activated
+   */
+  toggle?: boolean;
 }
 
 /**

--- a/types/configs/popover.d.ts
+++ b/types/configs/popover.d.ts
@@ -28,6 +28,12 @@ interface PopoverItemBase {
    */
   isActive?: boolean;
 
+
+  /**
+   * True if item should be disabled
+   */
+  isDisabled?: boolean;
+
   /**
    * True if popover should close once item is activated
    */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -71,6 +71,9 @@ export {
   Dictionary,
   DictValue,
   I18nConfig,
+  PopoverItem,
+  PopoverItemWithConfirmation,
+  PopoverItemWithoutConfirmation
 } from './configs';
 export {OutputData, OutputBlockData} from './data-formats/output-data';
 export { BlockAPI } from './api'

--- a/types/tools/block-tool.d.ts
+++ b/types/tools/block-tool.d.ts
@@ -5,6 +5,7 @@ import { ToolConfig } from './tool-config';
 import { API, BlockAPI, ToolboxConfig } from '../index';
 import { PasteEvent } from './paste-events';
 import { MoveEvent } from './hook-events';
+import { TunesMenuConfig } from './tool-settings';
 import { PopoverItem } from '../../src/components/utils/popover';
 
 /**
@@ -26,14 +27,10 @@ export interface BlockTool extends BaseTool {
 
   /**
    * Create Block's settings block
-   * @return {HTMLElement}
    */
-  renderSettings?(): HTMLElement;
+  renderSettings?(): HTMLElement | TunesMenuConfig;
 
-  /**
-   * 
-   */
-  blockSettings?: PopoverItem | PopoverItem[];
+
 
   /**
    * Validate Block's data
@@ -102,6 +99,11 @@ export interface BlockToolConstructable extends BaseToolConstructable {
    * Tool's Toolbox settings
    */
   toolbox?: ToolboxConfig;
+
+  /**
+   * Configures the way tool's tunes appear in tunes menu
+   */
+  tunes?: TunesMenuConfig;
 
   /**
    * Paste substitutions configuration

--- a/types/tools/block-tool.d.ts
+++ b/types/tools/block-tool.d.ts
@@ -30,8 +30,6 @@ export interface BlockTool extends BaseTool {
    */
   renderSettings?(): HTMLElement | TunesMenuConfig;
 
-
-
   /**
    * Validate Block's data
    * @param {BlockToolData} blockData

--- a/types/tools/block-tool.d.ts
+++ b/types/tools/block-tool.d.ts
@@ -6,7 +6,6 @@ import { API, BlockAPI, ToolboxConfig } from '../index';
 import { PasteEvent } from './paste-events';
 import { MoveEvent } from './hook-events';
 import { TunesMenuConfig } from './tool-settings';
-import { PopoverItem } from '../../src/components/utils/popover';
 
 /**
  * Describe Block Tool object

--- a/types/tools/block-tool.d.ts
+++ b/types/tools/block-tool.d.ts
@@ -99,11 +99,6 @@ export interface BlockToolConstructable extends BaseToolConstructable {
   toolbox?: ToolboxConfig;
 
   /**
-   * Configures the way tool's tunes appear in tunes menu
-   */
-  tunes?: TunesMenuConfig;
-
-  /**
    * Paste substitutions configuration
    */
   pasteConfig?: PasteConfig | false;

--- a/types/tools/block-tool.d.ts
+++ b/types/tools/block-tool.d.ts
@@ -5,6 +5,7 @@ import { ToolConfig } from './tool-config';
 import { API, BlockAPI, ToolboxConfig } from '../index';
 import { PasteEvent } from './paste-events';
 import { MoveEvent } from './hook-events';
+import { PopoverItem } from '../../src/components/utils/popover';
 
 /**
  * Describe Block Tool object
@@ -28,6 +29,11 @@ export interface BlockTool extends BaseTool {
    * @return {HTMLElement}
    */
   renderSettings?(): HTMLElement;
+
+  /**
+   * 
+   */
+  blockSettings?: PopoverItem | PopoverItem[];
 
   /**
    * Validate Block's data

--- a/types/tools/tool-settings.d.ts
+++ b/types/tools/tool-settings.d.ts
@@ -29,10 +29,26 @@ export interface ToolboxConfigEntry {
 }
 
 /**
+ * Represents single tunes menu entry
+ */
+export type TunesMenuEntry = PopoverItem & {
+  /**
+   * True if tunes menu should close once item is activated
+   */
+  closeOnActivate?: boolean,
+
+  /**
+   * True if tune is active.
+   * Is used to filter out items.
+   */
+  isActive?: boolean
+};
+
+/**
  * Tool may specify its tunes configuration
  * that can contain either one or multiple entries
  */
-export type TunesMenuConfig = PopoverItem | PopoverItem[];
+export type TunesMenuConfig = TunesMenuEntry | TunesMenuEntry[];
 
 /**
  * Object passed to the Tool's constructor by {@link EditorConfig#tools}

--- a/types/tools/tool-settings.d.ts
+++ b/types/tools/tool-settings.d.ts
@@ -1,5 +1,6 @@
 import { ToolConfig } from './tool-config';
 import { ToolConstructable, BlockToolData } from './index';
+import { PopoverItem } from '../../src/components/utils/popover';
 
 /**
  * Tool may specify its toolbox configuration
@@ -26,6 +27,12 @@ export interface ToolboxConfigEntry {
    */
   data?: BlockToolData
 }
+
+/**
+ * Tool may specify its tunes configuration
+ * that can contain either one or multiple entries
+ */
+export type TunesMenuConfig = PopoverItem | PopoverItem[];
 
 /**
  * Object passed to the Tool's constructor by {@link EditorConfig#tools}

--- a/types/tools/tool-settings.d.ts
+++ b/types/tools/tool-settings.d.ts
@@ -29,26 +29,10 @@ export interface ToolboxConfigEntry {
 }
 
 /**
- * Represents single tunes menu entry
- */
-export type TunesMenuEntry = PopoverItem & {
-  /**
-   * True if tunes menu should close once item is activated
-   */
-  closeOnActivate?: boolean,
-
-  /**
-   * True if tune is active.
-   * Is used to filter out items.
-   */
-  isActive?: boolean
-};
-
-/**
  * Tool may specify its tunes configuration
  * that can contain either one or multiple entries
  */
-export type TunesMenuConfig = TunesMenuEntry | TunesMenuEntry[];
+export type TunesMenuConfig = PopoverItem | PopoverItem[];
 
 /**
  * Object passed to the Tool's constructor by {@link EditorConfig#tools}

--- a/types/tools/tool-settings.d.ts
+++ b/types/tools/tool-settings.d.ts
@@ -1,6 +1,6 @@
 import { ToolConfig } from './tool-config';
 import { ToolConstructable, BlockToolData } from './index';
-import { PopoverItem } from '../../src/components/utils/popover';
+import { PopoverItem } from '../configs';
 
 /**
  * Tool may specify its toolbox configuration


### PR DESCRIPTION
- Updates block tunes to use popover component. As a temporary solution, non-default block tunes are rendered as before and inserted to special area inside the popover. 
- New getter `blockSettings` (naming could be discussed) is added to tunes interface. It allows to configure the way tune is displayed in the popover. 
<img width="212" alt="image" src="https://user-images.githubusercontent.com/31101125/177375932-a78735f6-b82d-4a13-8573-c0ade8913e15.png">
