### PR TITLE
fix(npm): ignore redundant files in sub-directories

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,6 @@
 *
-!dist/**/*
-!types/**/*
-!LICENSE
-!README.md
-!package.json
+!/dist/**/*
+!/types/**/*
+!/LICENSE
+!/README.md
+!/package.json


### PR DESCRIPTION
I've fixed `.npmignore` file so it'll include only files in the root directory.

https://github.com/npm/cli/wiki/Files-&-Ignores#details-1