### PR TITLE
fixed Caret.isAtStart

### DIFF
--- a/src/components/modules/caret.ts
+++ b/src/components/modules/caret.ts
@@ -61,7 +61,6 @@ export default class Caret extends Module {
     }
 
 
-
     /**
      * If caret was set by external code, it might be set to text node wrapper.
      * <div>|hello</div> <---- Selection references to <div> instead of text node
@@ -109,7 +108,7 @@ export default class Caret extends Module {
         return $.isEmpty(node) && !isLineBreak;
       });
 
-      if (nothingAtLeft && focusOffset===0) {
+      if (nothingAtLeft && focusOffset === 0) {
         return true;
       }
     }
@@ -119,7 +118,7 @@ export default class Caret extends Module {
      * "| Hello"  <--- selection.anchorOffset is 0, but firstLetterPosition is 1
      */
 
-    return firstNode === null || (focusNode === firstNode && focusOffset ===0);
+    return firstNode === null || (focusNode === firstNode && focusOffset === 0);
   }
 
   /**

--- a/src/components/modules/caret.ts
+++ b/src/components/modules/caret.ts
@@ -60,18 +60,7 @@ export default class Caret extends Module {
       return false;
     }
 
-    /**
-     * Workaround case when caret in the text like " |Hello!"
-     * selection.anchorOffset is 1, but real caret visible position is 0
-     *
-     * @type {number}
-     */
 
-    let firstLetterPosition = focusNode.textContent.search(/\S/);
-
-    if (firstLetterPosition === -1) { // empty text
-      firstLetterPosition = 0;
-    }
 
     /**
      * If caret was set by external code, it might be set to text node wrapper.
@@ -120,7 +109,7 @@ export default class Caret extends Module {
         return $.isEmpty(node) && !isLineBreak;
       });
 
-      if (nothingAtLeft && focusOffset === firstLetterPosition) {
+      if (nothingAtLeft && focusOffset===0) {
         return true;
       }
     }
@@ -129,7 +118,8 @@ export default class Caret extends Module {
      * We use <= comparison for case:
      * "| Hello"  <--- selection.anchorOffset is 0, but firstLetterPosition is 1
      */
-    return firstNode === null || (focusNode === firstNode && focusOffset <= firstLetterPosition);
+
+    return firstNode === null || (focusNode === firstNode && focusOffset ===0);
   }
 
   /**

--- a/test/cypress/tests/modules/BlockEvents/Backspace.cy.ts
+++ b/test/cypress/tests/modules/BlockEvents/Backspace.cy.ts
@@ -56,6 +56,31 @@ describe('Backspace keydown', function () {
       .should('have.text', 'The second bloc'); // last char is removed
   });
 
+  it('should just delete preceding white spaces (native behaviour) on click of backspace when Caret is not at the start of the Block', function () {
+    createEditorWithTextBlocks([
+      'The first block',
+      'The second block',
+    ]);
+
+    cy.get('[data-cy=editorjs]')
+      .find('.ce-paragraph')
+      .last()
+      .click()
+      .type('{home}')
+      .type(' ') // adding space at the start of the block
+      .type('{backspace}');
+
+    cy.get('[data-cy=editorjs]')
+      .find('div.ce-block')
+      .last()
+      .should('have.text', `The second block`);
+
+    cy.get('[data-cy=editorjs]')
+      .find('div.ce-block')
+      .first()
+      .should('have.text', `The first block`);
+  });
+
   it('should navigate previous input when Caret is not at the first input', function () {
     /**
      * Mock of tool with several inputs

--- a/test/cypress/tests/modules/BlockEvents/Delete.cy.ts
+++ b/test/cypress/tests/modules/BlockEvents/Delete.cy.ts
@@ -57,6 +57,32 @@ describe('Delete keydown', function () {
       .should('have.text', 'The first bloc'); // last char is removed
   });
 
+  it('should just delete preceding white space (native behaviour) when Caret is not at the end of the Block', function () {
+    createEditorWithTextBlocks([
+      'The first block',
+      'The second block',
+    ]);
+
+    cy.get('[data-cy=editorjs]')
+      .find('.ce-paragraph')
+      .last()
+      .click()
+      .type('{home}')
+      .type(' ') // adding space at the start of the block
+      .type('{leftarrow}') // now caret is at the start of the block
+      .type('{del}');
+
+    cy.get('[data-cy=editorjs]')
+      .find('div.ce-block')
+      .last()
+      .should('have.text', `The second block`);
+
+    cy.get('[data-cy=editorjs]')
+      .find('div.ce-block')
+      .first()
+      .should('have.text', `The first block`);
+  });
+
   it('should navigate next input when Caret is not at the last input', function () {
     /**
      * Mock of tool with several inputs


### PR DESCRIPTION
the current Caret.isAtStart ignores white spaces causing this issue
[#2429](https://github.com/codex-team/editor.js/issues/2429)