### PR TITLE
Added a github link to codex bot release notification

### DIFF
--- a/.github/workflows/publish-package-to-npm.yml
+++ b/.github/workflows/publish-package-to-npm.yml
@@ -4,13 +4,15 @@ on:
   release:
     types:
       - published
+env:
+    GITHUB_LINK: "${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }}/"
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
       # Checkout to target branch
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           # Pull submodules
           submodules: 'recursive'
@@ -48,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checkout to target branch
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Get package info
         id: package
@@ -58,6 +60,6 @@ jobs:
         uses: codex-team/action-codexbot-notify@v1
         with:
           webhook: ${{ secrets.CODEX_BOT_NOTIFY_EDITORJS_PUBLIC_CHAT }}
-          message: '📦 [${{ steps.package.outputs.name }}](${{ steps.package.outputs.npmjs-link }}) ${{ steps.package.outputs.version }} was published'
+          message: '📦 [${{ steps.package.outputs.name }}]($GITHUB_LINK) ${{ github.ref_name }} was published'
           parse_mode: 'markdown'
           disable_web_page_preview: true

--- a/.github/workflows/publish-package-to-npm.yml
+++ b/.github/workflows/publish-package-to-npm.yml
@@ -49,17 +49,17 @@ jobs:
     env:
       GITHUB_LINK: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }}
     steps:
-        # Checkout to target branch
-        - uses: actions/checkout@v4
-  
-        - name: Get package info
-          id: package
-          uses: codex-team/action-nodejs-package-info@v1
-  
-        - name: Send a message
-          uses: codex-team/action-codexbot-notify@v1
-          with:
-            webhook: ${{ secrets.CODEX_BOT_NOTIFY_EDITORJS_PUBLIC_CHAT }}
-            message: '📦 [${{ steps.package.outputs.name }} ${{ steps.package.outputs.version }}](${{ env.GITHUB_LINK }}) was published'
-            parse_mode: 'markdown'
-            disable_web_page_preview: true
+      # Checkout to target branch
+      - uses: actions/checkout@v4
+
+      - name: Get package info
+        id: package
+        uses: codex-team/action-nodejs-package-info@v1
+
+      - name: Send a message
+        uses: codex-team/action-codexbot-notify@v1
+        with:
+          webhook: ${{ secrets.CODEX_BOT_NOTIFY_EDITORJS_PUBLIC_CHAT }}
+          message: '📦 [${{ steps.package.outputs.name }} ${{ steps.package.outputs.version }}](${{ env.GITHUB_LINK }}) was published'
+          parse_mode: 'markdown'
+          disable_web_page_preview: true

--- a/.github/workflows/publish-package-to-npm.yml
+++ b/.github/workflows/publish-package-to-npm.yml
@@ -46,6 +46,8 @@ jobs:
   notify:
     needs: publish
     runs-on: ubuntu-latest
+    env:
+      GITHUB_LINK: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }}
     steps:
         # Checkout to target branch
         - uses: actions/checkout@v4
@@ -53,23 +55,11 @@ jobs:
         - name: Get package info
           id: package
           uses: codex-team/action-nodejs-package-info@v1
-
-        - name: Set link to the github repository
-          if: ${{ github.event_name != 'release ' }}
-          run: |
-            echo "GITHUB_LINK=${{ github.server_url }}/${{ github.repository }}" >> $GITHUB_ENV
-          shell: bash
-        
-        # If package is released, set the link to the released version
-        - name: Set github link to latest version
-          if: ${{ github.event_name == 'release' }}
-          run: |
-            echo "GITHUB_LINK=${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }}" >> $GITHUB_ENV
   
         - name: Send a message
           uses: codex-team/action-codexbot-notify@v1
           with:
-            webhook: https://notify.bot.codex.so/u/IJBC1JPEBK5P
+            webhook: ${{ secrets.CODEX_BOT_NOTIFY_EDITORJS_PUBLIC_CHAT }}
             message: '📦 [${{ steps.package.outputs.name }} ${{ steps.package.outputs.version }}](${{ env.GITHUB_LINK }}) was published'
             parse_mode: 'markdown'
             disable_web_page_preview: true

--- a/.github/workflows/publish-package-to-npm.yml
+++ b/.github/workflows/publish-package-to-npm.yml
@@ -4,8 +4,6 @@ on:
   release:
     types:
       - published
-env:
-    GITHUB_LINK: "${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }}/"
 
 jobs:
   publish:
@@ -49,17 +47,29 @@ jobs:
     needs: publish
     runs-on: ubuntu-latest
     steps:
-      # Checkout to target branch
-      - uses: actions/checkout@v4
+        # Checkout to target branch
+        - uses: actions/checkout@v4
+  
+        - name: Get package info
+          id: package
+          uses: codex-team/action-nodejs-package-info@v1
 
-      - name: Get package info
-        id: package
-        uses: codex-team/action-nodejs-package-info@v1
-
-      - name: Send a message
-        uses: codex-team/action-codexbot-notify@v1
-        with:
-          webhook: ${{ secrets.CODEX_BOT_NOTIFY_EDITORJS_PUBLIC_CHAT }}
-          message: '📦 [${{ steps.package.outputs.name }}]($GITHUB_LINK) ${{ github.ref_name }} was published'
-          parse_mode: 'markdown'
-          disable_web_page_preview: true
+        - name: Set link to the github repository
+          if: ${{ github.event_name != 'release ' }}
+          run: |
+            echo "GITHUB_LINK=${{ github.server_url }}/${{ github.repository }}" >> $GITHUB_ENV
+          shell: bash
+        
+        # If package is released, set the link to the released version
+        - name: Set github link to latest version
+          if: ${{ github.event_name == 'release' }}
+          run: |
+            echo "GITHUB_LINK=${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }}" >> $GITHUB_ENV
+  
+        - name: Send a message
+          uses: codex-team/action-codexbot-notify@v1
+          with:
+            webhook: https://notify.bot.codex.so/u/IJBC1JPEBK5P
+            message: '📦 [${{ steps.package.outputs.name }} ${{ steps.package.outputs.version }}](${{ env.GITHUB_LINK }}) was published'
+            parse_mode: 'markdown'
+            disable_web_page_preview: true


### PR DESCRIPTION
Modified an action so that it gives a link to the released github version instead of npm version.