### PR TITLE
propagate click event to popover item activation callback

### DIFF
--- a/src/components/utils/popover/components/popover-item/popover-item-default/popover-item-default.ts
+++ b/src/components/utils/popover/components/popover-item/popover-item-default/popover-item-default.ts
@@ -103,15 +103,16 @@ export class PopoverItemDefault extends PopoverItem {
 
   /**
    * Called on popover item click
+   * @param event - click event
    */
-  public handleClick(): void {
+  public handleClick(event: Event): void {
     if (this.isConfirmationStateEnabled && this.confirmationState !== null) {
-      this.activateOrEnableConfirmationMode(this.confirmationState);
+      this.activateOrEnableConfirmationMode(this.confirmationState, event);
 
       return;
     }
 
-    this.activateOrEnableConfirmationMode(this.params);
+    this.activateOrEnableConfirmationMode(this.params, event);
   }
 
   /**
@@ -281,11 +282,12 @@ export class PopoverItemDefault extends PopoverItem {
    * Executes item's onActivate callback if the item has no confirmation configured
    *
    * @param item - item to activate or bring to confirmation mode
+   * @param event - pointer event that triggered item activation
    */
-  private activateOrEnableConfirmationMode(item: PopoverItemDefaultParams): void {
+  private activateOrEnableConfirmationMode(item: PopoverItemDefaultParams, event?: PointerEvent): void {
     if (item.confirmation === undefined) {
       try {
-        item.onActivate?.(item);
+        item.onActivate?.(item, event);
         this.disableConfirmationMode();
       } catch {
         this.animateError();

--- a/src/components/utils/popover/popover-abstract.ts
+++ b/src/components/utils/popover/popover-abstract.ts
@@ -261,7 +261,7 @@ export abstract class PopoverAbstract<Nodes extends PopoverNodes = PopoverNodes>
     /** Cleanup other items state */
     this.itemsInteractive.filter(x => x !== item).forEach(x => x.reset());
 
-    item.handleClick();
+    item.handleClick(event);
 
     this.toggleItemActivenessIfNeeded(item);
 


### PR DESCRIPTION
For creating modals that can attach to the popover menu, it is useful to have the event data being propagated to the onActivate() callback. The interface already had the event implemented:
https://github.com/codex-team/editor.js/blob/238c90901681614a91e3b72ecbf406a7c2a23f05/src/components/utils/popover/components/popover-item/popover-item.types.ts#L91

But the methods in after the event listener did not pass the event data on yet.