### PR TITLE
fix(inline-toolbar): remove white dot visible in dark theme

### DIFF
--- a/src/styles/inline-toolbar.css
+++ b/src/styles/inline-toolbar.css
@@ -6,7 +6,7 @@
   --color-text-icon-active: #388AE5;
   --color-text-primary: black;
 
-  @apply --overlay-pane;
+  position: absolute;
   visibility: hidden;
   transition: opacity 250ms ease;
   will-change: opacity, left, top;

--- a/test/cypress/tests/modules/InlineToolbar.cy.ts
+++ b/test/cypress/tests/modules/InlineToolbar.cy.ts
@@ -71,7 +71,7 @@ describe('Inline Toolbar', () => {
             /**
              * Toolbar should be aligned with right side of text column
              */
-            expect($toolbar.offset().left + $toolbar.width()).to.closeTo(blockWrapperRect.right, 9);
+            expect($toolbar.offset().left + $toolbar.width()).to.closeTo(blockWrapperRect.right, 10);
           });
       });
   });


### PR DESCRIPTION
In dark mode hidden inline toolbar was still visible as a white dot. 

Removed redundant styles.

![telegram-cloud-photo-size-2-5199787704517253983-x](https://github.com/codex-team/editor.js/assets/31101125/0bf32372-262c-4832-b1cc-f7ff83e15619)
