### PR TITLE
fix: issue #2495

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,8 @@
 - `Fix` - Unexpected new line on Enter press with selected block without caret
 - `Fix` - Search input autofocus loosing after Block Tunes opening
 - `Fix` - Block removing while Enter press on Block Tunes
+- `Fix` - Render the placeholder only if defined.
+- `Fix` - Do not add empty block in readonly mode.
 
 ### 2.29.1
 

--- a/src/components/core.ts
+++ b/src/components/core.ts
@@ -170,7 +170,7 @@ export default class Core {
      * Initialize default Block to pass data to the Renderer
      */
     if (_.isEmpty(this.config.data) || !this.config.data.blocks || this.config.data.blocks.length === 0) {
-      this.config.data = { blocks: [ defaultBlockData ] };
+      this.config.data = { blocks: this.config.placeholder ? [ defaultBlockData ] : [] };
     }
 
     this.config.readOnly = this.config.readOnly as boolean || false;

--- a/src/components/modules/renderer.ts
+++ b/src/components/modules/renderer.ts
@@ -18,8 +18,8 @@ export default class Renderer extends Module {
     return new Promise((resolve) => {
       const { Tools, BlockManager } = this.Editor;
 
-      if (blocksData.length === 0) {
-        BlockManager.insert();
+      if (blocksData.length === 0 && this.config.readOnly === false) {
+          BlockManager.insert();
       } else {
         /**
          * Create Blocks instances

--- a/test/cypress/tests/initialization.cy.ts
+++ b/test/cypress/tests/initialization.cy.ts
@@ -37,8 +37,12 @@ describe('Editor basic initialization', () => {
       });
 
       it('should create editor without editing ability when true passed', () => {
+      /**
+       * Create readonly editor with a placeholder, to create a readonly paragraph block
+       */
         cy.createEditor({
           readOnly: true,
+          placeholder: "readonly-test"
         }).as('editorInstance');
 
         cy.get('[data-cy=editorjs]')


### PR DESCRIPTION
Fix issue #2495.

Changes:

* Add a default block only when a placeholder is defined.
* In renderer, inserting an empty block when zero blocks are given, results in an extra block being rendered. In readonly mode this is empty. Fix this behavior.

Outcome of this PR:

* Display the placeholder text, only if defined (whether in readonly mode or not).
* Do not add an extra empty paragraph in readonly mode.