### PR TITLE
fix(ci): release drafter now uses node 16

### DIFF
--- a/.github/workflows/create-a-release-draft.yml
+++ b/.github/workflows/create-a-release-draft.yml
@@ -12,6 +12,9 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       # Checkout to target branch
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/publish-package-to-npm.yml
+++ b/.github/workflows/publish-package-to-npm.yml
@@ -22,7 +22,7 @@ jobs:
       # Setup node environment
       - uses: actions/setup-node@v1
         with:
-          node-version: 14.17.0
+          node-version: 16
           registry-url: https://registry.npmjs.org/
 
       # Prepare, build and publish project


### PR DESCRIPTION
Fixes [broken CI](https://github.com/codex-team/editor.js/actions/runs/4961720362/jobs/8878875630#step:4:14):

```
error supports-hyperlinks@3.0.0: The engine "node" is incompatible with this module. Expected version ">=14.18". Got "14.17.0"
````