### PR TITLE
fix(block-events): unwanted soft line break on iOS after ". |"

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `Fix` - Unexpected new line on Enter press with selected block without caret
 - `Fix` - Search input autofocus loosing after Block Tunes opening
 - `Fix` - Block removing while Enter press on Block Tunes
+- `Fix` - Unwanted soft line break on Enter press after period and space (". |") on iOS devices
 
 ### 2.29.1
 

--- a/src/components/modules/blockEvents.ts
+++ b/src/components/modules/blockEvents.ts
@@ -279,8 +279,12 @@ export default class BlockEvents extends Module {
 
     /**
      * Allow to create line breaks by Shift+Enter
+     *
+     * Note. On iOS devices, Safari automatically treats enter after a period+space (". |") as Shift+Enter
+     * (it used for capitalizing of the first letter of the next sentence)
+     * We don't need to lead soft line break in this case — new block should be created
      */
-    if (event.shiftKey) {
+    if (event.shiftKey && !_.isIosDevice) {
       return;
     }
 


### PR DESCRIPTION
## Problem 

On iOS if you end block with the period and space, soft line break will be created on Enter instead of the new block

https://github.com/codex-team/editor.js/assets/3684889/a3598f61-e4e2-4ac9-a096-a4e0af6fc169

## Cause

iOS automatically capitalized the next word after a period and space (`. |`). It toggles the `event.shiftKey` of the next keydown event. So our logic decide that SHIFT+ENTER has been pressed.

## Solution

I added a check for iOS to do not handle such "fake" shiftKey. On Android it works fine so I'm checking only iOS.
