### PR TITLE
fix(tunes): make installed tunes render above default tunes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 
+### 2.26.2
+
+- `Fix` — *Menu Config* — Installed tunes are rendered above default tunes again.
+
 ### 2.26.1
 - `Improvement` — *Menu Config* — Now it becomes possible to create toggle groups.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/editorjs",
-  "version": "2.26.1",
+  "version": "2.26.2",
   "description": "Editor.js — Native JS, based on API and Open Source",
   "main": "dist/editor.js",
   "types": "./types/index.d.ts",

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -653,8 +653,8 @@ export default class Block extends EventsDispatcher<BlockEvents> {
 
     /** Common tunes: combination of default tunes (move up, move down, delete) and third-party tunes connected via tunes api */
     const commonTunes = [
-      ...this.defaultTunesInstances.values(),
       ...this.tunesInstances.values(),
+      ...this.defaultTunesInstances.values(),
     ].map(tuneInstance => tuneInstance.render());
 
     [tunesDefinedInTool, commonTunes].flat().forEach(rendered => {

--- a/test/cypress/tests/api/tunes.spec.ts
+++ b/test/cypress/tests/api/tunes.spec.ts
@@ -133,4 +133,56 @@ describe('Editor Tunes Api', () => {
       .get('.ce-popover')
       .should('contain.text', sampleText);
   });
+
+  it('should display installed tunes above default tunes', () => {
+    /** Test tune that should appear be rendered in block tunes menu */
+    class TestTune {
+      /** Set Tool is Tune */
+      public static readonly isTune = true;
+
+      /** Tune's appearance in block settings menu */
+      public render(): TunesMenuConfig {
+        return [
+          {
+            icon: 'ICON',
+            label: 'Tune entry',
+            name: 'test-tune',
+
+            onActivate: (): void => { },
+          },
+        ];
+      }
+
+      /** Save method stub */
+      public save(): void {}
+    }
+
+    cy.createEditor({
+      tools: {
+        testTune: TestTune,
+      },
+      tunes: [ 'testTune' ],
+    }).as('editorInstance');
+
+    cy.get('[data-cy=editorjs]')
+      .get('div.ce-block')
+      .type('some text')
+      .click();
+
+    cy.get('[data-cy=editorjs]')
+      .get('.ce-toolbar__settings-btn')
+      .click();
+
+    /** Check test tune is inserted at index 0 */
+    cy.get('[data-cy=editorjs]')
+      .get('.ce-settings .ce-popover__item')
+      .eq(0)
+      .should('have.attr', 'data-item-name', 'test-tune' );
+
+    /** Check default Move Up tune is inserted below the test tune */
+    cy.get('[data-cy=editorjs]')
+      .get('.ce-popover__item')
+      .eq(1)
+      .should('have.attr', 'data-item-name', 'move-up' );
+  });
 });

--- a/test/cypress/tests/api/tunes.spec.ts
+++ b/test/cypress/tests/api/tunes.spec.ts
@@ -181,7 +181,7 @@ describe('Editor Tunes Api', () => {
 
     /** Check default Move Up tune is inserted below the test tune */
     cy.get('[data-cy=editorjs]')
-      .get('.ce-popover__item')
+      .get('.ce-settings .ce-popover__item')
       .eq(1)
       .should('have.attr', 'data-item-name', 'move-up' );
   });


### PR DESCRIPTION
Fix for installed tunes being rendered below default tunes in Tunes Menu

![telegram-cloud-photo-size-2-5210903556620666491-y](https://user-images.githubusercontent.com/31101125/205510588-e10ac984-8992-496d-8a4e-b9256c40cda5.jpg)
