### PR TITLE
chore(blocks.render): mutex for onchange added to the blocks.render()

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `Improvement` - The stub-block style simplified.
 - `Improvement` - If some Block's tool will throw an error during construction, we will show Stub block instead of skipping it during render
 - `Improvement` - Call of `blocks.clear()` now will trigger onChange with "block-removed" event for all removed blocks.
+- `Improvement` - The `blocks.clear()` now can be awaited.
 - `Improvement` - `BlockMutationType` and `BlockMutationEvent` types exported
 - `Improvement` - `blocks.update(id, data)` now can accept partial data object — it will update only passed properties, others will remain the same.
 - `Improvement` - `blocks.update(id, data)` now will trigger onChange with only `block-change` event.

--- a/src/components/modules/api/blocks.ts
+++ b/src/components/modules/api/blocks.ts
@@ -18,7 +18,7 @@ export default class BlocksAPI extends Module {
    */
   public get methods(): Blocks {
     return {
-      clear: (): void => this.clear(),
+      clear: (): Promise<void> => this.clear(),
       render: (data: OutputData): Promise<void> => this.render(data),
       renderFromHTML: (data: string): Promise<void> => this.renderFromHTML(data),
       delete: (index?: number): void => this.delete(index),
@@ -172,8 +172,8 @@ export default class BlocksAPI extends Module {
   /**
    * Clear Editor's area
    */
-  public clear(): void {
-    this.Editor.BlockManager.clear(true);
+  public async clear(): Promise<void> {
+    await this.Editor.BlockManager.clear(true);
     this.Editor.InlineToolbar.close();
   }
 
@@ -187,9 +187,16 @@ export default class BlocksAPI extends Module {
       throw new Error('Incorrect data passed to the render() method');
     }
 
-    await this.Editor.BlockManager.clear();
+    /**
+     * Semantic meaning of the "render" method: "Display the new document over the existing one that stays unchanged"
+     * So we need to disable modifications observer temporarily
+     */
+    this.Editor.ModificationsObserver.disable();
 
-    return this.Editor.Renderer.render(data.blocks);
+    await this.Editor.BlockManager.clear();
+    await this.Editor.Renderer.render(data.blocks);
+
+    this.Editor.ModificationsObserver.enable();
   }
 
   /**

--- a/test/cypress/tests/onchange.cy.ts
+++ b/test/cypress/tests/onchange.cy.ts
@@ -578,7 +578,7 @@ describe('onChange callback', () => {
     ]);
   });
 
-  it('should be called on blocks.render() on non-empty editor with removed blocks', () => {
+  it('should not be called on blocks.render() on non-empty editor', () => {
     createEditor([
       {
         type: 'paragraph',
@@ -608,14 +608,7 @@ describe('onChange callback', () => {
         }));
       });
 
-    cy.get('@onChange').should('be.calledWithBatchedEvents', [
-      {
-        type: BlockRemovedMutationType,
-      },
-      {
-        type: BlockRemovedMutationType,
-      },
-    ]);
+    cy.get('@onChange').should('have.callCount', 0);
   });
 
   it('should be called on blocks.update() with "block-changed" event', () => {

--- a/types/api/blocks.d.ts
+++ b/types/api/blocks.d.ts
@@ -9,7 +9,7 @@ export interface Blocks {
   /**
    * Remove all blocks from Editor zone
    */
-  clear(): void;
+  clear(): Promise<void>;
 
   /**
    * Render passed data


### PR DESCRIPTION
## TL;DR

onChange won't be called on `blocks.render()`. Like in 2.27 and before.

## Context

#2430 introduced a few updates:
- `onChange` mutex was removed from Renderer since `Renderer.render()` became awaitable and we just enable Modification Observer after initial rendering:

https://github.com/codex-team/editor.js/blob/be0d33ce0f9947d09e8193b0d670120ec0062594/src/components/core.ts#L54-L62

**So the `onChange` became enabled in the `blocks.render()` API**

- blocks.clear() now triggers `onChange` with removed blocks
https://github.com/codex-team/editor.js/blob/be0d33ce0f9947d09e8193b0d670120ec0062594/src/components/modules/blockManager.ts#L858-L867

Both of these changes are correct and actual. The initial render does not call `onChange` (because a document is not changed), but the `blocks.render()` calls it with removed and added blocks (because an existing document is cleared).

## Problem

During the RC test we got feedback that the `blocks.render()` method is expected to be mutation-free.

## Solution

I thought about it and found three solutions:
- add "silent" option to the `render()` method
- add new API for the onChange enabling/disabling
- just mute onChange inside the `render()`

After all, I've decided to mute onChange inside the render method for two pros:
- it is the same behavior that we have in current version 2.27, so 2.28 won't introduce a breaking change here.
- semantic meaning of the render() method is to display a new document instead of a current that stays unchanged.

Cons:
- It's not obvious that some methods lead `onChange` call, but some are not. I think that we need to redesign the API at all, based on the new Document Model in 3.0.

## Also

`blocks.clear()` now returns a promise. So we can call it before render as a workaround if we want to receive "block-removed" events

```
await editor.blocks.clear(); // onChange will be called
await editor.blocks.render();
```