### PR TITLE
fix(slash): do not handle / + shift/alt, support for ascii keyboard

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,6 +32,7 @@
     "ArrayLike": true,
     "InputEvent": true,
     "unknown": true,
-    "requestAnimationFrame": true
+    "requestAnimationFrame": true,
+    "navigator": true
   }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 2.29.1
+
+- `Fix` — Toolbox wont be shown when Slash pressed with along with Shift or Alt
+- `Fix` — Toolbox will be opened when Slash pressed in ASCII-capable keyboard layout.
+
 ### 2.29.0
 
 - `New` — Editor Config now has the `style.nonce` attribute that could be used to allowlist editor style tag for Content Security Policy "style-src"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### 2.29.1
 
 - `Fix` — Toolbox wont be shown when Slash pressed with along with Shift or Alt
-- `Fix` — Toolbox will be opened when Slash pressed in ASCII-capable keyboard layout.
+- `Fix` — Toolbox will be opened when Slash pressed in non-US keyboard layout where there is no physical '/' key.
 
 ### 2.29.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/editorjs",
-  "version": "2.29.0",
+  "version": "2.29.1",
   "description": "Editor.js — Native JS, based on API and Open Source",
   "main": "dist/editorjs.umd.js",
   "module": "dist/editorjs.mjs",

--- a/src/components/modules/blockEvents.ts
+++ b/src/components/modules/blockEvents.ts
@@ -55,14 +55,21 @@ export default class BlockEvents extends Module {
     }
 
     /**
-     * Keyboard-layout independent handling of Slash key
+     * We check for "key" here since on different keyboard layouts "/" can be typed as "Shift + 7" etc
+     *
+     * @todo probably using "beforeInput" event would be better here
      */
-    if (event.key === '/' || event.code === 'Slash') {
-      if (event.ctrlKey || event.metaKey) {
-        this.commandSlashPressed();
-      } else if (!event.shiftKey && !event.altKey) {
-        this.slashPressed();
-      }
+    if (event.key === '/' && !event.ctrlKey && !event.metaKey) {
+      this.slashPressed();
+    }
+
+    /**
+     * If user pressed "Ctrl + /" or "Cmd + /" — open Block Settings
+     * We check for "code" here since on different keyboard layouts there can be different keys in place of Slash.
+     */
+    if (event.code === 'Slash' && (event.ctrlKey || event.metaKey)) {
+      event.preventDefault();
+      this.commandSlashPressed();
     }
   }
 

--- a/src/components/modules/blockEvents.ts
+++ b/src/components/modules/blockEvents.ts
@@ -52,13 +52,17 @@ export default class BlockEvents extends Module {
       case _.keyCodes.TAB:
         this.tabPressed(event);
         break;
-      case _.keyCodes.SLASH:
-        if (event.ctrlKey || event.metaKey) {
-          this.commandSlashPressed();
-        } else {
-          this.slashPressed();
-        }
-        break;
+    }
+
+    /**
+     * Keyboard-layout independent handling of Slash key
+     */
+    if (event.key === '/' || event.code === 'Slash') {
+      if (event.ctrlKey || event.metaKey) {
+        this.commandSlashPressed();
+      } else if (!event.shiftKey && !event.altKey) {
+        this.slashPressed();
+      }
     }
   }
 

--- a/src/components/modules/toolbar/index.ts
+++ b/src/components/modules/toolbar/index.ts
@@ -10,6 +10,7 @@ import Toolbox, { ToolboxEvent } from '../../ui/toolbox';
 import { IconMenu, IconPlus } from '@codexteam/icons';
 import { BlockHovered } from '../../events/BlockHovered';
 import { beautifyShortcut } from '../../utils';
+import { getKeyboardKeyForCode } from '../../utils/keyboard';
 
 /**
  * @todo Tab on non-empty block should open Block Settings of the hoveredBlock (not where caret is set)
@@ -352,7 +353,7 @@ export default class Toolbar extends Module<ToolbarNodes> {
   /**
    * Draws Toolbar elements
    */
-  private make(): void {
+  private async make(): Promise<void> {
     this.nodes.wrapper = $.make('div', this.CSS.toolbar);
     /**
      * @todo detect test environment and add data-cy="toolbar" to use it in tests instead of class name
@@ -414,10 +415,11 @@ export default class Toolbar extends Module<ToolbarNodes> {
 
     const blockTunesTooltip = $.make('div');
     const blockTunesTooltipEl = $.text(I18n.ui(I18nInternalNS.ui.blockTunes.toggler, 'Click to tune'));
+    const slashRealKey = await getKeyboardKeyForCode('Slash', '/');
 
     blockTunesTooltip.appendChild(blockTunesTooltipEl);
     blockTunesTooltip.appendChild($.make('div', this.CSS.plusButtonShortcut, {
-      textContent: beautifyShortcut('CMD + /'),
+      textContent: beautifyShortcut(`CMD + ${slashRealKey}`),
     }));
 
     tooltip.onHover(this.nodes.settingsToggler, blockTunesTooltip, {
@@ -585,7 +587,7 @@ export default class Toolbar extends Module<ToolbarNodes> {
     /**
      * Make Toolbar
      */
-    this.make();
+    void this.make();
   }
 
   /**

--- a/src/components/utils/keyboard.ts
+++ b/src/components/utils/keyboard.ts
@@ -1,0 +1,54 @@
+declare global {
+  /**
+   * https://developer.mozilla.org/en-US/docs/Web/API/KeyboardLayoutMap
+   */
+  interface KeyboardLayoutMap {
+    get(key: string): string | undefined;
+    has(key: string): boolean;
+    size: number;
+    entries(): IterableIterator<[string, string]>;
+    keys(): IterableIterator<string>;
+    values(): IterableIterator<string>;
+    forEach(callbackfn: (value: string, key: string, map: KeyboardLayoutMap) => void, thisArg?: unknown): void;
+  }
+
+  /**
+   * The getLayoutMap() method of the Keyboard interface returns a Promise
+   * that resolves with an instance of KeyboardLayoutMap which is a map-like object
+   * with functions for retrieving the strings associated with specific physical keys.
+   * https://developer.mozilla.org/en-US/docs/Web/API/Keyboard/getLayoutMap
+   */
+  interface Keyboard {
+    getLayoutMap(): Promise<KeyboardLayoutMap>;
+  }
+
+  interface Navigator {
+    /**
+     * Keyboard API. Not supported by Firefox and Safari.
+     */
+    keyboard?: Keyboard;
+  }
+}
+
+/**
+ * Returns real layout-related keyboard key for a given key code.
+ * For example, for "Slash" it will return "/" on US keyboard and "-" on Spanish keyboard.
+ *
+ * Works with Keyboard API which is not supported by Firefox and Safari. So fallback is used for these browsers.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/Keyboard
+ * @param code - {@link https://www.w3.org/TR/uievents-code/#key-alphanumeric-writing-system}
+ * @param fallback - fallback value to be returned if Keyboard API is not supported (Safari, Firefox)
+ */
+export async function getKeyboardKeyForCode(code: string, fallback: string): Promise<string> {
+  const keyboard = navigator.keyboard;
+
+  if (!keyboard) {
+    return fallback;
+  }
+
+  const map = await keyboard.getLayoutMap();
+  const key = map.get(code);
+
+  return key || fallback;
+}

--- a/test/cypress/tests/modules/BlockEvents/Slash.cy.ts
+++ b/test/cypress/tests/modules/BlockEvents/Slash.cy.ts
@@ -23,6 +23,36 @@ describe('Slash keydown', function () {
         .get('.ce-popover')
         .should('be.visible');
     });
+
+    [
+      '{shift}',
+      '{alt}',
+      '{option}',
+    ].forEach((key) => {
+      it(`should not open Toolbox if Slash pressed with ${key}`, () => {
+        cy.createEditor({
+          data: {
+            blocks: [
+              {
+                type: 'paragraph',
+                data: {
+                  text: '',
+                },
+              },
+            ],
+          },
+        });
+
+        cy.get('[data-cy=editorjs]')
+          .find('.ce-paragraph')
+          .click()
+          .type(`${key}/`);
+
+        cy.get('[data-cy="toolbox"]')
+          .get('.ce-popover')
+          .should('not.be.visible');
+      });
+    });
   });
 
   describe('pressed in non-empty block', function () {

--- a/test/cypress/tests/modules/BlockEvents/Slash.cy.ts
+++ b/test/cypress/tests/modules/BlockEvents/Slash.cy.ts
@@ -19,15 +19,13 @@ describe('Slash keydown', function () {
         .click()
         .type('/');
 
-      cy.get('[data-cy="toolbox"]')
-        .get('.ce-popover')
+      cy.get('[data-cy="toolbox"] .ce-popover')
         .should('be.visible');
     });
 
     [
-      '{shift}',
-      '{alt}',
-      '{option}',
+      'ctrl',
+      'cmd',
     ].forEach((key) => {
       it(`should not open Toolbox if Slash pressed with ${key}`, () => {
         cy.createEditor({
@@ -46,10 +44,9 @@ describe('Slash keydown', function () {
         cy.get('[data-cy=editorjs]')
           .find('.ce-paragraph')
           .click()
-          .type(`${key}/`);
+          .type(`{${key}}/`);
 
-        cy.get('[data-cy="toolbox"]')
-          .get('.ce-popover')
+        cy.get('[data-cy="toolbox"] .ce-popover')
           .should('not.be.visible');
       });
     });
@@ -75,8 +72,7 @@ describe('Slash keydown', function () {
         .click()
         .type('/');
 
-      cy.get('[data-cy="toolbox"]')
-        .get('.ce-popover')
+      cy.get('[data-cy="toolbox"] .ce-popover')
         .should('not.be.visible');
 
       /**
@@ -110,8 +106,7 @@ describe('CMD+Slash keydown', function () {
       .click()
       .type('{cmd}/');
 
-    cy.get('[data-cy="block-tunes"]')
-      .get('.ce-popover')
+    cy.get('[data-cy="block-tunes"] .ce-popover')
       .should('be.visible');
   });
 });

--- a/test/cypress/tests/utils/flipper.cy.ts
+++ b/test/cypress/tests/utils/flipper.cy.ts
@@ -38,7 +38,6 @@ class SomePlugin {
 
 describe('Flipper', () => {
   it('should prevent plugins event handlers from being called while keyboard navigation', () => {
-    const SLASH_KEY_CODE = 191;
     const ARROW_DOWN_KEY_CODE = 40;
     const ENTER_KEY_CODE = 13;
 
@@ -72,7 +71,7 @@ describe('Flipper', () => {
     cy.get('[data-cy=editorjs]')
       .get('.cdx-some-plugin')
       // Open tunes menu
-      .trigger('keydown', { keyCode: SLASH_KEY_CODE, ctrlKey: true })
+      .trigger('keydown', { code: 'Slash', ctrlKey: true })
       // Navigate to delete button (the second button)
       .trigger('keydown', { keyCode: ARROW_DOWN_KEY_CODE })
       .trigger('keydown', { keyCode: ARROW_DOWN_KEY_CODE });


### PR DESCRIPTION
## The problem

1. Right now Toolbox is opening even when Slash is pressed in a combination with Shift or Alt.
2. Toolbox is not opening for Slash press in non-default keyboard layouts 


https://github.com/codex-team/editor.js/assets/3684889/5b324819-69f4-49b4-86cd-210b12e0ee17


## Cause

1. We're checking all keyboard keys using `event.keyCode` property with is not working properly in some keyboard layout.
2. There was no check for Shift or Alt

## Solution

1. To open Toolbox we now use `event.key=/` to check exact "/" typed. So check for Shift or Alt is not needed, since `key` will be different in that case.
2. To open Block Tunes we now use `event.code=Slash` to check if slash-like key pressed with `cmd`. For example, in Spanish keyboard it will be `cmd+-`


Resolves #2597 
