### PR TITLE
fix(caret): caret loosing on mobile devices

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `Fix` — `blocks.render()` won't lead the `onChange` call in Safari
 - `Fix` — Editor wrapper element growing on the Inline Toolbar close
 - `Fix` — Fix errors thrown by clicks on a document when the editor is being initialized
+- `Fix` — Caret losing on Mobile Devices when adding a block via Toolbox or via Backspace at the beginning of a Block
 - `Fix` — Inline Toolbar sometimes opened in an incorrect position. Now it will be aligned by the left side of the selected text. And won't overflow the right side of the text column.
 
 ### 2.28.2

--- a/src/components/modules/caret.ts
+++ b/src/components/modules/caret.ts
@@ -255,13 +255,7 @@ export default class Caret extends Module {
         break;
     }
 
-    /**
-     * @todo try to fix via Promises or use querySelectorAll to not to use timeout
-     */
-    _.delay(() => {
-      this.set(nodeToSet as HTMLElement, offset);
-    // eslint-disable-next-line @typescript-eslint/no-magic-numbers
-    }, 20)();
+    this.set(nodeToSet as HTMLElement, offset);
 
     BlockManager.setCurrentBlockByChildNode(block.holder);
     BlockManager.currentBlock.currentInput = element;

--- a/src/components/modules/caret.ts
+++ b/src/components/modules/caret.ts
@@ -11,7 +11,6 @@ import Selection from '../selection';
 import Module from '../__module';
 import Block from '../block';
 import $ from '../dom';
-import * as _ from '../utils';
 
 /**
  * @typedef {Caret} Caret


### PR DESCRIPTION
## Problem

Sometimes Caret disappears on mobile devices:
- when adding a new block via Toolbox
- when pressing Backspace at the start of block

https://github.com/codex-team/editor.js/assets/3684889/21699b15-2643-40e1-992a-31008ecdaa10

## Cause

Problem located in `caret.setToBlock()`. We're setting caret using `setTimeout` and browser is blocking this action because it's prohibited to programmatically set a caret without user action. So it's not working inside a setTimeout callback. 

## Solution

I tried to change setTimeout with `requestAnimationFrame` it also seems working. But then I tried to remove timeout at all. And looks like nothing breaks, so it looks like a legacy. 

Resolves #2406
Resolves #2287 (possible)
