### PR TITLE
chore(on-change):  check data-mutation-free of parent nodes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `Improvement` — Now you can set focus via arrows/Tab to "contentless" (decorative) blocks like Delimiter which have no inputs.
 - `Improvement` — Inline Toolbar sometimes opened in an incorrect position. Now it will be aligned by the left side of the selected text. And won't overflow the right side of the text column.
 - `Improvement` - Now the `data-mutation-free` supports deep nesting, so you can mark some element with it to prevent the onChange call caused by child element mutating
+- `Improvement` - Now the `data-mutation-free` also allows to skip "characterData" mutations (eg. text content change)
 - `Refactoring` — `ce-block--focused` class toggling removed as unused.
 
 ### 2.28.2

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,7 +12,7 @@
 - `Fix` — Editor wrapper element growing on the Inline Toolbar close
 - `Fix` — Fix errors thrown by clicks on a document when the editor is being initialized
 - `Fix` — Inline Toolbar sometimes opened in an incorrect position. Now it will be aligned by the left side of the selected text. And won't overflow the right side of the text column.
-- `Feat` - Add deep check of `data-mutation-free` for mutation observer
+- `Improvement` - Now the `data-mutation-free` supports deep nesting, so you can mark some element with it to prevent the onChange call caused by child element mutating
 
 ### 2.28.2
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `Fix` — Editor wrapper element growing on the Inline Toolbar close
 - `Fix` — Fix errors thrown by clicks on a document when the editor is being initialized
 - `Fix` — Inline Toolbar sometimes opened in an incorrect position. Now it will be aligned by the left side of the selected text. And won't overflow the right side of the text column.
+- `Feat` - Add deep check of `data-mutation-free` for mutation observer
 
 ### 2.28.2
 

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -911,7 +911,7 @@ export default class Block extends EventsDispatcher<BlockEvents> {
             return false;
           }
 
-          return (node as HTMLElement).dataset.mutationFree === 'true';
+          return (node as HTMLElement).dataset.mutationFree === 'true' || !!node.closest('[data-mutation-free="deep"]');
         });
       });
 

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -911,7 +911,7 @@ export default class Block extends EventsDispatcher<BlockEvents> {
             return false;
           }
 
-          return (node as HTMLElement).dataset.mutationFree === 'true' || !!node.closest('[data-mutation-free="deep"]');
+          return !!node.closest('[data-mutation-free="true"]');
         });
       });
 

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -898,10 +898,13 @@ export default class Block extends EventsDispatcher<BlockEvents> {
 
         return changedNodes.some((node) => {
           if (!$.isElement(node)) {
-            return false;
+            /**
+             * "characterData" mutation record has Text node as a target, so we need to get parent element to check it for mutation-free attribute
+             */
+            node = node.parentElement;
           }
 
-          return node.closest('[data-mutation-free="true"]') !== null;
+          return node && (node as HTMLElement).closest('[data-mutation-free="true"]') !== null;
         });
       });
 

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -911,7 +911,7 @@ export default class Block extends EventsDispatcher<BlockEvents> {
             return false;
           }
 
-          return !!node.closest('[data-mutation-free="true"]');
+          return node.closest('[data-mutation-free="true"]') !== null;
         });
       });
 

--- a/test/cypress/tests/onchange.cy.ts
+++ b/test/cypress/tests/onchange.cy.ts
@@ -544,6 +544,73 @@ describe('onChange callback', () => {
     });
   });
 
+  it('should not be fired when child element of "data-mutation-free=deep" mark changes some attribute', () => {
+    /**
+     * Mock for tool wrapper which we will mutate in a test
+     */
+    const toolWrapper = document.createElement('div');
+    const toolChild = document.createElement('div');
+
+    toolWrapper.appendChild(toolChild);
+
+    /**
+     * Mark it as mutation-free with deep check
+     */
+    toolWrapper.dataset.mutationFree = 'deep';
+
+    /**
+     * Mock of tool with data-mutation-free attribute
+     */
+    class ToolWithMutationFreeAttribute {
+      /**
+       * Simply return mocked element
+       */
+      public render(): HTMLElement {
+        return toolWrapper;
+      }
+
+      /**
+       * Saving logic is not necessary for this test
+       */
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      public save(): void {}
+    }
+
+    const editorConfig = {
+      tools: {
+        testTool: ToolWithMutationFreeAttribute,
+      },
+      onChange: (api, event): void => {
+        console.log('something changed', event);
+      },
+      data: {
+        blocks: [
+          {
+            type: 'testTool',
+            data: {},
+          },
+        ],
+      },
+    };
+
+    cy.spy(editorConfig, 'onChange').as('onChange');
+    cy.createEditor(editorConfig).as('editorInstance');
+
+    /**
+     * Emulate tool's internal attribute mutation
+     */
+    cy.wait(100).then(() => {
+      toolChild.setAttribute('some-changed-attr', 'some-new-value');
+    });
+
+    /**
+     * Check that onChange callback was not called
+     */
+    cy.wait(500).then(() => {
+      cy.get('@onChange').should('have.callCount', 0);
+    });
+  });
+
   it('should be called on blocks.clear() with removed and added blocks', () => {
     createEditor([
       {

--- a/test/cypress/tests/onchange.cy.ts
+++ b/test/cypress/tests/onchange.cy.ts
@@ -544,7 +544,7 @@ describe('onChange callback', () => {
     });
   });
 
-  it('should not be fired when child element of "data-mutation-free=deep" mark changes some attribute', () => {
+  it('should not be fired when mutation happened in a child of element with the "data-mutation-free" mark', () => {
     /**
      * Mock for tool wrapper which we will mutate in a test
      */

--- a/test/cypress/tests/onchange.cy.ts
+++ b/test/cypress/tests/onchange.cy.ts
@@ -454,7 +454,7 @@ describe('onChange callback', () => {
       .get('div.ce-block')
       .click();
 
-    cy.wait(500).then(() => {
+    cy.wait(200).then(() => {
       cy.get('@onChange').should('have.callCount', 0);
     });
   });
@@ -539,7 +539,7 @@ describe('onChange callback', () => {
     /**
      * Check that onChange callback was not called
      */
-    cy.wait(500).then(() => {
+    cy.wait(200).then(() => {
       cy.get('@onChange').should('have.callCount', 0);
     });
   });
@@ -554,9 +554,9 @@ describe('onChange callback', () => {
     toolWrapper.appendChild(toolChild);
 
     /**
-     * Mark it as mutation-free with deep check
+     * Mark it as mutation-free
      */
-    toolWrapper.dataset.mutationFree = 'deep';
+    toolWrapper.dataset.mutationFree = 'true';
 
     /**
      * Mock of tool with data-mutation-free attribute
@@ -606,7 +606,7 @@ describe('onChange callback', () => {
     /**
      * Check that onChange callback was not called
      */
-    cy.wait(500).then(() => {
+    cy.wait(200).then(() => {
       cy.get('@onChange').should('have.callCount', 0);
     });
   });

--- a/test/cypress/tests/onchange.cy.ts
+++ b/test/cypress/tests/onchange.cy.ts
@@ -454,7 +454,7 @@ describe('onChange callback', () => {
       .get('div.ce-block')
       .click();
 
-    cy.wait(200).then(() => {
+    cy.wait(500).then(() => {
       cy.get('@onChange').should('have.callCount', 0);
     });
   });

--- a/test/cypress/tests/onchange.cy.ts
+++ b/test/cypress/tests/onchange.cy.ts
@@ -539,7 +539,7 @@ describe('onChange callback', () => {
     /**
      * Check that onChange callback was not called
      */
-    cy.wait(200).then(() => {
+    cy.wait(500).then(() => {
       cy.get('@onChange').should('have.callCount', 0);
     });
   });
@@ -606,7 +606,78 @@ describe('onChange callback', () => {
     /**
      * Check that onChange callback was not called
      */
-    cy.wait(200).then(() => {
+    cy.wait(500).then(() => {
+      cy.get('@onChange').should('have.callCount', 0);
+    });
+  });
+
+  it('should not be fired when "characterData" mutation happened in a child of element with the "data-mutation-free" mark', () => {
+    /**
+     * Mock for tool wrapper which we will mutate in a test
+     */
+    const toolWrapper = document.createElement('div');
+    const toolChild = document.createElement('div');
+
+    toolChild.setAttribute('data-cy', 'tool-child');
+    toolChild.setAttribute('contenteditable', 'true');
+
+    toolWrapper.appendChild(toolChild);
+
+    /**
+     * Mark it as mutation-free
+     */
+    toolWrapper.dataset.mutationFree = 'true';
+
+    /**
+     * Mock of tool with data-mutation-free attribute
+     */
+    class ToolWithMutationFreeAttribute {
+      /**
+       * Simply return mocked element
+       */
+      public render(): HTMLElement {
+        return toolWrapper;
+      }
+
+      /**
+       * Saving logic is not necessary for this test
+       */
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      public save(): void {}
+    }
+
+    const editorConfig = {
+      tools: {
+        testTool: ToolWithMutationFreeAttribute,
+      },
+      onChange: function (api, event) {
+        console.log('something changed!!!!!!!!', event);
+      },
+      data: {
+        blocks: [
+          {
+            type: 'testTool',
+            data: {},
+          },
+        ],
+      },
+    };
+
+    cy.spy(editorConfig, 'onChange').as('onChange');
+    cy.createEditor(editorConfig).as('editorInstance');
+
+    /**
+     * Emulate tool's child-element text typing
+     */
+    cy.get('[data-cy=editorjs')
+      .get('[data-cy=tool-child]')
+      .click()
+      .type('some text');
+
+    /**
+     * Check that onChange callback was not called
+     */
+    cy.wait(500).then(() => {
       cy.get('@onChange').should('have.callCount', 0);
     });
   });


### PR DESCRIPTION
- The `data-mutation-free` attribute now being checked for all parents of changed node
- "characterData" mutations also now could be muted

Resolves #2205

> I am rendering Vue components as Block Tools, for example a Video.js player. W I just play the video the editorjs gets a "block-changed" event and that's simply not true. The Video.js player creates lots of divs, where i have no "power" to set the data-mutation-free attribute!

