### PR TITLE
docs: replace holderId config by holder

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -69,7 +69,7 @@ Check [Editor.js's community](https://github.com/editor-js/) to see Tools exampl
 ## Create Editor instance
 
 Create an instance of Editor.js and pass [Configuration Object](../src/types-internal/editor-config.ts).
-At least the `holderId` option is required.
+At least the `holder` option is required.
 
 ```html
 <div id="editorjs"></div>
@@ -92,7 +92,7 @@ var editor = new EditorJS({
     /**
      * Create a holder for the Editor and pass its ID
      */
-    holderId : 'editorjs',
+    holder : 'editorjs',
 
     /**
      * Available Tools list.

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -70,7 +70,7 @@ to the `tools` property of Editor Config.
 
 ```javascript
 var editor = new EditorJS({
-  holderId : 'editorjs',
+  holder : 'editorjs',
   tools: {
     text: {
       class: Text,


### PR DESCRIPTION
The `holderId` configuration has recently been deprecated. The current documentation still references the old `holder` configuration attribute, which should now be updated to use the new attribute, `holder`. 

This pull request (PR) replaces the `holderId` attribute with `holder`.

I had accidentally deleted the head, Ref: https://github.com/codex-team/editor.js/pull/2503