### PR TITLE
fix(conversion): caret loosing after block conversion

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `Fix` - Unexpected new line on Enter press with selected block without caret
 - `Fix` - Search input autofocus loosing after Block Tunes opening
 - `Fix` - Block removing while Enter press on Block Tunes
+- `Fix` - Caret lost after block conversion on mobile devices.
 
 ### 2.29.1
 

--- a/src/components/modules/blockManager.ts
+++ b/src/components/modules/blockManager.ts
@@ -370,10 +370,10 @@ export default class BlockManager extends Module {
    * @param newTool - new Tool name
    * @param data - new Tool data
    */
-  public replace(block: Block, newTool: string, data: BlockToolData): void {
+  public replace(block: Block, newTool: string, data: BlockToolData): Block {
     const blockIndex = this.getBlockIndex(block);
 
-    this.insert({
+    return this.insert({
       tool: newTool,
       data,
       index: blockIndex,
@@ -821,7 +821,7 @@ export default class BlockManager extends Module {
    * @param targetToolName - name of the Tool to convert to
    * @param blockDataOverrides - optional new Block data overrides
    */
-  public async convert(blockToConvert: Block, targetToolName: string, blockDataOverrides?: BlockToolData): Promise<void> {
+  public async convert(blockToConvert: Block, targetToolName: string, blockDataOverrides?: BlockToolData): Promise<Block> {
     /**
      * At first, we get current Block data
      */
@@ -866,7 +866,7 @@ export default class BlockManager extends Module {
       newBlockData = Object.assign(newBlockData, blockDataOverrides);
     }
 
-    this.replace(blockToConvert, replacingTool.name, newBlockData);
+    return this.replace(blockToConvert, replacingTool.name, newBlockData);
   }
 
   /**

--- a/src/components/modules/toolbar/blockSettings.ts
+++ b/src/components/modules/toolbar/blockSettings.ts
@@ -289,18 +289,16 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
           icon: toolboxItem.icon,
           title: toolboxItem.title,
           name: toolName,
-          onActivate: () => {
+          onActivate: async () => {
             const { BlockManager, BlockSelection, Caret } = this.Editor;
 
-            BlockManager.convert(this.Editor.BlockManager.currentBlock, toolName, toolboxItem.data);
+            const newBlock = await BlockManager.convert(this.Editor.BlockManager.currentBlock, toolName, toolboxItem.data);
 
             BlockSelection.clearSelection();
 
             this.close();
 
-            window.requestAnimationFrame(() => {
-              Caret.setToBlock(this.Editor.BlockManager.currentBlock, Caret.positions.END);
-            });
+            Caret.setToBlock(newBlock, Caret.positions.END);
           },
         });
       });


### PR DESCRIPTION
## Problem

The editor loses focus after converting a block on mobile devices.

https://github.com/codex-team/editor.js/assets/3684889/9c10702a-deff-4df0-99ce-26c2ea7da95e

## Case

The block's focus was previously wrapped in requestAnimationFrame. However, Safari prevents the programmatic setting of a caret without user interaction. All caret operations should occur in the same execution stack as a user interaction, such as a keydown event.

## Solution

We have removed requestAnimationFrame and now set the caret explicitly to the added block. This solution ensures it works correctly in Safari as well as on the desktop version.