### PR TITLE
chore(api): blocks.update(id, data) method improved

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `Improvement` - The stub-block style simplified.
 - `Improvement` - If some Block's tool will throw an error during construction, we will show Stub block instead of skipping it during render
 - `Improvement` - Call of `blocks.clear()` now will trigger onChange will "block-removed" event for all removed blocks.
+- `Improvement` - `BlockMutationType` and `BlockMutationEvent` types exported
 
 ### 2.27.2
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,8 +3,8 @@
 ### 2.28.0
 
 - `New` - Block ids now displayed in DOM via a data-id attribute. Could be useful for plugins that want access a Block's element by id.
-- `New` - The `blocks.convert(blockId, newType)` API method added. It allows to convert existed Block to a Block of another type.
-- `New` - The `blocks.insertMany()` API method added. It allows to insert several Blocks to specified index.
+- `New` - The `blocks.convert(blockId, newType)` API method added. It allows to convert existing Block to a Block of another type.
+- `New` - The `blocks.insertMany()` API method added. It allows to insert several Blocks to the specified index.
 - `Improvement` - The Delete keydown at the end of the Block will now work opposite a Backspace at the start. Next Block will be removed (if empty) or merged with the current one.
 - `Improvement` - The Delete keydown will work like a Backspace when several Blocks are selected.
 - `Improvement` - If we have two empty Blocks, and press Backspace at the start of the second one, the previous will be removed instead of current.
@@ -17,8 +17,11 @@
 - `Improvement` - "I'm ready" log removed
 - `Improvement` - The stub-block style simplified.
 - `Improvement` - If some Block's tool will throw an error during construction, we will show Stub block instead of skipping it during render
-- `Improvement` - Call of `blocks.clear()` now will trigger onChange will "block-removed" event for all removed blocks.
+- `Improvement` - Call of `blocks.clear()` now will trigger onChange with "block-removed" event for all removed blocks.
 - `Improvement` - `BlockMutationType` and `BlockMutationEvent` types exported
+- `Improvement` - `blocks.update(id, data)` now can accept partial data object — it will update only passed properties, others will remain the same.
+- `Improvement` - `blocks.update(id, data)` now will trigger onChange with only `block-change` event.
+- `Improvement` - `blocks.update(id, data)` will return a promise with BlockAPI object of changed block.
 
 ### 2.27.2
 

--- a/src/components/blocks.ts
+++ b/src/components/blocks.ts
@@ -221,6 +221,24 @@ export default class Blocks {
   }
 
   /**
+   * Replaces block under passed index with passed block
+   *
+   * @param index - index of existed block
+   * @param block - new block
+   */
+  public replace(index: number, block: Block): void {
+    if (this.blocks[index] === undefined) {
+      throw Error('Incorrect index');
+    }
+
+    const prevBlock = this.blocks[index];
+
+    prevBlock.holder.replaceWith(block.holder);
+
+    this.blocks[index] = block;
+  }
+
+  /**
    * Inserts several blocks at once
    *
    * @param blocks - blocks to insert

--- a/src/components/modules/api/blocks.ts
+++ b/src/components/modules/api/blocks.ts
@@ -297,26 +297,19 @@ export default class BlocksAPI extends Module {
    * @param id - id of the block to update
    * @param data - the new data
    */
-  public update = (id: string, data: BlockToolData): void => {
+  public update = async (id: string, data: Partial<BlockToolData>): Promise<BlockAPIInterface> => {
     const { BlockManager } = this.Editor;
     const block = BlockManager.getBlockById(id);
 
-    if (!block) {
-      _.log('blocks.update(): Block with passed id was not found', 'warn');
-
-      return;
+    if (block === undefined) {
+      throw new Error('Block with passed id was not found');
     }
 
-    const blockIndex = BlockManager.getBlockIndex(block);
+    const updatedBlock = await BlockManager.update(block, data);
 
-    BlockManager.insert({
-      id: block.id,
-      tool: block.name,
-      data,
-      index: blockIndex,
-      replace: true,
-      tunes: block.tunes,
-    });
+    // we cast to any because our BlockAPI has no "new" signature
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return new (BlockAPI as any)(updatedBlock);
   };
 
   /**

--- a/src/components/modules/api/blocks.ts
+++ b/src/components/modules/api/blocks.ts
@@ -302,7 +302,7 @@ export default class BlocksAPI extends Module {
     const block = BlockManager.getBlockById(id);
 
     if (block === undefined) {
-      throw new Error('Block with passed id was not found');
+      throw new Error(`Block with id "${id}" not found`);
     }
 
     const updatedBlock = await BlockManager.update(block, data);

--- a/src/components/modules/blockManager.ts
+++ b/src/components/modules/blockManager.ts
@@ -334,6 +334,36 @@ export default class BlockManager extends Module {
   }
 
   /**
+   * Update Block data.
+   *
+   * Currently we don't have an 'update' method in the Tools API, so we just create a new block with the same id and type
+   * Should not trigger 'block-removed' or 'block-added' events
+   *
+   * @param block - block to update
+   * @param data - new data
+   */
+  public async update(block: Block, data: Partial<BlockToolData>): Promise<Block> {
+    const existingData = await block.data;
+
+    const newBlock = this.composeBlock({
+      id: block.id,
+      tool: block.name,
+      data: Object.assign({}, existingData, data),
+      tunes: block.tunes,
+    });
+
+    const blockIndex = this.getBlockIndex(block);
+
+    this._blocks.replace(blockIndex, newBlock);
+
+    this.blockDidMutated(BlockChangedMutationType, newBlock, {
+      index: blockIndex,
+    });
+
+    return newBlock;
+  }
+
+  /**
    * Replace passed Block with the new one with specified Tool and data
    *
    * @param block - block to replace

--- a/test/cypress/fixtures/types/PartialBlockMutationEvent.ts
+++ b/test/cypress/fixtures/types/PartialBlockMutationEvent.ts
@@ -1,0 +1,16 @@
+import { BlockMutationEvent, BlockMutationType } from '../../../../types';
+
+/**
+ * Simplified version of the BlockMutationEvent with optional fields that could be used in tests
+ */
+export default interface PartialBlockMutationEvent {
+  /**
+   * Event type
+   */
+  type?: BlockMutationType,
+
+  /**
+   * Details with partial properties
+   */
+  detail?: Partial<BlockMutationEvent['detail']>
+}

--- a/test/cypress/support/e2e.ts
+++ b/test/cypress/support/e2e.ts
@@ -1,0 +1,55 @@
+
+/* global chai */
+// because this file is imported from cypress/support/e2e.js
+// that means all other spec files will have this assertion plugin
+// available to them because the supportFile is bundled and served
+// prior to any spec files loading
+
+/**
+ * Chai plugin for checking if passed onChange method is called with an array of passed events
+ *
+ * @param _chai - Chai instance
+ */
+const beCalledWithBatchedEvents = (_chai): void => {
+  /**
+   * Check if passed onChange method is called with an array of passed events
+   *
+   * @param expectedEvents - batched events to check
+   */
+  function assertToBeCalledWithBatchedEvents(expectedEvents): void {
+    /**
+     * EditorJS API is passed as the first parameter of the onChange callback
+     */
+    const EditorJSApiMock = Cypress.sinon.match.any;
+    const $onChange = this._obj;
+
+    this.assert(
+      $onChange.calledOnce,
+      'expected #{this} to be called once',
+      'expected #{this} to not be called once'
+    );
+
+    this.assert(
+      $onChange.calledWithMatch(
+        EditorJSApiMock,
+        Cypress.sinon.match((events) => {
+          return events.every((event, index) => {
+            const eventToCheck = expectedEvents[index];
+
+            return expect(event).to.containSubset(eventToCheck);
+          });
+        })
+      ),
+      'expected #{this} to be called with #{exp}, but it was called with #{act}',
+      'expected #{this} to not be called with #{exp}, but it was called with #{act} ',
+      expectedEvents
+    );
+  }
+
+  _chai.Assertion.addMethod('calledWithBatchedEvents', assertToBeCalledWithBatchedEvents);
+};
+
+/**
+ * registers our assertion function "beCalledWithBatchedEvents" with Chai
+ */
+chai.use(beCalledWithBatchedEvents);

--- a/test/cypress/support/e2e.ts
+++ b/test/cypress/support/e2e.ts
@@ -5,6 +5,8 @@
 // available to them because the supportFile is bundled and served
 // prior to any spec files loading
 
+import PartialBlockMutationEvent from '../fixtures/types/PartialBlockMutationEvent';
+
 /**
  * Chai plugin for checking if passed onChange method is called with an array of passed events
  *
@@ -16,7 +18,7 @@ const beCalledWithBatchedEvents = (_chai): void => {
    *
    * @param expectedEvents - batched events to check
    */
-  function assertToBeCalledWithBatchedEvents(expectedEvents): void {
+  function assertToBeCalledWithBatchedEvents(expectedEvents: PartialBlockMutationEvent | PartialBlockMutationEvent[]): void {
     /**
      * EditorJS API is passed as the first parameter of the onChange callback
      */
@@ -32,7 +34,9 @@ const beCalledWithBatchedEvents = (_chai): void => {
     this.assert(
       $onChange.calledWithMatch(
         EditorJSApiMock,
-        Cypress.sinon.match((events) => {
+        Cypress.sinon.match((events: PartialBlockMutationEvent[]) => {
+          expect(events).to.be.an('array');
+
           return events.every((event, index) => {
             const eventToCheck = expectedEvents[index];
 

--- a/test/cypress/support/e2e.ts
+++ b/test/cypress/support/e2e.ts
@@ -18,7 +18,7 @@ const beCalledWithBatchedEvents = (_chai): void => {
    *
    * @param expectedEvents - batched events to check
    */
-  function assertToBeCalledWithBatchedEvents(expectedEvents: PartialBlockMutationEvent | PartialBlockMutationEvent[]): void {
+  function assertToBeCalledWithBatchedEvents(expectedEvents: PartialBlockMutationEvent[]): void {
     /**
      * EditorJS API is passed as the first parameter of the onChange callback
      */

--- a/test/cypress/support/index.d.ts
+++ b/test/cypress/support/index.d.ts
@@ -1,9 +1,17 @@
-// in cypress/support/index.d.ts
 // load type definitions that come with Cypress module
 /// <reference types="cypress" />
 
 import type { EditorConfig, OutputData } from './../../../types/index';
 import type EditorJS from '../../../types/index'
+import type { BlockMutationEvent, BlockMutationType } from '../../../types/index'
+
+/**
+ * Simplified version of the BlockMutationEvent with optional fields that could be used in tests
+ */
+interface PartialBlockMutationEvent {
+  type?: BlockMutationType,
+  detail?: Partial<BlockMutationEvent['detail']>
+}
 
 declare global {
   namespace Cypress {
@@ -65,6 +73,22 @@ declare global {
     interface ApplicationWindow {
       EditorJS: typeof EditorJS
     }
+
+    /**
+     * Extends Cypress assertion Chainer interface with the new assertion methods
+     */
+    interface Chainer<Subject> {
+      /**
+       * Custom Chai assertion that checks if given onChange method is called with an array of passed events
+       *
+       * @example
+       *   ```
+       *   cy.get('@onChange').should('be.calledWithBatchedEvents', [{ type: 'block-added', detail: { index: 0 }}])
+       *   expect(onChange).to.be.calledWithBatchedEvents([{ type: 'block-added', detail: { index: 0 }}])
+       *   ```
+       */
+      (chainer: 'be.calledWithBatchedEvents', expectedEvents: PartialBlockMutationEvent[]): Chainable<Subject>;
+    }
   }
 
   /**
@@ -76,6 +100,17 @@ declare global {
        * "containSubset" object properties matcher
        */
       containSubset(subset: any): Assertion;
+
+      /**
+       * Custom Chai assertion that checks if given onChange method is called with an array of passed events
+       *
+       * @example
+       *   ```
+       *   cy.get('@onChange').should('be.calledWithBatchedEvents', [{ type: 'block-added', detail: { index: 0 }}])
+       *   expect(onChange).to.be.calledWithBatchedEvents([{ type: 'block-added', detail: { index: 0 }}])
+       *   ```
+       */
+      calledWithBatchedEvents(expectedEvents: PartialBlockMutationEvent[]): Assertion;
     }
   }
 }

--- a/test/cypress/support/index.d.ts
+++ b/test/cypress/support/index.d.ts
@@ -79,7 +79,7 @@ declare global {
        *   expect(onChange).to.be.calledWithBatchedEvents([{ type: 'block-added', detail: { index: 0 }}])
        *   ```
        */
-      (chainer: 'be.calledWithBatchedEvents', expectedEvents: PartialBlockMutationEvent[] | PartialBlockMutationEvent): Chainable<Subject>;
+      (chainer: 'be.calledWithBatchedEvents', expectedEvents: PartialBlockMutationEvent[]): Chainable<Subject>;
     }
   }
 
@@ -102,7 +102,7 @@ declare global {
        *   expect(onChange).to.be.calledWithBatchedEvents([{ type: 'block-added', detail: { index: 0 }}])
        *   ```
        */
-      calledWithBatchedEvents(expectedEvents: PartialBlockMutationEvent[] | PartialBlockMutationEvent): Assertion;
+      calledWithBatchedEvents(expectedEvents: PartialBlockMutationEvent[]): Assertion;
     }
   }
 }

--- a/test/cypress/support/index.d.ts
+++ b/test/cypress/support/index.d.ts
@@ -3,15 +3,7 @@
 
 import type { EditorConfig, OutputData } from './../../../types/index';
 import type EditorJS from '../../../types/index'
-import type { BlockMutationEvent, BlockMutationType } from '../../../types/index'
-
-/**
- * Simplified version of the BlockMutationEvent with optional fields that could be used in tests
- */
-interface PartialBlockMutationEvent {
-  type?: BlockMutationType,
-  detail?: Partial<BlockMutationEvent['detail']>
-}
+import PartialBlockMutationEvent from '../fixtures/types/PartialBlockMutationEvent';
 
 declare global {
   namespace Cypress {
@@ -87,7 +79,7 @@ declare global {
        *   expect(onChange).to.be.calledWithBatchedEvents([{ type: 'block-added', detail: { index: 0 }}])
        *   ```
        */
-      (chainer: 'be.calledWithBatchedEvents', expectedEvents: PartialBlockMutationEvent[]): Chainable<Subject>;
+      (chainer: 'be.calledWithBatchedEvents', expectedEvents: PartialBlockMutationEvent[] | PartialBlockMutationEvent): Chainable<Subject>;
     }
   }
 
@@ -110,7 +102,7 @@ declare global {
        *   expect(onChange).to.be.calledWithBatchedEvents([{ type: 'block-added', detail: { index: 0 }}])
        *   ```
        */
-      calledWithBatchedEvents(expectedEvents: PartialBlockMutationEvent[]): Assertion;
+      calledWithBatchedEvents(expectedEvents: PartialBlockMutationEvent[] | PartialBlockMutationEvent): Assertion;
     }
   }
 }

--- a/test/cypress/support/index.ts
+++ b/test/cypress/support/index.ts
@@ -16,6 +16,11 @@ installLogsCollector();
  */
 import './commands';
 
+/**
+ * File with custom assertions
+ */
+import './e2e';
+
 import chaiSubset from 'chai-subset';
 
 /**

--- a/test/cypress/tests/api/blocks.cy.ts
+++ b/test/cypress/tests/api/blocks.cy.ts
@@ -108,7 +108,7 @@ describe('api.blocks', () => {
     it('shouldn\'t update any block if not-existed id passed', () => {
       cy.createEditor({
         data: editorDataMock,
-      }).then(async (editor) => {
+      }).then((editor) => {
         const idToUpdate = 'wrong-id-123';
         const newBlockData = {
           text: 'Updated text',

--- a/test/cypress/tests/api/blocks.cy.ts
+++ b/test/cypress/tests/api/blocks.cy.ts
@@ -108,19 +108,23 @@ describe('api.blocks', () => {
     it('shouldn\'t update any block if not-existed id passed', () => {
       cy.createEditor({
         data: editorDataMock,
-      }).then((editor) => {
+      }).then(async (editor) => {
         const idToUpdate = 'wrong-id-123';
         const newBlockData = {
           text: 'Updated text',
         };
 
-        editor.blocks.update(idToUpdate, newBlockData);
-
-        cy.get('[data-cy=editorjs]')
-          .get('div.ce-block')
-          .invoke('text')
-          .then(blockText => {
-            expect(blockText).to.be.eq(firstBlock.data.text);
+        editor.blocks.update(idToUpdate, newBlockData)
+          .catch(error => {
+            expect(error.message).to.be.eq(`Block with id "${idToUpdate}" not found`);
+          })
+          .finally(() => {
+            cy.get('[data-cy=editorjs]')
+              .get('div.ce-block')
+              .invoke('text')
+              .then(blockText => {
+                expect(blockText).to.be.eq(firstBlock.data.text);
+              });
           });
       });
     });
@@ -161,7 +165,7 @@ describe('api.blocks', () => {
             {
               type: 'paragraph',
               data: { text: 'first block' },
-            }
+            },
           ],
         },
       }).then((editor) => {

--- a/test/cypress/tests/onchange.cy.ts
+++ b/test/cypress/tests/onchange.cy.ts
@@ -105,22 +105,20 @@ describe('onChange callback', () => {
       .type('change')
       .type('{enter}');
 
-    cy.get('@onChange').should(($callback) => {
-      return beCalledWithBatchedEvents($callback, [
-        {
-          type: BlockChangedMutationType,
-          detail: {
-            index: 0,
-          },
+    cy.get('@onChange').should('be.calledWithBatchedEvents', [
+      {
+        type: BlockChangedMutationType,
+        detail: {
+          index: 0,
         },
-        {
-          type: BlockAddedMutationType,
-          detail: {
-            index: 1,
-          },
+      },
+      {
+        type: BlockAddedMutationType,
+        detail: {
+          index: 1,
         },
-      ]);
-    });
+      },
+    ]);
   });
 
   it('should filter out similar events on batching', () => {

--- a/test/cypress/tests/onchange.cy.ts
+++ b/test/cypress/tests/onchange.cy.ts
@@ -7,31 +7,10 @@ import { BlockRemovedMutationType } from '../../../types/events/block/BlockRemov
 import { BlockMovedMutationType } from '../../../types/events/block/BlockMoved';
 import type EditorJS from '../../../types/index';
 
-
 /**
  * EditorJS API is passed as the first parameter of the onChange callback
  */
 const EditorJSApiMock = Cypress.sinon.match.any;
-
-/**
- * Check if passed onChange method is called with an array of passed events
- *
- * @param $onChange - editor onChange spy
- * @param expectedEvents - batched events to check
- */
-function beCalledWithBatchedEvents($onChange, expectedEvents): void {
-  expect($onChange).to.be.calledOnce;
-  expect($onChange).to.be.calledWithMatch(
-    EditorJSApiMock,
-    Cypress.sinon.match((events) => {
-      return events.every((event, index) => {
-        const eventToCheck = expectedEvents[index];
-
-        return expect(event).to.containSubset(eventToCheck);
-      });
-    })
-  );
-}
 
 /**
  * @todo Add checks that correct block API object is passed to onChange
@@ -241,37 +220,35 @@ describe('onChange callback', () => {
       .get('div.ce-popover-item[data-item-name=delimiter]')
       .click();
 
-    cy.get('@onChange').should(($callback) => {
-      return beCalledWithBatchedEvents($callback, [
-        {
-          type: BlockRemovedMutationType,
-          detail: {
-            index: 0,
-            target: {
-              name: 'paragraph',
-            },
+    cy.get('@onChange').should('be.calledWithBatchedEvents', [
+      {
+        type: BlockRemovedMutationType,
+        detail: {
+          index: 0,
+          target: {
+            name: 'paragraph',
           },
         },
-        {
-          type: BlockAddedMutationType,
-          detail: {
-            index: 0,
-            target: {
-              name: 'delimiter',
-            },
+      },
+      {
+        type: BlockAddedMutationType,
+        detail: {
+          index: 0,
+          target: {
+            name: 'delimiter',
           },
         },
-        {
-          type: BlockAddedMutationType,
-          detail: {
-            index: 1,
-            target: {
-              name: 'paragraph',
-            },
+      },
+      {
+        type: BlockAddedMutationType,
+        detail: {
+          index: 1,
+          target: {
+            name: 'paragraph',
           },
         },
-      ]);
-    });
+      },
+    ]);
   });
 
   it('should be fired on block replacement for both of blocks', () => {
@@ -289,28 +266,26 @@ describe('onChange callback', () => {
       .get('div.ce-popover-item[data-item-name=header]')
       .click();
 
-    cy.get('@onChange').should(($callback) => {
-      return beCalledWithBatchedEvents($callback, [
-        {
-          type: BlockRemovedMutationType,
-          detail: {
-            index: 0,
-            target: {
-              name: 'paragraph',
-            },
+    cy.get('@onChange').should('be.calledWithBatchedEvents', [
+      {
+        type: BlockRemovedMutationType,
+        detail: {
+          index: 0,
+          target: {
+            name: 'paragraph',
           },
         },
-        {
-          type: BlockAddedMutationType,
-          detail: {
-            index: 0,
-            target: {
-              name: 'header',
-            },
+      },
+      {
+        type: BlockAddedMutationType,
+        detail: {
+          index: 0,
+          target: {
+            name: 'header',
           },
         },
-      ]);
-    });
+      },
+    ]);
   });
 
   it('should be fired on tune modifying', () => {
@@ -373,28 +348,26 @@ describe('onChange callback', () => {
       .get('div[data-item-name=delete]')
       .click();
 
-    cy.get('@onChange').should(($callback) => {
-      return beCalledWithBatchedEvents($callback, [
-        /**
-         * "block-removed" fired since we have deleted a block
-         */
-        {
-          type: BlockRemovedMutationType,
-          detail: {
-            index: 0,
-          },
+    cy.get('@onChange').should('be.calledWithBatchedEvents', [
+      /**
+       * "block-removed" fired since we have deleted a block
+       */
+      {
+        type: BlockRemovedMutationType,
+        detail: {
+          index: 0,
         },
-        /**
-         * "block-added" fired since we have deleted the last block, so the new one is created
-         */
-        {
-          type: BlockAddedMutationType,
-          detail: {
-            index: 0,
-          },
+      },
+      /**
+       * "block-added" fired since we have deleted the last block, so the new one is created
+       */
+      {
+        type: BlockAddedMutationType,
+        detail: {
+          index: 0,
         },
-      ]);
-    });
+      },
+    ]);
   });
 
   it('should be fired when block is moved', () => {
@@ -592,19 +565,17 @@ describe('onChange callback', () => {
         cy.wrap(editor.blocks.clear());
       });
 
-    cy.get('@onChange').should(($callback) => {
-      return beCalledWithBatchedEvents($callback, [
-        {
-          type: BlockRemovedMutationType,
-        },
-        {
-          type: BlockRemovedMutationType,
-        },
-        {
-          type: BlockAddedMutationType,
-        },
-      ]);
-    });
+    cy.get('@onChange').should('be.calledWithBatchedEvents', [
+      {
+        type: BlockRemovedMutationType,
+      },
+      {
+        type: BlockRemovedMutationType,
+      },
+      {
+        type: BlockAddedMutationType,
+      },
+    ]);
   });
 
   it('should be called on blocks.render() on non-empty editor with removed blocks', () => {
@@ -637,15 +608,52 @@ describe('onChange callback', () => {
         }));
       });
 
-    cy.get('@onChange').should(($callback) => {
-      return beCalledWithBatchedEvents($callback, [
-        {
-          type: BlockRemovedMutationType,
-        },
-        {
-          type: BlockRemovedMutationType,
-        },
-      ]);
-    });
+    cy.get('@onChange').should('be.calledWithBatchedEvents', [
+      {
+        type: BlockRemovedMutationType,
+      },
+      {
+        type: BlockRemovedMutationType,
+      },
+    ]);
+  });
+
+  it('should be called on blocks.update() with "block-changed" event', () => {
+    const block = {
+      id: 'bwnFX5LoX7',
+      type: 'paragraph',
+      data: {
+        text: 'The first block mock.',
+      },
+    };
+    const config = {
+      data: {
+        blocks: [
+          block,
+        ],
+      },
+      onChange: (api, event): void => {
+        console.log('something changed', event);
+      },
+    };
+
+    cy.spy(config, 'onChange').as('onChange');
+
+    cy.createEditor(config)
+      .then((editor) => {
+        editor.blocks.update(block.id, {
+          text: 'Updated text',
+        });
+
+        cy.get('@onChange').should('be.calledWithMatch', EditorJSApiMock, Cypress.sinon.match({
+          type: BlockChangedMutationType,
+          detail: {
+            index: 0,
+            target: {
+              id: block.id,
+            },
+          },
+        }));
+      });
   });
 });

--- a/types/api/blocks.d.ts
+++ b/types/api/blocks.d.ts
@@ -134,9 +134,9 @@ export interface Blocks {
    * Updates block data by id
    *
    * @param id - id of the block to update
-   * @param data - the new data
+   * @param data - the new data. Can be partial.
    */
-  update(id: string, data: BlockToolData): void;
+  update(id: string, data: Partial<BlockToolData>): Promise<BlockAPI>;
 
   /**
    * Converts block to another type. Both blocks should provide the conversionConfig.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -31,7 +31,7 @@ import {
 } from './api';
 
 import { OutputData } from './data-formats';
-import { BlockMutationEventMap } from './events/block';
+import { BlockMutationEvent, BlockMutationEventMap, BlockMutationType } from './events/block';
 import { BlockAddedMutationType, BlockAddedEvent } from './events/block/BlockAdded';
 import { BlockChangedMutationType, BlockChangedEvent } from './events/block/BlockChanged';
 import { BlockMovedMutationType, BlockMovedEvent } from './events/block/BlockMoved';
@@ -85,6 +85,8 @@ export { OutputData, OutputBlockData} from './data-formats/output-data';
 export { BlockId } from './data-formats/block-id';
 export { BlockAPI } from './api'
 export {
+  BlockMutationType,
+  BlockMutationEvent,
   BlockMutationEventMap,
   BlockAddedMutationType,
   BlockAddedEvent,


### PR DESCRIPTION
1. `blocks.update(id, data)` previously triggers onChange with `block-removed`, `block-added`, `block-changed` events. Now it will trigger only `block-changed` 
2. `blocks.update(id, data)` now can accept partial data to update. It will be merged with existing data
3. `blocks.update(id, data)` now will return `Promise<BlockAPI>`
4. Custom Chai assertion `be.calledWithBatchedEvents` implemented
5. `BlockMutationType` and `BlockMutationEvent` types exported