### PR TITLE
feat: Supported toolbox activate key setting in Config.

### DIFF
--- a/src/components/core.ts
+++ b/src/components/core.ts
@@ -7,6 +7,7 @@ import { CriticalError } from './errors/critical';
 import EventsDispatcher from './utils/events';
 import Modules from './modules';
 import { EditorEventMap } from './events';
+import { keyCodes } from './utils';
 
 /**
  * Editor.js core class. Bootstraps modules.
@@ -187,6 +188,11 @@ export default class Core {
      * Text direction. If not set, uses ltr
      */
     this.config.i18n.direction = this.config.i18n?.direction || 'ltr';
+
+    /**
+     * KeyCode for activate toolbox. If not set, uses TAB key
+     */
+    this.config.toolboxKeyCode = this.config.toolboxKeyCode || keyCodes.TAB;
   }
 
   /**

--- a/src/components/modules/blockEvents.ts
+++ b/src/components/modules/blockEvents.ts
@@ -49,7 +49,7 @@ export default class BlockEvents extends Module {
         this.arrowLeftAndUp(event);
         break;
 
-      case _.keyCodes.TAB:
+      case this.config.toolboxKeyCode:
         this.tabPressed(event);
         break;
     }
@@ -135,18 +135,35 @@ export default class BlockEvents extends Module {
     const canOpenToolbox = currentBlock.tool.isDefault && isEmptyBlock;
     const conversionToolbarOpened = !isEmptyBlock && ConversionToolbar.opened;
     const inlineToolbarOpened = !isEmptyBlock && !SelectionUtils.isCollapsed && InlineToolbar.opened;
-    const canOpenBlockTunes = !conversionToolbarOpened && !inlineToolbarOpened;
+    const canOpenBlockTunes = !conversionToolbarOpened && !inlineToolbarOpened && this.isBlockSettingKeyPressed(event);
 
     /**
      * For empty Blocks we show Plus button via Toolbox only for default Blocks
      */
     if (canOpenToolbox) {
+      event.stopPropagation();
+      event.preventDefault();
       this.activateToolbox();
     } else if (canOpenBlockTunes) {
+      event.stopPropagation();
+      event.preventDefault();
       this.activateBlockSettings();
     }
   }
 
+  /**
+   * Returns whether the setting key is pressed
+   *
+   * @param {KeyboardEvent} event keyboard event
+   * @private
+   */
+  private isBlockSettingKeyPressed(event: KeyboardEvent): boolean {
+    if (this.config.blockSettingModifier === undefined) {
+      return true;
+    }
+
+    return event.getModifierState(this.config.blockSettingModifier);
+  }
   /**
    * Add drop target styles
    *

--- a/types/configs/editor-config.d.ts
+++ b/types/configs/editor-config.d.ts
@@ -104,4 +104,15 @@ export interface EditorConfig {
    * Common Block Tunes list. Will be added to all the blocks which do not specify their own 'tunes' set
    */
   tunes?: string[];
+
+  /**
+   * KeyCode for activate toolbox
+   */
+  toolboxKeyCode?: number;
+
+  /**
+   * Modifier key for activate block setting
+   */
+  blockSettingModifier?: string;
+
 }


### PR DESCRIPTION
In the current implementation, the key to activate the Toolbox is fixed to the TAB key. I have added a function to allow this to be specified from Config.

Properties added to Config:
toolboxKeyCode: KeyCode for activate toolbox
blockSettingModifier: Modifier key for activate block setting

Since toolboxKeyCode is implemented in the form of specifying a numerical value that is the KeyCode, it may not be user-friendly.

Also, regarding keys for displaying block settings, if keys such as not TAB, CTRL, ALT, META, etc. (such as /) are specified for toolboxKeyCode, the characters themselves cannot be input, so the blockSettingModifier property has been added.
This allows CTRL+/etc. to display the block settings.

Best Regards.