### PR TITLE
Add support for copying and pasting of "strong" and "em" HTML elements

### DIFF
--- a/src/components/inline-tools/inline-tool-bold.ts
+++ b/src/components/inline-tools/inline-tool-bold.ts
@@ -23,13 +23,14 @@ export default class BoldInlineTool implements InlineTool {
 
   /**
    * Sanitizer Rule
-   * Leave <b> tags
+   * Leave <b> and <strong> tags
    *
    * @returns {object}
    */
   public static get sanitize(): SanitizerConfig {
     return {
       b: {},
+      strong: {},
     } as SanitizerConfig;
   }
 

--- a/src/components/inline-tools/inline-tool-italic.ts
+++ b/src/components/inline-tools/inline-tool-italic.ts
@@ -23,13 +23,14 @@ export default class ItalicInlineTool implements InlineTool {
 
   /**
    * Sanitizer Rule
-   * Leave <i> tags
+   * Leave <i> and <em> tags
    *
    * @returns {object}
    */
   public static get sanitize(): SanitizerConfig {
     return {
       i: {},
+      em: {},
     } as SanitizerConfig;
   }
 

--- a/test/cypress/tests/sanitisation.spec.ts
+++ b/test/cypress/tests/sanitisation.spec.ts
@@ -9,20 +9,51 @@ describe('Output sanitisation', () => {
   });
 
   context('Output should save inline formatting', () => {
-    it('should save initial formatting for paragraph', () => {
+    it('should save initial bold formatting for paragraph', () => {
       cy.createEditor({
         data: {
-          blocks: [ {
-            type: 'paragraph',
-            data: { text: '<b>Bold text</b>' },
-          } ],
+          blocks: [
+            {
+              type: 'paragraph',
+              data: { text: '<b>Bold text</b>' },
+            }, {
+              type: 'paragraph',
+              data: { text: '<strong>Important text</strong>' },
+            },
+          ],
         },
       }).then(async editor => {
         const output = await (editor as any).save();
 
         const boldText = output.blocks[0].data.text;
+        const importantText = output.blocks[1].data.text;
 
         expect(boldText).to.eq('<b>Bold text</b>');
+        expect(importantText).to.eq('<strong>Important text</strong>');
+      });
+    });
+
+    it('should save initial italic formatting for paragraph', () => {
+      cy.createEditor({
+        data: {
+          blocks: [
+            {
+              type: 'paragraph',
+              data: { text: '<i>Italic text</i>' },
+            }, {
+              type: 'paragraph',
+              data: { text: '<em>Emphasis text</em>' },
+            },
+          ],
+        },
+      }).then(async editor => {
+        const output = await (editor as any).save();
+
+        const italicText = output.blocks[0].data.text;
+        const emphasisText = output.blocks[1].data.text;
+
+        expect(italicText).to.eq('<i>Italic text</i>');
+        expect(emphasisText).to.eq('<em>Emphasis text</em>');
       });
     });
 


### PR DESCRIPTION
Fixes #1666 

Followed the [suggestion](https://github.com/codex-team/editor.js/issues/1666#issuecomment-1238587836) of @neSpecc to extend the sanitization config for both italic and bold formatting. 

I also added tests to cover the new use cases.

## Before:

https://user-images.githubusercontent.com/44353593/199292460-d22fd918-9ef2-45e2-ad97-599eafa3f9d9.mov



## After:

https://user-images.githubusercontent.com/44353593/199292392-6d9b7b99-f410-4c02-ae65-18565c5e458b.mov

