### PR TITLE
[Fix] add default block for readonly toggler

### DIFF
--- a/src/components/modules/readonly.ts
+++ b/src/components/modules/readonly.ts
@@ -97,8 +97,9 @@ export default class ReadOnly extends Module {
      * Save current Editor Blocks and render again
      */
     const savedBlocks = await this.Editor.Saver.save();
+    const shouldAddDefaultBlock = savedBlocks.blocks.length === 0;
 
-    await this.Editor.BlockManager.clear();
+    await this.Editor.BlockManager.clear(shouldAddDefaultBlock);
     await this.Editor.Renderer.render(savedBlocks.blocks);
 
     return this.readOnlyEnabled;

--- a/test/cypress/tests/readOnly.spec.ts
+++ b/test/cypress/tests/readOnly.spec.ts
@@ -47,4 +47,18 @@ describe('ReadOnly API spec', () => {
           });
       });
   });
+
+  it('should add default block when block list is empty', () => {
+    createEditor({ readOnly: true });
+
+    cy
+      .get<EditorJS>('@editorInstance')
+      .then(async editor => {
+        editor.readOnly.toggle(false).then(() => {
+          cy.get('[data-cy=editorjs').click();
+
+          expect(editor.readOnly.isEnabled).to.be.false;
+        });
+      });
+  });
 });


### PR DESCRIPTION
It fixes the problem when you toggle the read-only property with empty blocks attached to the editor.
https://github.com/codex-team/editor.js/issues/2090