### PR TITLE
chore(icons): icons size increased for mobile devices

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `Fix` — Pasting from Microsoft Word to Chrome (Mac OS) fixed. Now if there are no image-tools connected, regular text content will be pasted.
 - `Fix` — Workaround for the HTMLJanitor bug with Tables (https://github.com/guardian/html-janitor/issues/3) added
 - `Fix` — Toolbox shortcuts appearance and execution fixed [#2112](https://github.com/codex-team/editor.js/issues/2112)
+- `Fix` — Inline Tools click handling on mobile devices improved
 - `Improvement` — *Tools API* — `pasteConfig().tags` now support sanitizing configuration. It allows you to leave some explicitly specified attributes for pasted content.
 - `Improvement` — *CodeStyle* — [CodeX ESLint Config](https://github.com/codex-team/eslint-config) has bee updated. All ESLint/Spelling issues resolved
 - `Improvement` — *ToolsAPI* — The `icon` property of the `toolbox` getter became optional.

--- a/src/components/modules/toolbar/inline.ts
+++ b/src/components/modules/toolbar/inline.ts
@@ -68,7 +68,8 @@ export default class InlineToolbar extends Module<InlineToolbarNodes> {
   /**
    * Margin above/below the Toolbar
    */
-  private readonly toolbarVerticalMargin: number = 5;
+  // eslint-disable-next-line @typescript-eslint/no-magic-numbers
+  private readonly toolbarVerticalMargin: number = _.isMobileScreen() ? 20 : 6;
 
   /**
    * TODO: Get rid of this

--- a/src/styles/export.css
+++ b/src/styles/export.css
@@ -46,6 +46,17 @@
   &--active {
     color: var(--color-active-icon);
   }
+
+  svg {
+    width: auto;
+    height: auto;
+  }
+
+  @media (--mobile) {
+    width: var(--toolbox-buttons-size--mobile);
+    height: var(--toolbox-buttons-size--mobile);
+    border-radius: 8px;
+  }
 }
 
 /**
@@ -93,9 +104,11 @@
   text-align: center;
   cursor: pointer;
 
-  &:hover {
-    background: #FBFCFE;
-    box-shadow: 0 1px 3px 0 rgba(18,30,57,0.08);
+  @media (--can-hover) {
+    &:hover {
+      background: #FBFCFE;
+      box-shadow: 0 1px 3px 0 rgba(18,30,57,0.08);
+    }
   }
 
   svg {

--- a/src/styles/inline-toolbar.css
+++ b/src/styles/inline-toolbar.css
@@ -58,8 +58,10 @@
     border-right: 1px solid var(--color-gray-border);
     box-sizing: border-box;
 
-    &:hover {
-      background: var(--bg-light);
+    @media (--can-hover) {
+      &:hover {
+        background: var(--bg-light);
+      }
     }
 
     &--hidden {
@@ -88,7 +90,6 @@
 
   border-radius: 0;
   line-height: normal;
-  padding: 0 1px !important;
 
 
   &--link {
@@ -119,6 +120,13 @@
     display: none;
     font-weight: 500;
     border-top: 1px solid rgba(201,201,204,.48);
+    -webkit-appearance: none;
+    font-family: inherit;
+
+    @media (--mobile){
+      font-size: 15px;
+      font-weight: 500;
+    }
 
     &::placeholder {
       color: var(--grayText);

--- a/src/styles/inline-toolbar.css
+++ b/src/styles/inline-toolbar.css
@@ -1,6 +1,8 @@
 .ce-inline-toolbar {
+  --y-offset: 8px;
+
   @apply --overlay-pane;
-  transform: translateX(-50%) translateY(8px) scale(0.9);
+  transform: translateX(-50%) translateY(8px) scale(0.94);
   opacity: 0;
   visibility: hidden;
   transition: transform 150ms ease, opacity 250ms ease;
@@ -16,7 +18,7 @@
   }
 
   &--left-oriented {
-    transform: translateX(-23px) translateY(8px) scale(0.9);
+    transform: translateX(-23px) translateY(8px) scale(0.94);
   }
 
   &--left-oriented&--showed {
@@ -24,7 +26,7 @@
   }
 
   &--right-oriented {
-    transform: translateX(-100%) translateY(8px) scale(0.9);
+    transform: translateX(-100%) translateY(8px) scale(0.94);
     margin-left: 23px;
   }
 

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -236,15 +236,20 @@
     flex-shrink: 0;
     margin-right: 10px;
 
+    svg {
+      width: var(--icon-size);
+      height: var(--icon-size);
+    }
+
     @media (--mobile) {
       width: var(--toolbox-buttons-size--mobile);
       height: var(--toolbox-buttons-size--mobile);
       border-radius: 8px;
-    }
 
-    svg {
-      width: var(--icon-size);
-      height: var(--icon-size);
+      svg {
+        width: 80%;
+        height: 80%;
+      }
     }
   }
 }

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -59,7 +59,7 @@
    * Size of svg icons got from the CodeX Icons pack
    */
   --icon-size: 20px;
-  --icon-size--mobile: 30px;
+  --icon-size--mobile: 28px;
 
 
   /**

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -59,6 +59,8 @@
    * Size of svg icons got from the CodeX Icons pack
    */
   --icon-size: 20px;
+  --icon-size--mobile: 30px;
+
 
   /**
    * The main `.cdx-block` wrapper has such vertical paddings
@@ -173,6 +175,11 @@
     svg {
       width: var(--icon-size);
       height: var(--icon-size);
+
+      @media (--mobile) {
+        width: var(--icon-size--mobile);
+        height: var(--icon-size--mobile);
+      }
     }
 
     &:hover {
@@ -247,8 +254,8 @@
       border-radius: 8px;
 
       svg {
-        width: 80%;
-        height: 80%;
+        width: var(--icon-size--mobile);
+        height: var(--icon-size--mobile);
       }
     }
   }

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -84,11 +84,6 @@
     border-radius: 6px;
     z-index: 2;
 
-    @media (--mobile){
-      box-shadow: 0 8px 6px -6px rgb(33 48 73 / 19%);
-      border-bottom-color: #c7c7c7;
-    }
-
     &--left-oriented {
       &::before {
         left: 15px;
@@ -162,7 +157,7 @@
     align-items: center;
     justify-content: center;
 
-    padding: 0;
+    padding: 6px 1px;
     border-radius: 3px;
     cursor: pointer;
     border: 0;
@@ -182,8 +177,10 @@
       }
     }
 
-    &:hover {
-      background-color: var(--bg-light);
+    @media (--can-hover) {
+      &:hover {
+        background-color: var(--bg-light);
+      }
     }
 
     &--active {


### PR DESCRIPTION
1. Toolbox and Block Tunes icons upscaled for mobile devices

<img width="815" alt="image" src="https://user-images.githubusercontent.com/3684889/204391598-52324977-c9f1-4857-b554-88b710d054c6.png">

2. Inline Toolbar icons upscaled as well