### PR TITLE
fix(inline-toolbar): Make link tools with actions more stable

### DIFF
--- a/src/components/inline-tools/inline-tool-convert.ts
+++ b/src/components/inline-tools/inline-tool-convert.ts
@@ -1,6 +1,6 @@
 import { IconReplace } from '@codexteam/icons';
 import { InlineTool, API } from '../../../types';
-import { MenuConfig } from '../../../types/tools';
+import { MenuConfig, MenuConfigItem } from '../../../types/tools';
 import * as _ from '../utils';
 import { Blocks, Selection, Tools, I18n, Caret } from '../../../types/api';
 import SelectionUtils from '../selection';
@@ -57,6 +57,11 @@ export default class ConvertInlineTool implements InlineTool {
   public async render(): Promise<MenuConfig> {
     const currentSelection = SelectionUtils.get();
     const currentBlock = this.blocksAPI.getBlockByElement(currentSelection.anchorNode as HTMLElement);
+
+    if (currentBlock === undefined) {
+      return [];
+    }
+
     const allBlockTools = this.toolsAPI.getBlockTools();
     const convertibleTools = await getConvertibleToolsForBlock(currentBlock, allBlockTools);
 
@@ -64,8 +69,8 @@ export default class ConvertInlineTool implements InlineTool {
       return [];
     }
 
-    const convertToItems = convertibleTools.reduce((result, tool) => {
-      tool.toolbox.forEach((toolboxItem) => {
+    const convertToItems = convertibleTools.reduce<MenuConfigItem[]>((result, tool) => {
+      tool.toolbox?.forEach((toolboxItem) => {
         result.push({
           icon: toolboxItem.icon,
           title: toolboxItem.title,

--- a/src/components/modules/toolbar/inline.ts
+++ b/src/components/modules/toolbar/inline.ts
@@ -384,7 +384,7 @@ export default class InlineToolbar extends Module<InlineToolbarNodes> {
             const actions = instance.renderActions();
 
             (popoverItem as WithChildren<PopoverItemHtmlParams>).children = {
-              isOpen: instance.checkState(SelectionUtils.get()),
+              isOpen: instance.checkState?.(SelectionUtils.get()),
               items: [
                 {
                   type: PopoverItemType.Html,
@@ -396,7 +396,7 @@ export default class InlineToolbar extends Module<InlineToolbarNodes> {
             /**
              * Legacy inline tools might perform some UI mutating logic in checkState method, so, call it just in case
              */
-            instance.checkState(SelectionUtils.get());
+            instance.checkState?.(SelectionUtils.get());
           }
 
           popoverItems.push(popoverItem);
@@ -521,10 +521,6 @@ export default class InlineToolbar extends Module<InlineToolbarNodes> {
    */
   private toolClicked(tool: IInlineTool): void {
     const range = SelectionUtils.range;
-
-    if (range === null) {
-      return;
-    }
 
     tool.surround?.(range);
     this.checkToolsState();

--- a/src/components/utils/popover/components/popover-item/popover-item-html/popover-item-html.ts
+++ b/src/components/utils/popover/components/popover-item/popover-item-html/popover-item-html.ts
@@ -67,11 +67,4 @@ export class PopoverItemHtml extends PopoverItem {
 
     return Array.from(controls);
   }
-
-  /**
-   * Called on popover item click
-   */
-  public handleClick(): void {
-    this.params.onActivate?.(this.params);
-  }
 }

--- a/src/components/utils/popover/components/popover-item/popover-item.ts
+++ b/src/components/utils/popover/components/popover-item/popover-item.ts
@@ -59,6 +59,21 @@ export abstract class PopoverItem {
   }
 
   /**
+   * Called on popover item click
+   */
+  public handleClick(): void {
+    if (this.params === undefined) {
+      return;
+    }
+
+    if (!('onActivate' in this.params)) {
+      return;
+    }
+
+    this.params.onActivate?.(this.params);
+  }
+
+  /**
    * Adds hint to the item element if hint data is provided
    *
    * @param itemElement - popover item root element to add hint to
@@ -128,8 +143,9 @@ export abstract class PopoverItem {
     if (this.params === undefined) {
       return false;
     }
+
     if (!('isActive' in this.params)) {
-      return;
+      return false;
     }
 
     if (typeof this.params.isActive === 'function') {

--- a/src/components/utils/popover/popover-desktop.ts
+++ b/src/components/utils/popover/popover-desktop.ts
@@ -1,6 +1,6 @@
 import Flipper from '../../flipper';
 import { PopoverAbstract } from './popover-abstract';
-import { PopoverItem, PopoverItemRenderParamsMap, PopoverItemSeparator, WithChildren, css as popoverItemCls } from './components/popover-item';
+import { PopoverItem, PopoverItemRenderParamsMap, PopoverItemSeparator, css as popoverItemCls } from './components/popover-item';
 import { PopoverEvent, PopoverParams } from './popover.types';
 import { keyCodes } from '../../utils';
 import { CSSVariables, css } from './popover.const';
@@ -31,6 +31,11 @@ export class PopoverDesktop extends PopoverAbstract {
    * Undefined by default, PopoverDesktop when exists and null after destroyed.
    */
   protected nestedPopover: PopoverDesktop | undefined | null;
+
+  /**
+   * Item nested popover is displayed for
+   */
+  protected nestedPopoverTriggerItem: PopoverItem | null = null;
 
   /**
    * Last hovered item inside popover.
@@ -166,10 +171,13 @@ export class PopoverDesktop extends PopoverAbstract {
    *
    * @param item – item to show nested popover for
    */
-  protected override showNestedItems(item: WithChildren<PopoverItemDefault> | WithChildren<PopoverItemHtml>): void {
+  protected override showNestedItems(item: PopoverItem): void {
     if (this.nestedPopover !== null && this.nestedPopover !== undefined) {
       return;
     }
+
+    this.nestedPopoverTriggerItem = item;
+
     this.showNestedPopoverForItem(item);
   }
 
@@ -207,7 +215,7 @@ export class PopoverDesktop extends PopoverAbstract {
    * @param nestedPopoverEl - nested popover element
    * @param item – item near which nested popover should be displayed
    */
-  protected setTriggerItemPosition(nestedPopoverEl: HTMLElement, item: WithChildren<PopoverItemDefault> | WithChildren<PopoverItemHtml>): void {
+  protected setTriggerItemPosition(nestedPopoverEl: HTMLElement, item: PopoverItem): void {
     const itemEl = item.getElement();
     const itemOffsetTop = (itemEl ? itemEl.offsetTop : 0) - this.scrollTop;
     const topOffset = this.offsetTop + itemOffsetTop;
@@ -230,7 +238,7 @@ export class PopoverDesktop extends PopoverAbstract {
     this.nestedPopover = null;
     this.flipper.activate(this.flippableElements);
 
-    this.items.forEach(item => item.onChildrenClose());
+    this.nestedPopoverTriggerItem?.onChildrenClose();
   }
 
   /**
@@ -239,7 +247,7 @@ export class PopoverDesktop extends PopoverAbstract {
    *
    * @param item - item to display nested popover by
    */
-  protected showNestedPopoverForItem(item: WithChildren<PopoverItemDefault> | WithChildren<PopoverItemHtml>): PopoverDesktop {
+  protected showNestedPopoverForItem(item: PopoverItem): PopoverDesktop {
     this.nestedPopover = new PopoverDesktop({
       searchable: item.isChildrenSearchable,
       items: item.children,

--- a/src/components/utils/popover/popover-inline.ts
+++ b/src/components/utils/popover/popover-inline.ts
@@ -1,5 +1,5 @@
 import { isMobileScreen } from '../../utils';
-import { PopoverItem, PopoverItemDefault, PopoverItemType, WithChildren } from './components/popover-item';
+import { PopoverItem, PopoverItemDefault, PopoverItemType } from './components/popover-item';
 import { PopoverItemHtml } from './components/popover-item/popover-item-html/popover-item-html';
 import { PopoverDesktop } from './popover-desktop';
 import { CSSVariables, css } from './popover.const';
@@ -9,11 +9,6 @@ import { PopoverParams } from './popover.types';
  * Horizontal popover that is displayed inline with the content
  */
 export class PopoverInline extends PopoverDesktop {
-  /**
-   * Item nested popover is displayed for
-   */
-  private nestedPopoverTriggerItem: PopoverItemDefault | PopoverItemHtml | null = null;
-
   /**
    * Constructs the instance
    *
@@ -138,7 +133,6 @@ export class PopoverInline extends PopoverDesktop {
       return;
     }
 
-    this.nestedPopoverTriggerItem = item;
     super.showNestedItems(item);
   }
 
@@ -148,7 +142,7 @@ export class PopoverInline extends PopoverDesktop {
    *
    * @param item - item to display nested popover by
    */
-  protected showNestedPopoverForItem(item: WithChildren<PopoverItemDefault> | WithChildren<PopoverItemHtml>): PopoverDesktop {
+  protected showNestedPopoverForItem(item: PopoverItem): PopoverDesktop {
     const nestedPopover = super.showNestedPopoverForItem(item);
     const nestedPopoverEl = nestedPopover.getElement();
 

--- a/types/tools/inline-tool.d.ts
+++ b/types/tools/inline-tool.d.ts
@@ -13,10 +13,10 @@ export interface InlineTool extends BaseTool<HTMLElement | MenuConfig> {
 
   /**
    * Method that accepts selected range and wrap it somehow
-   * @param {Range} range - selection's range
+   * @param range - selection's range. If no active selection, range is null
    * @deprecated use {@link MenuConfig} item onActivate property instead
    */
-  surround?(range: Range): void;
+  surround?(range: Range | null): void;
 
   /**
    * Get SelectionUtils and detect if Tool was applied


### PR DESCRIPTION
## Problem

In Safari after serial opening of Convert to and Link tools, Link tools actions stop rendering. 
This was happening due to 2 reasons:
- children popover close callback was called on all the items regardless which item exactly "owned" children popover
- Link tool's `surround()` that toggles actions visibility was not called when range is 'null' (no active selection). This was broken by [recent PR](https://github.com/codex-team/editor.js/commit/439658a9123b747ab45a7391dab146194200cb0e#diff-e55ad4bb9846bb8d75e77413ab3e49c30e75f6bb8b58833d2b539cebb8186b10R525)

https://github.com/codex-team/editor.js/assets/31101125/34204333-5fd2-4188-a557-1623311e3aa6

## Solution
- Removed null check for calling `surround()`
- Start calling close callback fn more precisely