### PR TITLE
added async to renderFromHTML in BlocksAPI

### DIFF
--- a/src/components/modules/api/blocks.ts
+++ b/src/components/modules/api/blocks.ts
@@ -205,8 +205,8 @@ export default class BlocksAPI extends Module {
    * @param {string} data - HTML string to render
    * @returns {Promise<void>}
    */
-  public renderFromHTML(data: string): Promise<void> {
-    this.Editor.BlockManager.clear();
+  public async renderFromHTML(data: string): Promise<void> {
+    await this.Editor.BlockManager.clear();
 
     return this.Editor.Paste.processText(data, true);
   }


### PR DESCRIPTION
fix #2641 

Added aync to renderFromHTML within BlocksAPI. 
This was done to be able to await BlockManager.clear()