### PR TITLE
Fix workflow not working properly when running from fork

### DIFF
--- a/.github/workflows/bump-version-on-merge-next.yml
+++ b/.github/workflows/bump-version-on-merge-next.yml
@@ -1,7 +1,14 @@
 name: Bump version on merge
 
+# Caution: 
+# the use of "pull_request_target" trigger allows to successfully
+# run workflow even when triggered from a fork. The trigger grants
+# access to repo's secrets and gives write permission to the runner.
+# This can be used to run malicious code on untrusted PR, so, please
+# DO NOT checkout any PR's ongoing commits (aka github.event.pull_request.head.sha)
+# while using this trigger.
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - next
     types: [closed]

--- a/.github/workflows/create-a-release-draft.yml
+++ b/.github/workflows/create-a-release-draft.yml
@@ -1,7 +1,14 @@
 name: Create a release draft
 
+# Caution: 
+# the use of "pull_request_target" trigger allows to successfully
+# run workflow even when triggered from a fork. The trigger grants
+# access to repo's secrets and gives write permission to the runner.
+# This can be used to run malicious code on untrusted PR, so, please
+# DO NOT checkout any PR's ongoing commits (aka github.event.pull_request.head.sha)
+# while using this trigger.
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - next
     types: [closed]


### PR DESCRIPTION
Changed trigger from **"pull_request"** to **"pull_request_target"**, which will grant write permissions and secrets to workflow (even from **forks**).

Documented this warning in the code:
```
Caution: 
the use of "pull_request_target" trigger allows to successfully
run workflow even when triggered from a fork. The trigger grants
access to repo's secrets and gives write permission to the runner.
This can be used to run malicious code on untrusted PR, so, please
DO NOT checkout any PR's ongoing commits (aka github.event.pull_request.head.sha)
while using this trigger.
```