### PR TITLE
fix: inline toolbar incorrectly calculates orientation

### DIFF
--- a/src/components/modules/toolbar/inline.ts
+++ b/src/components/modules/toolbar/inline.ts
@@ -191,12 +191,12 @@ export default class InlineToolbar extends Module<InlineToolbarNodes> {
      */
     this.nodes.wrapper.classList.toggle(
       this.CSS.inlineToolbarLeftOriented,
-      realLeftCoord < this.Editor.UI.contentRect.left
+      realLeftCoord < this.Editor.UI.contentRect.left - wrapperOffset.x
     );
 
     this.nodes.wrapper.classList.toggle(
       this.CSS.inlineToolbarRightOriented,
-      realRightCoord > this.Editor.UI.contentRect.right
+      realRightCoord > this.Editor.UI.contentRect.right - wrapperOffset.x
     );
 
     this.nodes.wrapper.style.left = Math.floor(newCoords.x) + 'px';

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -15,9 +15,10 @@ import Chainable = Cypress.Chainable;
  * Then return the instance
  *
  * @param editorConfig - config to pass to the editor
+ * @param container [window.document.body] - HTML Element to append editor element into
  * @returns EditorJS - created instance
  */
-Cypress.Commands.add('createEditor', (editorConfig: EditorConfig = {}): Chainable<EditorJS> => {
+Cypress.Commands.add('createEditor', (editorConfig: EditorConfig = {}, container?: HTMLElement): Chainable<EditorJS> => {
   return cy.window()
     .then((window) => {
       return new Promise((resolve: (instance: EditorJS) => void) => {
@@ -27,7 +28,7 @@ Cypress.Commands.add('createEditor', (editorConfig: EditorConfig = {}): Chainabl
         editorContainer.dataset.cy = 'editorjs';
         editorContainer.style.border = '1px dotted #388AE5';
 
-        window.document.body.appendChild(editorContainer);
+        (container ?? window.document.body).appendChild(editorContainer);
 
         const editorInstance: EditorJS = new window.EditorJS(editorConfig);
 

--- a/test/cypress/support/index.d.ts
+++ b/test/cypress/support/index.d.ts
@@ -11,9 +11,10 @@ declare global {
       /**
        * Custom command to select DOM element by data-cy attribute.
        * @param editorConfig - config to pass to the editor
+       * @param container [window.document.body] - HTML Element to append editor element into
        * @example cy.createEditor({})
        */
-      createEditor(editorConfig: EditorConfig): Chainable<EditorJS>
+      createEditor(editorConfig: EditorConfig, container?: HTMLElement): Chainable<EditorJS>
 
       /**
        * Paste command to dispatch paste event

--- a/test/cypress/tests/ui/inline-toolbar.cy.ts
+++ b/test/cypress/tests/ui/inline-toolbar.cy.ts
@@ -1,0 +1,205 @@
+import type EditorJS from '../../../../types/index';
+
+describe('Inline Toolbar Renders', () => {
+  const hideToolbarWorkaround = (): void => {
+    // TODO: hideToolbar doesn't work, remove workaround when fixed
+    cy.get('[data-cy=editorjs]')
+      .find('.ce-toolbar')
+      .then(($el) => {
+        $el.hide();
+      });
+
+    cy.get('[data-cy=editorjs]')
+      .find('.codex-editor--narrow')
+      .then(($el) => {
+        $el.removeClass('codex-editor--narrow');
+      });
+  };
+
+  const selectTextElement = (editor: EditorJS, selector: string): void => {
+    cy.get('[data-cy=editorjs]')
+      .find(selector)
+      .then(($el) => {
+        editor.selection.expandToTag(
+          $el.get(0)
+        );
+        editor.inlineToolbar.open();
+      });
+  };
+
+  it('should be visible (left)', () => {
+    cy.window().then((window) => {
+      const container: HTMLElement = window.document.createElement('div');
+
+      container.style.width =  '120px';
+      container.style.overflow = 'hidden';
+      window.document.body.appendChild(container);
+
+      cy.createEditor({
+        // Hiding the block toolbar makes simplier to reproduce
+        hideToolbar: true,
+        data: {
+          blocks: [
+            {
+              type: 'paragraph',
+              data: {
+                text: '<u>F</u>irst block text',
+              },
+            },
+          ],
+        },
+      }, container)
+        .then((editor) => {
+          hideToolbarWorkaround();
+          selectTextElement(editor, 'div.ce-block u');
+
+          cy.get('[data-cy=editorjs]')
+            .find('.ce-inline-toolbar')
+            .should('have.class', 'ce-inline-toolbar--left-oriented');
+
+          cy.get('[data-cy=editorjs]')
+            .get('button.ce-inline-tool')
+            .should((items) => {
+              items.each((_, $el) => {
+                if (!Cypress.dom.isVisible($el)) {
+                  throw new Error(`Element is hidden (${$el.classList})`);
+                }
+              });
+            });
+        });
+    });
+  });
+
+  it('should be visible (right)', () => {
+    cy.window().then((window) => {
+      const container: HTMLElement = window.document.createElement('div');
+
+      container.style.width =  '120px';
+      container.style.overflow = 'hidden';
+      window.document.body.appendChild(container);
+
+      cy.createEditor({
+        // Hiding the block toolbar makes simplier to reproduce
+        hideToolbar: true,
+        data: {
+          blocks: [
+            {
+              type: 'paragraph',
+              data: {
+                text: 'First block tex<u>t</u>',
+              },
+            },
+          ],
+        },
+      }, container)
+        .then((editor) => {
+          hideToolbarWorkaround();
+          selectTextElement(editor, 'div.ce-block u');
+
+          cy.get('[data-cy=editorjs]')
+            .find('.ce-inline-toolbar')
+            .should('have.class', 'ce-inline-toolbar--right-oriented');
+
+          cy.get('[data-cy=editorjs]')
+            .get('button.ce-inline-tool')
+            .should((items) => {
+              items.each((_, $el) => {
+                if (!Cypress.dom.isVisible($el)) {
+                  throw new Error(`Element is hidden (${$el.classList})`);
+                }
+              });
+            });
+        });
+    });
+  });
+
+  it('should be visible when wraper element is offset (left)', () => {
+    cy.window().then((window) => {
+      const offsetContainer: HTMLElement = window.document.createElement('div');
+
+      offsetContainer.style.position = 'absolute';
+      offsetContainer.style.left = '100px';
+      offsetContainer.style.width =  '120px';
+      offsetContainer.style.overflow = 'hidden';
+      window.document.body.appendChild(offsetContainer);
+
+      cy.createEditor({
+        // Hiding the block toolbar makes simplier to reproduce
+        hideToolbar: true,
+        data: {
+          blocks: [
+            {
+              type: 'paragraph',
+              data: {
+                text: '<u>F</u>irst block text',
+              },
+            },
+          ],
+        },
+      }, offsetContainer)
+        .then((editor) => {
+          hideToolbarWorkaround();
+          selectTextElement(editor, 'div.ce-block u');
+
+          cy.get('[data-cy=editorjs]')
+            .find('.ce-inline-toolbar')
+            .should('have.class', 'ce-inline-toolbar--left-oriented');
+
+          cy.get('[data-cy=editorjs]')
+            .get('button.ce-inline-tool')
+            .should((items) => {
+              items.each((_, $el) => {
+                if (!Cypress.dom.isVisible($el)) {
+                  throw new Error(`Element is hidden (${$el.classList})`);
+                }
+              });
+            });
+        });
+    });
+  });
+
+  it('should be visible when wraper element is offset (right)', () => {
+    cy.window().then((window) => {
+      const offsetContainer: HTMLElement = window.document.createElement('div');
+
+      offsetContainer.style.position = 'absolute';
+      offsetContainer.style.left = '100px';
+      offsetContainer.style.width =  '120px';
+      offsetContainer.style.overflow = 'hidden';
+      window.document.body.appendChild(offsetContainer);
+
+      cy.createEditor({
+        // Hiding the block toolbar makes simplier to reproduce
+        hideToolbar: true,
+        data: {
+          blocks: [
+            {
+              type: 'paragraph',
+              data: {
+                text: 'First block tex<u>t</u>',
+              },
+            },
+          ],
+        },
+      }, offsetContainer)
+        .then((editor) => {
+          hideToolbarWorkaround();
+          selectTextElement(editor, 'div.ce-block u');
+
+          cy.get('[data-cy=editorjs]')
+            .find('.ce-inline-toolbar')
+            .should('have.class', 'ce-inline-toolbar--right-oriented');
+
+          cy.get('[data-cy=editorjs]')
+            .get('button.ce-inline-tool')
+            .should((items) => {
+              items.each((_, $el) => {
+                if (!Cypress.dom.isVisible($el)) {
+                  throw new Error(`Element is hidden (${$el.classList})`);
+                }
+              });
+            });
+        });
+    });
+  });
+});


### PR DESCRIPTION
### Summary

When calculating the inline toolbar orientation, the selection coordinates are being adjusted for the offset of the wrapper element however, the content coordinates are not. 

https://github.com/codex-team/editor.js/blob/77eb320203e5a25e9b8699de6fe0a0cc285da73e/src/components/modules/toolbar/inline.ts#L164-L167

https://github.com/codex-team/editor.js/blob/77eb320203e5a25e9b8699de6fe0a0cc285da73e/src/components/modules/toolbar/inline.ts#L186

https://github.com/codex-team/editor.js/blob/77eb320203e5a25e9b8699de6fe0a0cc285da73e/src/components/modules/toolbar/inline.ts#L199

### Changes

- take offset into account for comparison against content rects
- added regression test

Resolves: #2476
Resolves: #2268

<img width="564" alt="fixed-editorjs" src="https://github.com/codex-team/editor.js/assets/57508183/c38d360c-66c2-4e58-90c1-b528ef2eeb3c">