### PR TITLE
Confirmation delete label change to red color

### DIFF
--- a/src/styles/popover.css
+++ b/src/styles/popover.css
@@ -110,7 +110,7 @@
       }
 
       .ce-popover__item-label {
-        color: white;
+        color: #e24a4a;
       }
 
       &:not(.ce-popover__item--no-visible-hover) {


### PR DESCRIPTION
When confirmation delete is active, the text change to white and this can't be looked, i change this to red color(same of icon) and look good newly.