### PR TITLE
feat(popover): Add hint support

### DIFF
--- a/src/components/utils/popover/components/hint-content/hint-content.ts
+++ b/src/components/utils/popover/components/hint-content/hint-content.ts
@@ -1,0 +1,6 @@
+/**
+ *
+ */
+export class HintContent {
+
+}

--- a/src/components/utils/popover/components/popover-item/popover-item-default/popover-item-default.ts
+++ b/src/components/utils/popover/components/popover-item/popover-item-default/popover-item-default.ts
@@ -6,6 +6,7 @@ import {
 } from '../popover-item.types';
 import { PopoverItem } from '../popover-item';
 import { css } from './popover-item-default.const';
+import * as tooltip from '../../../../../utils/tooltip';
 
 /**
  * Represents sigle popover item node
@@ -195,6 +196,13 @@ export class PopoverItemDefault extends PopoverItem {
 
     if (params.isDisabled) {
       el.classList.add(css.disabled);
+    }
+
+    if (params.hint !== undefined) {
+      tooltip.onHover(el, params.hint.title, {
+        placement: 'right',
+        hidingDelay: 100,
+      });
     }
 
     return el;

--- a/src/components/utils/popover/components/popover-item/popover-item.types.ts
+++ b/src/components/utils/popover/components/popover-item/popover-item.types.ts
@@ -89,6 +89,11 @@ interface PopoverItemDefaultBaseParams {
    * In case of string, works like radio buttons group and highlights as inactive any other item that has same toggle key value.
    */
   toggle?: boolean | string;
+
+  hint?: {
+    title: string;
+    description?: string;
+  }
 }
 
 /**


### PR DESCRIPTION
It becomes possible to display a hint near popover item. 
Only works in desktop popover. 

![image](https://github.com/codex-team/editor.js/assets/31101125/ba315060-21c7-4984-86d0-a671751089ee)
