### PR TITLE
fix(onchange): support data-mutation-free on attributes change

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+### 2.27.2
+
+- `Fix` - `onChange` won't be called when element with data-mutation-free changes some attribute
+
 ### 2.27.1
 
-- `Fix` - `onChange` will be called on removing the whole text in the last block
+- `Fix` - `onChange` will be called on removing the whole text in a block
 
 ### 2.27.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/editorjs",
-  "version": "2.27.1",
+  "version": "2.27.2",
   "description": "Editor.js — Native JS, based on API and Open Source",
   "main": "dist/editorjs.umd.js",
   "module": "dist/editorjs.mjs",

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -878,10 +878,11 @@ export default class Block extends EventsDispatcher<BlockEvents> {
        *    — we should fire 'didMutated' event in that case
        */
       const everyRecordIsMutationFree = mutationsOrInputEvent.length > 0 && mutationsOrInputEvent.every((record) => {
-        const { addedNodes, removedNodes } = record;
+        const { addedNodes, removedNodes, target } = record;
         const changedNodes = [
           ...Array.from(addedNodes),
           ...Array.from(removedNodes),
+          target,
         ];
 
         return changedNodes.some((node) => {


### PR DESCRIPTION
For now, `data-mutation-free` works only on `addedNodes` and `removedNodes` of a mutation record. This PR also adds a support for "attributes" mutation type — we need to check record `target` as well.

For example, Table tool fires unnecessary `onChange` callings (See https://github.com/editor-js/table/issues/125) when hovering on a table cells. That is [fixed](https://github.com/editor-js/table/pull/129) by adding a `data-mutation-free` attribute. But that fix requires this PR to be merged

![image](https://github.com/codex-team/editor.js/assets/3684889/58bdf8f1-c346-4fa9-b569-06ede7b935f2)

