### PR TITLE
fix(inline-toolbar): editor element grow on inline toolbar close

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `Fix` — Multiple Tooltip elements creation fixed
 - `Fix` — When the focusing Block is out of the viewport, the page will be scrolled.
 - `Fix` — `blocks.render()` won't lead the `onChange` call in Safari
+- `Fix` — Editor wrapper element growing on the Inline Toolbar close
 
 ### 2.28.2
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/editorjs",
-  "version": "2.29.0-rc.3",
+  "version": "2.29.0-rc.4",
   "description": "Editor.js — Native JS, based on API and Open Source",
   "main": "dist/editorjs.umd.js",
   "module": "dist/editorjs.mjs",
@@ -44,7 +44,7 @@
     "@editorjs/code": "^2.7.0",
     "@editorjs/delimiter": "^1.2.0",
     "@editorjs/header": "^2.7.0",
-    "@editorjs/paragraph": "^2.11.1",
+    "@editorjs/paragraph": "^2.11.3",
     "@editorjs/simple-image": "^1.4.1",
     "@types/node": "^18.15.11",
     "chai-subset": "^1.6.0",

--- a/src/components/modules/toolbar/inline.ts
+++ b/src/components/modules/toolbar/inline.ts
@@ -379,8 +379,8 @@ export default class InlineToolbar extends Module<InlineToolbarNodes> {
       this.CSS.inlineToolbarRightOriented
     );
 
-    this.nodes.wrapper.style.left = 'unset';
-    this.nodes.wrapper.style.top = 'unset';
+    this.nodes.wrapper.style.left = '0';
+    this.nodes.wrapper.style.top = '0';
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -571,10 +571,10 @@
   dependencies:
     "@codexteam/icons" "^0.0.5"
 
-"@editorjs/paragraph@^2.11.1":
-  version "2.11.1"
-  resolved "https://registry.yarnpkg.com/@editorjs/paragraph/-/paragraph-2.11.1.tgz#86e14a9f4856eaa9577ddf65cfcf21a89f0b4bca"
-  integrity sha512-OekbO6/47yTV7n6+uF/Qw2/blsI+QpveqdFUK5dh0Hq6hfKMjBYkENiShmEUKP69EbI9BQrlMNVnrmz8W4V2jw==
+"@editorjs/paragraph@^2.11.3":
+  version "2.11.3"
+  resolved "https://registry.yarnpkg.com/@editorjs/paragraph/-/paragraph-2.11.3.tgz#fb438de863179739f18de7d8851671a0d8447923"
+  integrity sha512-ON72lhvhgWzPrq4VXpHUeut9bsFeJgVATDeL850FVToOwYHKvdsNpfu0VgxEodhkXgzU/IGl4FzdqC2wd3AJUQ==
   dependencies:
     "@codexteam/icons" "^0.0.4"
 


### PR DESCRIPTION
Some users meets a bug: 

When Inline Toolbar closes, wrapper element grows down. See a grey zone below editor — it appears when Inline Toolbar left and top becomes "unset". 

<img width="1274" alt="image" src="https://github.com/codex-team/editor.js/assets/3684889/7060b40a-3954-4881-bb90-f6f003518d5e">

That happened because Inline Toolbar inserted below the blocks-wrapper, so "unset" returns it to the DOM-based position: below the editor. And since the Inline Toolbar has height, browser somewhy expands a wrapper.

As a solution, we can reset Inline Toolbar coords by "0" instead of "unset". So hidden Inline Toolbar will be placed at top-left corner of editor.
