### PR TITLE
fix(slash): slash insertion in a wrong place

### DIFF
--- a/src/components/modules/blockEvents.ts
+++ b/src/components/modules/blockEvents.ts
@@ -249,6 +249,13 @@ export default class BlockEvents extends Module {
       return;
     }
 
+    /**
+     * The Toolbox will be opened with immediate focus on the Search input,
+     * and '/' will be added in the search input by default — we need to prevent it and add '/' manually
+     */
+    event.preventDefault();
+    this.Editor.Caret.insertContentAtCaretPosition('/');
+
     this.activateToolbox();
   }
 

--- a/test/cypress/tests/modules/BlockEvents/Slash.cy.ts
+++ b/test/cypress/tests/modules/BlockEvents/Slash.cy.ts
@@ -1,6 +1,6 @@
 describe('Slash keydown', function () {
   describe('pressed in empty block', function () {
-    it('should open Toolbox', () => {
+    it('should add "/" in a block and open Toolbox', () => {
       cy.createEditor({
         data: {
           blocks: [
@@ -18,6 +18,14 @@ describe('Slash keydown', function () {
         .find('.ce-paragraph')
         .click()
         .type('/');
+
+      /**
+       * Block content should contain slash
+       */
+      cy.get('[data-cy=editorjs]')
+        .find('.ce-paragraph')
+        .invoke('text')
+        .should('eq', '/');
 
       cy.get('[data-cy="toolbox"] .ce-popover__container')
         .should('be.visible');


### PR DESCRIPTION
## Problem

In the RC version, when you press the "/", it inserted at the opened toolbox search input.

https://github.com/codex-team/editor.js/assets/3684889/4d02f226-0a92-4b25-b23c-636e8ace37d5

### Expected behaviour

Slash inserted at the Block, Toolbox is opened with a focused search.

## Cause 

In #2650 I have removed the `requestAnimationFrame` from the Popover focusing. It is ok otherwise browser will block setting a caret.

<img width="408" alt="image" src="https://github.com/codex-team/editor.js/assets/3684889/af0b351d-1fc7-422b-9d39-259c6b098152">

So right now the default slash keydown handler is called when search input is focused.

## Solution

I'm preventing the default slash-keydown handler and add a slash manually before opening a caret.

## P. S. 

There is no changelog since bug exists only in RC
