### PR TITLE
Change calculating toolbar right orientation

### DIFF
--- a/src/components/modules/toolbar/inline.ts
+++ b/src/components/modules/toolbar/inline.ts
@@ -194,7 +194,7 @@ export default class InlineToolbar extends Module<InlineToolbarNodes> {
 
     this.nodes.wrapper.classList.toggle(
       this.CSS.inlineToolbarRightOriented,
-      realRightCoord > this.Editor.UI.contentRect.right
+      realRightCoord > this.Editor.UI.contentRect.width
     );
 
     this.nodes.wrapper.style.left = Math.floor(newCoords.x) + 'px';


### PR DESCRIPTION
use contentRect.width when calculating toolbar orientation. Fix #2268


newCoords are calculated relative to wrapper 
![image](https://github.com/codex-team/editor.js/assets/48745722/311abdf0-2b57-44e1-b97a-32a9071b275e)

so we need to compare realRightCoord with wrapper width not it's right coordinate
![image](https://github.com/codex-team/editor.js/assets/48745722/e537c303-3acf-4333-96fb-9f10839d0e73)