### PR TITLE
Close Toolbar in blocks.clear method

### DIFF
--- a/src/components/modules/blockManager.ts
+++ b/src/components/modules/blockManager.ts
@@ -880,7 +880,7 @@ export default class BlockManager extends Module {
     });
 
     await queue.completed;
-
+    this.Editor.InlineToolbar.close();
     this.dropPointer();
 
     if (needToAddDefaultBlock) {


### PR DESCRIPTION
We need to close the toolbar when all the blocks are cleared.
#656 