### PR TITLE
Add a check that allows inline toolboxes to work with nested editorsjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "tools:update": "yarn _tools:checkout && yarn _tools:pull && yarn _tools:make",
     "test:e2e": "yarn build:test && cypress run",
     "test:e2e:open": "yarn build:test && cypress open",
-    "devserver:start": "yarn build && node ./devserver.js"
+    "devserver:start": "yarn build && node ./devserver.js",
+    "prepare": "npm run build"
   },
   "author": "CodeX",
   "license": "Apache-2.0",
@@ -75,5 +76,8 @@
   "collective": {
     "type": "opencollective",
     "url": "https://opencollective.com/editorjs"
+  },
+  "dependencies": {
+    "yarn": "^1.22.21"
   }
 }

--- a/src/components/modules/ui.ts
+++ b/src/components/modules/ui.ts
@@ -820,9 +820,13 @@ export default class UI extends Module<UINodes> {
 
     /**
      * Event can be fired on clicks at non-block-content elements,
-     * for example, at the Inline Toolbar or some Block Tune element
+     * for example, at the Inline Toolbar or some Block Tune element.
+     * We also make sure that the closest block belongs to the current editor and not a parent
      */
-    const clickedOutsideBlockContent = focusedElement.closest(`.${Block.CSS.content}`) === null;
+    const closestBlock = focusedElement.closest(`.${Block.CSS.content}`);
+    const clickedOutsideBlockContent =
+      closestBlock === null
+      || (closestBlock.closest(`.${Selection.CSS.editorWrapper}`) !== this.nodes.wrapper);
 
     if (clickedOutsideBlockContent) {
       /**


### PR DESCRIPTION
In our project, we have cases where we can have nested editorjs.
For instance, we have a block tool that will create an editorjs instance inside of it.

We ran into a situation where the inline toolbox would close when opening the link tool inside a nested editor.
This is due to the editor checking for the parent block only to verify if we clicked outside the toolbox.

We added a check that should prevent this issue (at least it does for us) and also keep the standard functionality of editorjs.
We hope that this change can be merged so we can get rid of our fork and make everyone else benefit from it.

Respectfully, Lucas Lelievre