### PR TITLE
feat: Skip workflow and do not bump version if it was changed already

### DIFF
--- a/.github/workflows/bump-version-on-merge-next.yml
+++ b/.github/workflows/bump-version-on-merge-next.yml
@@ -31,13 +31,12 @@ jobs:
         id: packageOld
         uses: codex-team/action-nodejs-package-info@v1
 
-      # Stop workflow and do not bump version if it was changed already
-      - name: Stop workflow and do not bump version if it was changed already
-        uses: actions/github-script@v3
+      # Stop workflow if version was not changed
+      - name: Stop workflow if version was not changed
+        uses: styfle/cancel-workflow-action@0.12.0
         if: steps.packageOld.outputs.version != steps.packageNew.outputs.version
         with:
-          script: |
-            core.setFailed('Version was changed! ${{ steps.packageOld.outputs.version }} -> ${{ steps.packageNew.outputs.version }}')
+          workflow_id: ${{ github.run_id }}
 
   bump-version:
     needs: check-for-no-version-changing

--- a/.github/workflows/bump-version-on-merge-next.yml
+++ b/.github/workflows/bump-version-on-merge-next.yml
@@ -31,7 +31,7 @@ jobs:
         id: packageOld
         uses: codex-team/action-nodejs-package-info@v1
 
-      # Stop workflow if version was not changed
+      # Stop workflow and do not bump version if it was changed already
       - name: Stop workflow if version was not changed
         uses: styfle/cancel-workflow-action@0.12.0
         if: steps.packageOld.outputs.version != steps.packageNew.outputs.version

--- a/.github/workflows/bump-version-on-merge-next.yml
+++ b/.github/workflows/bump-version-on-merge-next.yml
@@ -32,7 +32,7 @@ jobs:
         uses: codex-team/action-nodejs-package-info@v1
 
       # Stop workflow and do not bump version if it was changed already
-      - name: Stop workflow if version was not changed
+      - name: Stop workflow if version was changed already
         uses: styfle/cancel-workflow-action@0.12.0
         if: steps.packageOld.outputs.version != steps.packageNew.outputs.version
         with:


### PR DESCRIPTION
It now doesn't throw an error. Instead it sets the workflow status to "skipped'