### PR TITLE
Add `editor.tools` API, to update the tools' user provided config

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `New` — Toolbox now will be opened by '/' in empty Block instead of Tab
 - `New` — Block Tunes now will be opened by 'CMD+/' instead of Tab in non-empty block
 - `New` — Tab now will navigate through Blocks. In last block Tab will navigate to the next input on page.
+- `New` - Adds `editor.tools` API, which can be used to update the tools' config without having to destroy & re-initialize the editor.
 - `Fix` — Passing an empty array via initial data or `blocks.render()` won't break the editor
 - `Fix` — Layout did not shrink when a large document cleared in Chrome
 - `Fix` — Multiple Tooltip elements creation fixed

--- a/src/components/modules/api/index.ts
+++ b/src/components/modules/api/index.ts
@@ -28,6 +28,7 @@ export default class API extends Module {
       selection: this.Editor.SelectionAPI.methods,
       styles: this.Editor.StylesAPI.classes,
       toolbar: this.Editor.ToolbarAPI.methods,
+      tools: this.Editor.ToolsAPI.methods,
       inlineToolbar: this.Editor.InlineToolbarAPI.methods,
       tooltip: this.Editor.TooltipAPI.methods,
       i18n: this.Editor.I18nAPI.methods,

--- a/src/components/modules/api/tools.ts
+++ b/src/components/modules/api/tools.ts
@@ -1,0 +1,37 @@
+import { ToolConfig } from '../../../../types';
+import { Tools } from '../../../../types/api';
+import * as _ from '../../utils';
+import Module from '../../__module';
+
+/**
+ * @class ToolsAPI
+ * Provides methods for working with the Tools
+ */
+export default class ToolsAPI extends Module {
+  /**
+   * Available methods
+   *
+   * @returns {Tools}
+   */
+  public get methods(): Tools {
+    return {
+      updateToolConfig:(toolName:string, config: ToolConfig) => this.updateToolConfig(toolName, config),
+    };
+  }
+
+  /**
+   * Update Tool's config
+   *
+   * @param toolName Name of the tool
+   * @param config Tools Config
+   */
+  public updateToolConfig(toolName:string, config: ToolConfig): void {
+    const tool = this.Editor.Tools.available.get(toolName);
+
+    if (tool) {
+      tool.updateConfig(config);
+    } else {
+      _.log(`Incorrect toolName: ${toolName}`);
+    }
+  }
+}

--- a/src/components/modules/api/tools.ts
+++ b/src/components/modules/api/tools.ts
@@ -15,7 +15,7 @@ export default class ToolsAPI extends Module {
    */
   public get methods(): Tools {
     return {
-      updateToolConfig:(toolName:string, config: ToolConfig) => this.updateToolConfig(toolName, config),
+      updateToolConfig: (toolName: string, config: ToolConfig) => this.updateToolConfig(toolName, config),
     };
   }
 
@@ -25,7 +25,7 @@ export default class ToolsAPI extends Module {
    * @param toolName Name of the tool
    * @param config Tools Config
    */
-  public updateToolConfig(toolName:string, config: ToolConfig): void {
+  public updateToolConfig(toolName: string, config: ToolConfig): void {
     const tool = this.Editor.Tools.available.get(toolName);
 
     if (tool) {

--- a/src/components/modules/index.ts
+++ b/src/components/modules/index.ts
@@ -14,6 +14,7 @@ import SelectionAPI from './api/selection';
 import StylesAPI from './api/styles';
 import ToolbarAPI from './api/toolbar';
 import TooltipAPI from './api/tooltip';
+import ToolsAPI from './api/tools';
 import UiAPI from './api/ui';
 
 /** ./toolbar */
@@ -55,6 +56,7 @@ export default {
   StylesAPI,
   ToolbarAPI,
   TooltipAPI,
+  ToolsAPI,
   UiAPI,
 
   // Toolbar Modules

--- a/src/components/tools/base.ts
+++ b/src/components/tools/base.ts
@@ -1,4 +1,4 @@
-import { Tool, ToolConstructable, ToolSettings } from '../../../types/tools';
+import { Tool, ToolConfig, ToolConstructable, ToolSettings } from '../../../types/tools';
 import { SanitizerConfig } from '../../../types';
 import * as _ from '../utils';
 import type InlineTool from './inline';
@@ -213,6 +213,17 @@ export default abstract class BaseTool<Type extends Tool = Tool> {
   public reset(): void | Promise<void> {
     if (_.isFunction(this.constructable.reset)) {
       return this.constructable.reset();
+    }
+  }
+
+  /**
+   * Update tool's current config
+   *
+   * @param {ToolConfig} config - Tool's config
+   */
+  public updateConfig(config: ToolConfig):void {
+    if (this.config) {
+      this.config[UserSettings.Config] = config;
     }
   }
 

--- a/src/components/tools/base.ts
+++ b/src/components/tools/base.ts
@@ -221,7 +221,7 @@ export default abstract class BaseTool<Type extends Tool = Tool> {
    *
    * @param {ToolConfig} config - Tool's config
    */
-  public updateConfig(config: ToolConfig):void {
+  public updateConfig(config: ToolConfig): void {
     if (this.config) {
       this.config[UserSettings.Config] = config;
     }

--- a/src/types-internal/editor-modules.d.ts
+++ b/src/types-internal/editor-modules.d.ts
@@ -37,6 +37,7 @@ import Renderer from '../components/modules/renderer';
 import Saver from '../components/modules/saver';
 import Tools from '../components/modules/tools';
 import UI from '../components/modules/ui';
+import ToolsAPI from '../components/modules/api/tools';
 
 export interface EditorModules {
   // API Modules
@@ -55,6 +56,7 @@ export interface EditorModules {
   StylesAPI: StylesAPI,
   ToolbarAPI: ToolbarAPI,
   TooltipAPI: TooltipAPI,
+  ToolsAPI: ToolsAPI;
   UiAPI: UiAPI,
 
   // Toolbar Modules

--- a/types/api/index.d.ts
+++ b/types/api/index.d.ts
@@ -14,3 +14,4 @@ export * from './block';
 export * from './readonly';
 export * from './i18n';
 export * from './ui';
+export * from './tools';

--- a/types/api/tools.d.ts
+++ b/types/api/tools.d.ts
@@ -4,11 +4,11 @@ import { ToolConfig } from '../tools';
  * Describes Tools API methods
  */
 export interface Tools {
-    /**
-     * Updates tool's config
-     *
-     * @param toolName Name of the tool
-     * @param type inline or block tools
-     */
-   updateToolConfig(toolName:string, config: ToolConfig): void
+  /**
+   * Updates tool's config
+   *
+   * @param toolName name of the tool
+   * @param config config of the tool
+   */
+  updateToolConfig(toolName: string, config: ToolConfig): void
 }

--- a/types/api/tools.d.ts
+++ b/types/api/tools.d.ts
@@ -1,0 +1,14 @@
+import { ToolConfig } from '../tools';
+
+/**
+ * Describes Tools API methods
+ */
+export interface Tools {
+    /**
+     * Updates tool's config
+     *
+     * @param toolName Name of the tool
+     * @param type inline or block tools
+     */
+   updateToolConfig(toolName:string, config: ToolConfig): void
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -26,6 +26,7 @@ import {
   Styles,
   Toolbar,
   Tooltip,
+  Tools,
   I18n,
   Ui,
 } from './api';
@@ -115,6 +116,7 @@ export interface API {
   toolbar: Toolbar;
   inlineToolbar: InlineToolbar;
   tooltip: Tooltip;
+  tools: Tools;
   i18n: I18n;
   readOnly: ReadOnly;
   ui: Ui;
@@ -135,6 +137,7 @@ declare class EditorJS {
   public selection: Selection;
   public styles: Styles;
   public toolbar: Toolbar;
+  public tools: Tools;
   public inlineToolbar: InlineToolbar;
   public readOnly: ReadOnly;
   constructor(configuration?: EditorConfig|string);


### PR DESCRIPTION
- Fixes #2397
- Adds a new API `tools` on the editor instance, which can now be used to update the tools' config without having to destroy and reinitialize the editor. 