### PR TITLE
feat(config): new style.nonce option for CSP

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 2.29.0
 
+- `New` — Editor Config now has the `style.nonce` attribute that could be used to allowlist editor style tag for Content Security Policy "style-src"
 - `Fix` — Passing an empty array via initial data or `blocks.render()` won't break the editor
 - `Fix` — Layout did not shrink when a large document cleared in Chrome
 - `Fix` — Multiple Tooltip elements creation fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/editorjs",
-  "version": "2.29.0-rc.4",
+  "version": "2.29.0-rc.5",
   "description": "Editor.js — Native JS, based on API and Open Source",
   "main": "dist/editorjs.umd.js",
   "module": "dist/editorjs.mjs",

--- a/src/components/dom.ts
+++ b/src/components/dom.ts
@@ -52,7 +52,7 @@ export default class Dom {
    * @param  {object} [attributes] - any attributes
    * @returns {HTMLElement}
    */
-  public static make(tagName: string, classNames: string | string[] = null, attributes: object = {}): HTMLElement {
+  public static make(tagName: string, classNames: string | string[] | null = null, attributes: object = {}): HTMLElement {
     const el = document.createElement(tagName);
 
     if (Array.isArray(classNames)) {

--- a/src/components/modules/ui.ts
+++ b/src/components/modules/ui.ts
@@ -295,6 +295,15 @@ export default class UI extends Module<UINodes> {
     });
 
     /**
+     * If user enabled Content Security Policy, he can pass nonce through the config
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce
+     */
+    if (this.config.style && !_.isEmpty(this.config.style) && this.config.style.nonce) {
+      tag.setAttribute('nonce', this.config.style.nonce);
+    }
+
+    /**
      * Append styles at the top of HEAD tag
      */
     $.prepend(document.head, tag);

--- a/test/cypress/tests/initialization.cy.ts
+++ b/test/cypress/tests/initialization.cy.ts
@@ -48,5 +48,21 @@ describe('Editor basic initialization', () => {
           .should('eq', 'false');
       });
     });
+
+    describe('style', () => {
+      describe('nonce', () => {
+        it('should add passed nonce as attribute to editor style tag', () => {
+          cy.createEditor({
+            style: {
+              nonce: 'test-nonce',
+            },
+          }).as('editorInstance');
+
+          cy.get('[data-cy=editorjs]')
+            .get('#editor-js-styles')
+            .should('have.attr', 'nonce', 'test-nonce');
+        });
+      });
+    });
   });
 });

--- a/types/configs/editor-config.d.ts
+++ b/types/configs/editor-config.d.ts
@@ -104,4 +104,15 @@ export interface EditorConfig {
    * Common Block Tunes list. Will be added to all the blocks which do not specify their own 'tunes' set
    */
   tunes?: string[];
+
+  /**
+   * Section for style-related settings
+   */
+  style?: {
+    /**
+     * A random value to handle Content Security Policy "style-src" policy
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce
+     */
+    nonce?: string;
+  }
 }


### PR DESCRIPTION
## Problem

If user enables Content Security Policy [style-src](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src), editor's styles are not working

<img width="761" alt="image" src="https://github.com/codex-team/editor.js/assets/3684889/177f9a1d-3403-47bb-b4f4-804e9cdeb2a0">

<img width="959" alt="image" src="https://github.com/codex-team/editor.js/assets/3684889/089355f2-a0d1-408b-acf8-93943e32eaed">


## Cause 

If CSP "style-src" enabled, browser will execute style only if:
- `Content-Security-Policy: style-src 'unsafe-inline'` — bad solution
- `Content-Security-Policy: style-src 'sha256-ozBpjL6dxO8fsS4u6fwG1dFDACYvpNxYeBA6tzR+FY8='` — user have to manually update hash on every editor style change
- `Content-Security-Policy: style-src 'nonce-2726c7f26c'` — nonce is random number re-generated on each request

## Solution

If user enabled CSP, he should generate random [nonce](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce) on each request, set it in CSP header `Content-Security-Policy: style-src 'nonce-2726c7f26c'` and pass it to the Editor, so we will add that nonce to the style tag.

<img width="413" alt="image" src="https://github.com/codex-team/editor.js/assets/3684889/562bbdb7-3ab1-4eb9-a9f6-991d2d8bddf6">

Resolves #1334