### PR TITLE
Feature/2153 relative toolbar position

### DIFF
--- a/src/components/modules/toolbar/index.ts
+++ b/src/components/modules/toolbar/index.ts
@@ -457,6 +457,13 @@ export default class Toolbar extends Module<ToolbarNodes> {
    * @param block - block to move Toolbar near it
    */
   private assignToolbarLeftPosition(block: Block = this.Editor.BlockManager.currentBlock): void {
+    /**
+     * If no Block is selected as a Current
+     */
+    if (!block) {
+      return;
+    }
+
     const targetBlockHolder = block.holder;
     const blockContentNode = targetBlockHolder.querySelector(`.${Block.CSS.content}`) as HTMLElement | null;
 

--- a/src/components/modules/toolbar/index.ts
+++ b/src/components/modules/toolbar/index.ts
@@ -265,6 +265,8 @@ export default class Toolbar extends Module<ToolbarNodes> {
      */
     this.nodes.wrapper.style.top = `${Math.floor(toolbarY)}px`;
 
+    this.assignToolbarLeftPosition(block);
+
     /**
      * Do not show Block Tunes Toggler near single and empty block
      */
@@ -450,6 +452,20 @@ export default class Toolbar extends Module<ToolbarNodes> {
   }
 
   /**
+   * Move Toolbar to the Left coordinate of Block
+   *
+   * @param block - block to move Toolbar near it
+   */
+  private assignToolbarLeftPosition(block: Block = this.Editor.BlockManager.currentBlock): void {
+    const targetBlockHolder = block.holder;
+    const blockContentNode = targetBlockHolder.querySelector(`.${Block.CSS.content}`) as HTMLElement | null;
+
+    if (blockContentNode) {
+      this.nodes.wrapper.style.left = `${Math.floor(blockContentNode.offsetLeft)}px`;
+    }
+  }
+
+  /**
    * Enable bindings
    */
   private enableModuleBindings(): void {
@@ -491,6 +507,15 @@ export default class Toolbar extends Module<ToolbarNodes> {
         }
 
         this.moveAndOpen(data.block);
+      });
+
+      /**
+       * Need to move toolbar on resize because we are now moving it to te left of a Block if Block Settings or Toolbox opened
+       */
+      this.readOnlyMutableListeners.on(window, 'resize', () => {
+        this.assignToolbarLeftPosition(this.hoveredBlock);
+      }, {
+        passive: true,
       });
     }
   }

--- a/src/components/modules/toolbar/index.ts
+++ b/src/components/modules/toolbar/index.ts
@@ -510,7 +510,8 @@ export default class Toolbar extends Module<ToolbarNodes> {
       });
 
       /**
-       * Need to move toolbar on resize because we are now moving it to te left of a Block if Block Settings or Toolbox opened
+       * Need to move toolbar on resize because we are now moving it to te left of a Block
+       * This is needed because max-width is removed from Toolbar content to accommodate different block layouts
        */
       this.readOnlyMutableListeners.on(window, 'resize', () => {
         this.assignToolbarLeftPosition(this.hoveredBlock);

--- a/src/styles/toolbar.css
+++ b/src/styles/toolbar.css
@@ -13,7 +13,6 @@
   }
 
   &__content {
-    max-width: var(--content-width);
     margin: 0 auto;
     position: relative;
   }


### PR DESCRIPTION
As described in #2153, in certain use cases, different layouts may be applied to blocks; i.e a grid layout. This will make it very difficult to get to the toolbar of the desired block because focused block changes on mouse enter:

https://user-images.githubusercontent.com/8109619/205445843-ff0cb2fd-a652-4bd2-8409-bab3110a8c06.mov

With the changes in this branch, the toolbar is absolutely position to the left of a block content as well as the top. The changes should not affect left positioning at all if the block layout is untouched.

<img width="793" alt="Screenshot 2022-12-03 at 14 33 05" src="https://user-images.githubusercontent.com/8109619/205446123-7384450a-f498-4a84-a40e-17e2933b899c.png">

<img width="566" alt="Screenshot 2022-12-03 at 14 32 38" src="https://user-images.githubusercontent.com/8109619/205446155-70d2133b-8caf-4438-a1d1-7f7d06440d4c.png">

<img width="560" alt="Screenshot 2022-12-03 at 14 32 44" src="https://user-images.githubusercontent.com/8109619/205446160-c5c4e1db-509d-4adf-90bd-03b09088b6d1.png">

With a grid layout;

https://user-images.githubusercontent.com/8109619/205446258-e4ba5eb0-345b-4cb4-af5d-67836e7b6487.mov
