### PR TITLE
fix(block-events): caret losing after backspace after nested list 

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `Fix` – Unwanted scroll on first typing on iOS devices
 - `Fix` - Unwanted soft line break on Enter press after period and space (". |") on iOS devices
 - `Fix` - Caret lost after block conversion on mobile devices.
+- `Fix` - Caret lost after Backspace at the start of block when previoius block is not convertable
 - `Improvement` - The API `blocks.convert()` now returns the new block API
 - `Improvement` - The API `caret.setToBlock()` now can accept either BlockAPI or block index or block id
 - `New` – *Menu Config* – New item type – HTML

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/editorjs",
-  "version": "2.30.0-rc.9",
+  "version": "2.30.0-rc.10",
   "description": "Editor.js — Native JS, based on API and Open Source",
   "main": "dist/editorjs.umd.js",
   "module": "dist/editorjs.mjs",

--- a/src/components/modules/blockEvents.ts
+++ b/src/components/modules/blockEvents.ts
@@ -395,7 +395,6 @@ export default class BlockEvents extends Module {
       return;
     }
 
-
     const bothBlocksMergeable = areBlocksMergeable(previousBlock, currentBlock);
 
     /**

--- a/src/components/modules/blockEvents.ts
+++ b/src/components/modules/blockEvents.ts
@@ -500,7 +500,7 @@ export default class BlockEvents extends Module {
   private mergeBlocks(targetBlock: Block, blockToMerge: Block): void {
     const { BlockManager, Caret, Toolbar } = this.Editor;
 
-    Caret.createShadow(targetBlock.pluginsContent);
+    Caret.createShadow(targetBlock.lastInput);
 
     BlockManager
       .mergeBlocks(targetBlock, blockToMerge)

--- a/src/components/modules/blockEvents.ts
+++ b/src/components/modules/blockEvents.ts
@@ -60,7 +60,7 @@ export default class BlockEvents extends Module {
      * @todo probably using "beforeInput" event would be better here
      */
     if (event.key === '/' && !event.ctrlKey && !event.metaKey) {
-      this.slashPressed();
+      this.slashPressed(event);
     }
 
     /**
@@ -233,8 +233,10 @@ export default class BlockEvents extends Module {
 
   /**
    * '/' keydown inside a Block
+   *
+   * @param event - keydown
    */
-  private slashPressed(): void {
+  private slashPressed(event: KeyboardEvent): void {
     const currentBlock = this.Editor.BlockManager.currentBlock;
     const canOpenToolbox = currentBlock.isEmpty;
 

--- a/src/components/modules/blockEvents.ts
+++ b/src/components/modules/blockEvents.ts
@@ -395,7 +395,8 @@ export default class BlockEvents extends Module {
       return;
     }
 
-    const bothBlocksMergeable = areBlocksMergeable(currentBlock, previousBlock);
+
+    const bothBlocksMergeable = areBlocksMergeable(previousBlock, currentBlock);
 
     /**
      * If Blocks could be merged, do it

--- a/test/cypress/tests/modules/BlockEvents/Backspace.cy.ts
+++ b/test/cypress/tests/modules/BlockEvents/Backspace.cy.ts
@@ -1,6 +1,7 @@
 import type EditorJS from '../../../../../types/index';
 import Chainable = Cypress.Chainable;
 import { SimpleHeader } from '../../../fixtures/tools/SimpleHeader';
+import type { ConversionConfig } from '../../../../../types/index';
 
 
 /**
@@ -525,7 +526,7 @@ describe('Backspace keydown', function () {
       /**
        * Mock of the conversionConfig
        */
-      public static get conversionConfig(): { export: string | Function; import: string | Function } {
+      public static get conversionConfig(): ConversionConfig {
         return {
           export: 'key',
           import: 'key',

--- a/test/cypress/tests/modules/BlockEvents/Backspace.cy.ts
+++ b/test/cypress/tests/modules/BlockEvents/Backspace.cy.ts
@@ -519,13 +519,13 @@ describe('Backspace keydown', function () {
       public save(): { key: string } {
         return {
           key: 'value',
-        }
+        };
       }
 
       /**
        * Mock of the conversionConfig
        */
-      static get conversionConfig() {
+      public static get conversionConfig(): { export: string | Function; import: string | Function } {
         return {
           export: 'key',
           import: 'key',


### PR DESCRIPTION
## Problem

Pressing backspace at the start of a paragraph after a Nested List causes the caret to be lost.

https://github.com/codex-team/editor.js/assets/3684889/90764672-dafe-424a-949b-4a74566926f4


## Cause

There are two problems:

1. The backspace handler incorrectly shows `true` for `areBlockMergeable()`. This was due to confused arguments: the first argument is the block to merge into, and the second is the block to merge from. After fixing this, `areBlockMergeable()` will return `false`.

2. The Nested List tool has a `conversionConfig` but lacks a `merge()` method, making it **not mergeable**. This case was not covered by tests, so I've added the corresponding test case.

3. During debugging, I noticed that creating/restoring the Shadow caret did not work for Nested Lists. Previously, it added a Shadow caret to `pluginContent`, which is complex for Nested Lists, and it was added to a wrong place.

## Solution

1. Fixed the order of arguments for `areBlockMergeable()`.
2. Changed the argument of `createShadow()` from `pluginContent` to `lastInput`, so the shadow caret is now set properly. Although with the fix №1 this logic won't be called, but I've fixed it anyway.

https://github.com/codex-team/editor.js/assets/3684889/7b119fa5-dfec-4895-9f20-8f08a4b7a681

And then I'm gonna update the Nested List tool adding a `merge()` method in there. After that the merging will start working instead of caret moving.