### PR TITLE
chore(cypress): Change cypress bundler from Webpack to Vite

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
     // We've imported your old cypress plugins here.
     // You may want to clean this up later by importing these.
     setupNodeEvents(on, config) {
+      on('file:preprocessor', require('cypress-vite')(config));
+
       /**
        * Plugin for cypress that adds better terminal output for easier debugging.
        * Prints cy commands, browser console logs, cy.request and cy.intercept data. Great for your pipelines.

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "cypress-intellij-reporter": "^0.0.7",
     "cypress-plugin-tab": "^1.0.5",
     "cypress-terminal-report": "^5.3.2",
+    "cypress-vite": "^1.5.0",
     "eslint": "^8.37.0",
     "eslint-config-codex": "^1.7.1",
     "eslint-plugin-chai-friendly": "^0.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1424,6 +1424,21 @@ chokidar@3.5.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
+chokidar@^3.5.3:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
+  integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 ci-info@^3.2.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
@@ -1688,6 +1703,14 @@ cypress-terminal-report@^5.3.2:
     safe-json-stringify "^1.2.0"
     semver "^7.3.5"
     tv4 "^1.3.0"
+
+cypress-vite@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/cypress-vite/-/cypress-vite-1.5.0.tgz#471ecc1175c7ab51b3b132c595dc3c7e222fe944"
+  integrity sha512-vvTMqJZgI3sN2ylQTi4OQh8LRRjSrfrIdkQD5fOj+EC/e9oHkxS96lif1SyDF1PwailG1tnpJE+VpN6+AwO/rg==
+  dependencies:
+    chokidar "^3.5.3"
+    debug "^4.3.4"
 
 cypress@^13.7.1:
   version "13.7.1"


### PR DESCRIPTION
Using [cypress-vite](https://github.com/mammadataei/cypress-vite) and Cypress [preprocessors API](https://docs.cypress.io/plugins#preprocessors)