### PR TITLE
Solve the problem that / cannot evoke toolbox in Chinese input method…

### DIFF
--- a/src/components/modules/blockEvents.ts
+++ b/src/components/modules/blockEvents.ts
@@ -59,7 +59,7 @@ export default class BlockEvents extends Module {
      *
      * @todo probably using "beforeInput" event would be better here
      */
-    if (event.key === '/' && !event.ctrlKey && !event.metaKey) {
+    if (event.code === 'Slash' && !event.ctrlKey && !event.metaKey) {
       this.slashPressed(event);
     }
 
@@ -251,14 +251,9 @@ export default class BlockEvents extends Module {
       return;
     }
 
-    /**
-     * The Toolbox will be opened with immediate focus on the Search input,
-     * and '/' will be added in the search input by default — we need to prevent it and add '/' manually
-     */
-    event.preventDefault();
-    this.Editor.Caret.insertContentAtCaretPosition('/');
-
-    this.activateToolbox();
+    setTimeout(() => {
+      this.activateToolbox();
+    }, 0);
   }
 
   /**


### PR DESCRIPTION
1. Solve the problem that `/` cannot evoke toolbox in Chinese input method. `the symbol / : event.key=Process, event.code=Slash, event.keyCode=229`
2. Solve the problem that `/` is automatically entered in searchInput after Chinese input method evokes toolbox