### PR TITLE
ci(tests): improve workflow for running tests

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -28,7 +28,7 @@ jobs:
           browser: chrome
           build: yarn build
   edge:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'cypress'
+import { defineConfig } from 'cypress';
 
 export default defineConfig({
   env: {
@@ -11,9 +11,9 @@ export default defineConfig({
     // We've imported your old cypress plugins here.
     // You may want to clean this up later by importing these.
     setupNodeEvents(on, config) {
-      return require('./test/cypress/plugins/index.ts')(on, config)
+      return require('./test/cypress/plugins/index.ts')(on, config);
     },
     specPattern: 'test/cypress/tests/**/*.cy.{js,jsx,ts,tsx}',
     supportFile: 'test/cypress/support/index.ts',
   },
-})
+});

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `Improvement` — *Dependencies* — Upgrade TypeScript to v5.
 - `Fix` — *ToolsAPI* — `pasteConfig` getter with `false` value could be used to disable paste handling by Editor.js core. Could be useful if your tool has its own paste handler.
 - `Improvement` — *Dependencies* — Upgrade Cypress to v12, upgrade related libraries to latest versions.
+- `CI` — Use Ubuntu container for Edge tests runner.
 
 ### 2.26.5
 


### PR DESCRIPTION
I changed the container for Edge browser tests because of the official example: https://github.com/cypress-io/github-action#edge. Now, CI for Edge is more stable. Also, CI is faster now. 6-8m vs 12-14m.