### PR TITLE
fix(onchange): callback will be fired on removing of a whole text

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.27.1
+
+- `Fix` - `onChange` will be called on removing the whole text in the last block
+
 ### 2.27.0
 
 - `New` — *Toolbar API* — Added a new method for toggling the toolbox.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/editorjs",
-  "version": "2.27.0",
+  "version": "2.27.1",
   "description": "Editor.js — Native JS, based on API and Open Source",
   "main": "dist/editorjs.umd.js",
   "module": "dist/editorjs.mjs",

--- a/src/components/utils/mutations.ts
+++ b/src/components/utils/mutations.ts
@@ -8,6 +8,15 @@ export function isMutationBelongsToElement(mutationRecord: MutationRecord, eleme
   const { type, target, addedNodes, removedNodes } = mutationRecord;
 
   /**
+   * In case of removing the whole text in element, mutation type will be 'childList',
+   * 'removedNodes' will contain text node that is not existed anymore, so we can't check it with 'contains' method
+   * But Target will be the element itself, so we can detect it.
+   */
+  if (target === element) {
+    return true;
+  }
+
+  /**
    * Check typing and attributes changes
    */
   if (['characterData', 'attributes'].includes(type)) {

--- a/test/cypress/tests/onchange.cy.ts
+++ b/test/cypress/tests/onchange.cy.ts
@@ -489,7 +489,7 @@ describe('onChange callback', () => {
     });
   });
 
-  it.only('should be fired when the whole text inside block is removed', () => {
+  it('should be fired when the whole text inside block is removed', () => {
     createEditor([ {
       type: 'paragraph',
       data: {

--- a/test/cypress/tests/onchange.cy.ts
+++ b/test/cypress/tests/onchange.cy.ts
@@ -488,4 +488,25 @@ describe('onChange callback', () => {
       cy.get('@onChange').should('have.callCount', 0);
     });
   });
+
+  it.only('should be fired when the whole text inside block is removed', () => {
+    createEditor([ {
+      type: 'paragraph',
+      data: {
+        text: 'a',
+      },
+    } ]);
+
+    cy.get('[data-cy=editorjs')
+      .get('div.ce-block')
+      .click()
+      .type('{backspace}');
+
+    cy.get('@onChange').should('be.calledWithMatch', EditorJSApiMock, Cypress.sinon.match({
+      type: BlockChangedMutationType,
+      detail: {
+        index: 0,
+      },
+    }));
+  });
 });


### PR DESCRIPTION
Bug:

1. Open editor with the only block
2. Type something, select all text and press Backspace
3. on change was not triggered

The problem happened because MutationObserver called with `childList` record that contains `removedNodes` with `TextNode` that is not existed on a page anymore, so we can't check it with 'contains' method.

Resolves #2386
Resolves #2384
