### PR TITLE
fix(onchange): blocks.render would not call onChange in safari

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `Fix` — Layout did not shrink when a large document cleared in Chrome
 - `Fix` — Multiple Tooltip elements creation fixed
 - `Fix` — When the focusing Block is out of the viewport, the page will be scrolled.
+- `Fix` — `blocks.render()` won't lead the `onChange` call in Safari
 
 ### 2.28.2
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@editorjs/code": "^2.7.0",
     "@editorjs/delimiter": "^1.2.0",
     "@editorjs/header": "^2.7.0",
-    "@editorjs/paragraph": "^2.10.0",
+    "@editorjs/paragraph": "^2.11.1",
     "@editorjs/simple-image": "^1.4.1",
     "@types/node": "^18.15.11",
     "chai-subset": "^1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -571,10 +571,10 @@
   dependencies:
     "@codexteam/icons" "^0.0.5"
 
-"@editorjs/paragraph@^2.10.0":
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/@editorjs/paragraph/-/paragraph-2.10.0.tgz#dcf152e69738a9399b4af83262606d76cf1376e5"
-  integrity sha512-AzaGxR9DQAdWhx43yupBcwqtwH0WWi5jBDOCSeALIK86IYOnO6Lp4anEbH8IYmYrE/5MdnRiTwdU8/Xs8W15Nw==
+"@editorjs/paragraph@^2.11.1":
+  version "2.11.1"
+  resolved "https://registry.yarnpkg.com/@editorjs/paragraph/-/paragraph-2.11.1.tgz#86e14a9f4856eaa9577ddf65cfcf21a89f0b4bca"
+  integrity sha512-OekbO6/47yTV7n6+uF/Qw2/blsI+QpveqdFUK5dh0Hq6hfKMjBYkENiShmEUKP69EbI9BQrlMNVnrmz8W4V2jw==
   dependencies:
     "@codexteam/icons" "^0.0.4"
 


### PR DESCRIPTION
This PR actually pulls the latest version of "Paragraph" tool with the fix of unwanted `onChange` in `blocks.render()`

See https://github.com/editor-js/paragraph/pull/76 for details