### PR TITLE
Give write permissions to jobs that release / bump a new version

### DIFF
--- a/.github/workflows/bump-version-on-merge-next.yml
+++ b/.github/workflows/bump-version-on-merge-next.yml
@@ -42,6 +42,8 @@ jobs:
   bump-version:
     needs: check-for-no-version-changing
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       # Checkout to target branch
       - uses: actions/checkout@v2

--- a/.github/workflows/create-a-release-draft.yml
+++ b/.github/workflows/create-a-release-draft.yml
@@ -45,6 +45,8 @@ jobs:
   release-draft:
     needs: check-version-changing
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       # Checkout to target branch
       - uses: actions/checkout@v2


### PR DESCRIPTION
The fix is made due to an error that occurs, when the merge was made from a fork.