### PR TITLE
Remove incorrect import for typings

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 2.26.5
 
-- `Fix` — *Types* — Remove unused import.
+- `Fix` — *Types* — Remove unnecessary import that creates a dependency on the `cypress`.
 
 ### 2.26.4
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.26.5
+
+- `Fix` — *Types* — Remove unused import.
+
 ### 2.26.4
 
 - `Improvement` — *Menu Config* — Property `label` renamed to `title`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/editorjs",
-  "version": "2.26.4",
+  "version": "2.26.5",
   "description": "Editor.js — Native JS, based on API and Open Source",
   "main": "dist/editor.js",
   "types": "./types/index.d.ts",

--- a/types/configs/index.d.ts
+++ b/types/configs/index.d.ts
@@ -1,5 +1,3 @@
-import { fromCallback } from 'cypress/types/bluebird';
-
 export * from './editor-config';
 export * from './sanitizer-config';
 export * from './paste-config';


### PR DESCRIPTION
Removes incorrect `'cypress/types/bluebird'` import; fixes #2251