### PR TITLE
chore(types): improve block constructor options types

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@
 – `Refactoring` – Switched to Vite as Cypress bundler
 – `New` – *Menu Config* – Default and HTML items now support hints
 – `Fix` — Deleting whitespaces at the start/end of the block
+– `Improvement` — *Types* — `BlockToolConstructorOptions` type improved, `block` and `config` are not optional anymore
 
 ### 2.29.1
 

--- a/types/tools/block-tool.d.ts
+++ b/types/tools/block-tool.d.ts
@@ -86,8 +86,8 @@ export interface BlockTool extends BaseTool {
 export interface BlockToolConstructorOptions<D extends object = any, C extends object = any> {
   api: API;
   data: BlockToolData<D>;
-  config?: ToolConfig<C>;
-  block?: BlockAPI;
+  config: ToolConfig<C>;
+  block: BlockAPI;
   readOnly: boolean;
 }
 


### PR DESCRIPTION
## Problem 

We have a mistake in the `BlockToolConstructorOptions` options: `block` and `config` types marked as optional but they are always assigned.

And tools developers had to check them for emptiness, which is useless:

<img width="500" alt="image" src="https://github.com/codex-team/editor.js/assets/3684889/a471ce2a-58a6-4a4d-8736-af60592be6a4">

## Cause

Probably it was added for supporting of old tools, but old tools should use old version of editor. 

## Solution

`block` and `config` became not-optional