### PR TITLE
feat(block): Add option to disable mutation observation

### DIFF
--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -748,8 +748,15 @@ export default class Block extends EventsDispatcher<BlockEvents> {
    * Is fired when Block will be unselected
    */
   public willUnselect(): void {
-    this.mutationObserver?.disconnect();
-    this.removeInputEvents();
+    /**
+     * There's no need to disconnect the observer or
+     * remove listeners if shouldUpdateOnMutation is false,
+     * since they weren't set up in the first place.
+     */
+    if (this.tool.shouldUpdateOnMutation) {
+      this.mutationObserver.disconnect();
+      this.removeInputEvents();
+    }
   }
 
   /**

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -199,11 +199,11 @@ export default class Block extends EventsDispatcher<BlockEvents> {
   private mutationObserver: MutationObserver | undefined;
 
   /**
-   * Debounce Timer
+   * Minimum time to wait between mutation events, in milliseconds.
    *
    * @type {number}
    */
-  private readonly modificationDebounceTimer = 450;
+  private readonly modificationDebounceTimer = _.modificationDebounceTimer;
 
   /**
    * Is fired when DOM mutation has been happened
@@ -309,7 +309,7 @@ export default class Block extends EventsDispatcher<BlockEvents> {
     this.tool = tool;
     this.toolInstance = tool.create(data, this.blockAPI, readOnly);
 
-    if (tool.isMutationObserverEnabled) {
+    if (tool.shouldUpdateOnMutation) {
       this.mutationObserver = new MutationObserver(this.didMutated);
     }
 

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -194,9 +194,9 @@ export default class Block extends EventsDispatcher<BlockEvents> {
   /**
    * Mutation observer to handle DOM mutations
    *
-   * @type {MutationObserver}
+   * @type {MutationObserver | undefined}
    */
-  private mutationObserver: MutationObserver;
+  private mutationObserver: MutationObserver | undefined;
 
   /**
    * Debounce Timer
@@ -306,10 +306,12 @@ export default class Block extends EventsDispatcher<BlockEvents> {
     this.api = api;
     this.blockAPI = new BlockAPI(this);
 
-    this.mutationObserver = new MutationObserver(this.didMutated);
-
     this.tool = tool;
     this.toolInstance = tool.create(data, this.blockAPI, readOnly);
+
+    if (tool.isMutationObserverEnabled) {
+      this.mutationObserver = new MutationObserver(this.didMutated);
+    }
 
     /**
      * @type {BlockTune[]}
@@ -718,7 +720,7 @@ export default class Block extends EventsDispatcher<BlockEvents> {
     /**
      * Observe DOM mutations to update Block inputs
      */
-    this.mutationObserver.observe(
+    this.mutationObserver?.observe(
       this.holder.firstElementChild,
       {
         childList: true,
@@ -739,7 +741,7 @@ export default class Block extends EventsDispatcher<BlockEvents> {
    * Is fired when Block will be unselected
    */
   public willUnselect(): void {
-    this.mutationObserver.disconnect();
+    this.mutationObserver?.disconnect();
     this.removeInputEvents();
   }
 

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -718,23 +718,30 @@ export default class Block extends EventsDispatcher<BlockEvents> {
    */
   public willSelect(): void {
     /**
-     * Observe DOM mutations to update Block inputs
+     * If the tool allows it, observe mutations and input changes in the
+     * element tree to trigger updates. Tools allow observation by default.
+     * To disable observation, set BlockTool.shouldUpdateOnMutation to false.
      */
-    this.mutationObserver?.observe(
-      this.holder.firstElementChild,
-      {
-        childList: true,
-        subtree: true,
-        characterData: true,
-        attributes: true,
-      }
-    );
+    if (this.tool.shouldUpdateOnMutation) {
+      /**
+       * Observe DOM mutations to update Block inputs
+       */
+      this.mutationObserver.observe(
+        this.holder.firstElementChild,
+        {
+          childList: true,
+          subtree: true,
+          characterData: true,
+          attributes: true,
+        }
+      );
 
-    /**
-     * Mutation observer doesn't track changes in "<input>" and "<textarea>"
-     * so we need to track focus events to update current input and clear cache.
-     */
-    this.addInputEvents();
+      /**
+       * Mutation observer doesn't track changes in "<input>" and "<textarea>"
+       * so we need to track focus events to update current input and clear cache.
+       */
+      this.addInputEvents();
+    }
   }
 
   /**

--- a/src/components/tools/base.ts
+++ b/src/components/tools/base.ts
@@ -91,9 +91,10 @@ export enum InternalBlockToolSettings {
    */
   PasteConfig = 'pasteConfig',
   /**
-   * Should observe for mutations in the rendered element tree and trigger updates
+   * Should observe for mutations and input changes in the rendered
+   * element tree and trigger updates automatically.
    */
-  IsMutationObserverEnabled = 'isMutationObserverEnabled'
+  ShouldUpdateOnMutation = 'shouldUpdateOnMutation'
 }
 
 /**

--- a/src/components/tools/base.ts
+++ b/src/components/tools/base.ts
@@ -89,7 +89,11 @@ export enum InternalBlockToolSettings {
   /**
    * Tool paste config
    */
-  PasteConfig = 'pasteConfig'
+  PasteConfig = 'pasteConfig',
+  /**
+   * Should observe for mutations in the rendered element tree and trigger updates
+   */
+  IsMutationObserverEnabled = 'isMutationObserverEnabled'
 }
 
 /**

--- a/src/components/tools/block.ts
+++ b/src/components/tools/block.ts
@@ -70,10 +70,11 @@ export default class BlockTool extends BaseTool<IBlockTool> {
   }
 
   /**
-   * Returns true if mutations in the rendered element tree should trigger data updates.
+   * Returns true if mutations and input changes in the rendered
+   * element tree should trigger data updates automatically.
    */
-  public get isMutationObserverEnabled(): boolean {
-    return this.constructable[InternalBlockToolSettings.IsMutationObserverEnabled] !== false;
+  public get shouldUpdateOnMutation(): boolean {
+    return this.constructable[InternalBlockToolSettings.ShouldUpdateOnMutation] !== false;
   }
 
   /**

--- a/src/components/tools/block.ts
+++ b/src/components/tools/block.ts
@@ -70,6 +70,13 @@ export default class BlockTool extends BaseTool<IBlockTool> {
   }
 
   /**
+   * Returns true if mutations in the rendered element tree should trigger data updates.
+   */
+  public get isMutationObserverEnabled(): boolean {
+    return this.constructable[InternalBlockToolSettings.IsMutationObserverEnabled] !== false;
+  }
+
+  /**
    * Returns Tool toolbox configuration (internal or user-specified).
    *
    * Merges internal and user-defined toolbox configs based on the following rules:

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -787,3 +787,10 @@ export function equals(var1: unknown, var2: unknown): boolean {
 
   return var1 === var2;
 }
+
+/**
+ * Minimum time to wait between mutation events, in milliseconds.
+ *
+ * @type {number}
+ */
+export const modificationDebounceTimer = 450;


### PR DESCRIPTION
This PR adds the option to disable updates when DOM mutations are observed or inputs are changed inside the element tree of a rendered block. Disabling this behavior is as simple as adding a getter to the block's class:

```typescript
class ExampleBlock extends BlockTool {
  public static get shouldUpdateOnMutation(): boolean {
    return false;
  }
}
```

After this, the block should use `dispatchChange()` whenever it needs to trigger an update.

### Context

I'm currently implementing custom Blocks on a project using React. It uses a portal to render React components inside the wrapper element returned by the `render()` method, and it works quite well.

However, every time React updates the DOM inside this portal, the EditorJS instance triggers an update since its MutationObserver is always listening for mutations inside the block. This is undesirable for performance reasons, and this behavior can actually cause loops when interacting with React states.

To fix this, I've added `shouldUpdateOnMutation` and every time my internal React component updates its internal data state, it calls `dispatchChange()` to tell EditorJS that a change occurred.

The code in this PR is heavily based on the solution found in #2205, created by @medzhidov (thanks, by the way!). I've only changed the name of the option, since my implementation also disables listening for input changes in the block's element tree.

Side note: I intend to release the code that allows users to implement Blocks as React components as a library in the near future. I'll definitely let people know when I do so.