### PR TITLE
Improve link creating on mobile devices

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@
 – `Fix` — Deleting whitespaces at the start/end of the block
 – `Improvement` — *Types* — `BlockToolConstructorOptions` type improved, `block` and `config` are not optional anymore
 - `Improvement` - The Plus button and Block Tunes toggler are now better aligned with large line-height blocks, such as Headings
+- `Improvement` — Creating links on Android devices: now the mobile keyboard will have an "Enter" key for accepting the inserted link.
 
 ### 2.29.1
 

--- a/src/components/inline-tools/inline-tool-link.ts
+++ b/src/components/inline-tools/inline-tool-link.ts
@@ -134,6 +134,7 @@ export default class LinkInlineTool implements InlineTool {
   public renderActions(): HTMLElement {
     this.nodes.input = document.createElement('input') as HTMLInputElement;
     this.nodes.input.placeholder = this.i18n.t('Add a link');
+    this.nodes.input.enterKeyHint = 'done';
     this.nodes.input.classList.add(this.CSS.input);
     this.nodes.input.addEventListener('keydown', (event: KeyboardEvent) => {
       if (event.keyCode === this.ENTER_KEY) {


### PR DESCRIPTION
I suggest you to add new attribute for the link input to make it work inside forms with multiple fields.

Right now when you creating a link on Android device, you cannot confirm it, because you will be switched to the next text input of the form. But if we will add `enterKeyHint` attribute, everything works as expected.

Before the change:

https://github.com/codex-team/editor.js/assets/1257284/0dddbf57-23da-42a5-bb68-1e291a275364

After the change

https://github.com/codex-team/editor.js/assets/1257284/af0b65e0-65ff-4ba6-a4c0-4e79804f1204

P.S. I think [this issue](https://github.com/codex-team/editor.js/issues/1970) is related but you can't reproduce it on demo site because you have no next inputs in the form.


