### PR TITLE
fix: scroll up offset for blocks above viewport

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@
 - `Improvement` — *Toolbox* — Number of `close()` method calls optimized.
 - `Improvement` — The `onChange` callback won't be triggered only if all mutations contain nodes with the `data-mutation-free` attributes.
 - `Fix` — Resolve compiler error from importing the BlockToolData type
-- `Fix` — The scroll offset when moving up an element above viewport
+- `Fix` — Resolved a problem when document was being scrolled to the beginning after moving up a Block above the viewport
 
 ### 2.26.5
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `Improvement` — *Toolbox* — Number of `close()` method calls optimized.
 - `Improvement` — The `onChange` callback won't be triggered only if all mutations contain nodes with the `data-mutation-free` attributes.
 - `Fix` — Resolve compiler error from importing the BlockToolData type
+- `Fix` — The scroll offset when moving up an element above viewport
 
 ### 2.26.5
 

--- a/src/components/block-tunes/block-tune-move-up.ts
+++ b/src/components/block-tunes/block-tune-move-up.ts
@@ -82,7 +82,7 @@ export default class MoveUpTune implements BlockTune {
     if (previousBlockCoords.top > 0) {
       scrollUpOffset = Math.abs(currentBlockCoords.top) - Math.abs(previousBlockCoords.top);
     } else {
-      scrollUpOffset = window.innerHeight - Math.abs(currentBlockCoords.top) + Math.abs(previousBlockCoords.top);
+      scrollUpOffset = Math.abs(currentBlockCoords.top) + previousBlockCoords.height;
     }
 
     window.scrollBy(0, -1 * scrollUpOffset);


### PR DESCRIPTION
Fixes issue where Move Up tune would scroll to top of page when the previous block is above viewport.

resolves #2297