### PR TITLE
feat(ui): placeholders updated

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,9 @@
 – `Improvement` — *Types* — `BlockToolConstructorOptions` type improved, `block` and `config` are not optional anymore
 - `Improvement` - The Plus button and Block Tunes toggler are now better aligned with large line-height blocks, such as Headings
 - `Improvement` — Creating links on Android devices: now the mobile keyboard will have an "Enter" key for accepting the inserted link.
+- `Improvement` — Placeholders will stay visible on inputs focus.
+- `New` — Editor.js now supports contenteditable placeholders out of the box. Just add `data-placeholder` or `data-placeholder-active` attribute to make it work. The first one will work like native placeholder while the second one will show placeholder only when block is current.
+- `Improvement` — Now Paragraph placeholder will be shown for the current paragraph, not the only first one.
 
 ### 2.29.1
 

--- a/index.html
+++ b/index.html
@@ -203,6 +203,9 @@
        */
       // defaultBlock: 'paragraph',
 
+      placeholder: 'Write something or press / to select a tool',
+      autofocus: true,
+
       /**
        * Initial Editor data
        */

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@editorjs/code": "^2.7.0",
     "@editorjs/delimiter": "^1.2.0",
     "@editorjs/header": "^2.7.0",
-    "@editorjs/paragraph": "^2.11.4",
+    "@editorjs/paragraph": "^2.11.6",
     "@editorjs/simple-image": "^1.4.1",
     "@types/node": "^18.15.11",
     "chai-subset": "^1.6.0",

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../types';
 
 import { SavedData } from '../../../types/data-formats';
-import $ from '../dom';
+import $, { toggleEmptyMark } from '../dom';
 import * as _ from '../utils';
 import ApiModules from '../modules/api';
 import BlockAPI from './api';
@@ -255,6 +255,12 @@ export default class Block extends EventsDispatcher<BlockEvents> {
        * so we need to track focus events to update current input and clear cache.
        */
       this.addInputEvents();
+
+      /**
+       * We mark inputs with [data-empty] attribute
+       * It can be useful for developers, for example for correct placeholder behavior and
+       */
+      this.toggleInputsEmptyMark();
     });
   }
 
@@ -931,6 +937,11 @@ export default class Block extends EventsDispatcher<BlockEvents> {
      */
     this.updateCurrentInput();
 
+    /**
+     * We mark inputs with 'data-empty' attribute, so new inputs should be marked as well
+     */
+    this.toggleInputsEmptyMark();
+
     this.call(BlockToolAPI.UPDATED);
 
     /**
@@ -992,5 +1003,9 @@ export default class Block extends EventsDispatcher<BlockEvents> {
    */
   private dropInputsCache(): void {
     this.cachedInputs = [];
+  }
+
+  private toggleInputsEmptyMark(): void {
+    this.inputs.forEach(toggleEmptyMark);
   }
 }

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -258,7 +258,7 @@ export default class Block extends EventsDispatcher<BlockEvents> {
 
       /**
        * We mark inputs with [data-empty] attribute
-       * It can be useful for developers, for example for correct placeholder behavior and
+       * It can be useful for developers, for example for correct placeholder behavior
        */
       this.toggleInputsEmptyMark();
     });

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -1005,6 +1005,9 @@ export default class Block extends EventsDispatcher<BlockEvents> {
     this.cachedInputs = [];
   }
 
+  /**
+   * Mark inputs with 'data-empty' attribute with the empty state
+   */
   private toggleInputsEmptyMark(): void {
     this.inputs.forEach(toggleEmptyMark);
   }

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -184,11 +184,6 @@ export default class Block extends EventsDispatcher<BlockEvents> {
   private unavailableTunesData: { [name: string]: BlockTuneData } = {};
 
   /**
-   * Editor`s API module
-   */
-  private readonly api: ApiModules;
-
-  /**
    * Focused input index
    *
    * @type {number}
@@ -232,7 +227,6 @@ export default class Block extends EventsDispatcher<BlockEvents> {
     this.id = id;
     this.settings = tool.settings;
     this.config = tool.settings.config || {};
-    this.api = api;
     this.editorEventBus = eventBus || null;
     this.blockAPI = new BlockAPI(this);
 

--- a/src/components/block/index.ts
+++ b/src/components/block/index.ts
@@ -218,7 +218,6 @@ export default class Block extends EventsDispatcher<BlockEvents> {
     id = _.generateBlockId(),
     data,
     tool,
-    api,
     readOnly,
     tunesData,
   }: BlockConstructorOptions, eventBus?: EventsDispatcher<EditorEventMap>) {

--- a/src/components/dom.ts
+++ b/src/components/dom.ts
@@ -662,3 +662,13 @@ export function calculateBaseline(element: Element): number {
 
   return baselineY;
 }
+
+/**
+ * Toggles the [data-empty] attribute on element depending on its emptiness
+ * Used to mark empty inputs with a special attribute for placeholders feature
+ *
+ * @param element - The element to toggle the [data-empty] attribute on
+ */
+export function toggleEmptyMark(element: HTMLElement): void {
+  element.dataset.empty = Dom.isEmpty(element) ? 'true' : 'false';
+}

--- a/src/components/modules/blockManager.ts
+++ b/src/components/modules/blockManager.ts
@@ -544,7 +544,7 @@ export default class BlockManager extends Module {
        * If first Block was removed, insert new Initial Block and set focus on it`s first input
        */
       if (!this.blocks.length) {
-        this.currentBlockIndex = -1;
+        this.unsetCurrentBlock();
 
         if (addLastBlock) {
           this.insert();
@@ -591,7 +591,7 @@ export default class BlockManager extends Module {
       this._blocks.remove(index);
     }
 
-    this.currentBlockIndex = -1;
+    this.unsetCurrentBlock();
     this.insert();
     this.currentBlock.firstInput.focus();
   }
@@ -873,7 +873,7 @@ export default class BlockManager extends Module {
    * Sets current Block Index -1 which means unknown
    * and clear highlights
    */
-  public dropPointer(): void {
+  public unsetCurrentBlock(): void {
     this.currentBlockIndex = -1;
   }
 
@@ -895,7 +895,7 @@ export default class BlockManager extends Module {
 
     await queue.completed;
 
-    this.dropPointer();
+    this.unsetCurrentBlock();
 
     if (needToAddDefaultBlock) {
       this.insert();

--- a/src/components/modules/ui.ts
+++ b/src/components/modules/ui.ts
@@ -17,7 +17,6 @@ import styles from '../../styles/main.css?inline';
 import { BlockHovered } from '../events/BlockHovered';
 import { selectionChangeDebounceTimeout } from '../constants';
 import { EditorMobileLayoutToggled } from '../events';
-import { notEmpty } from '../utils/empty';
 /**
  * HTML Elements used for UI
  */
@@ -386,7 +385,7 @@ export default class UI extends Module<UINodes> {
      * We have custom logic for providing placeholders for contenteditable elements.
      * To make it work, we need to have data-empty mark on empty inputs.
      */
-    this.enableInputsEmptyMark();;
+    this.enableInputsEmptyMark();
   }
 
 
@@ -890,16 +889,17 @@ export default class UI extends Module<UINodes> {
    * Then, CSS could rely on this attribute to show placeholders
    */
   private enableInputsEmptyMark(): void {
-    function toggleEmptyMark(input: HTMLElement): void {
-      const isInputEmpty = $.isEmpty(input);
-
-      input.dataset.empty = isInputEmpty ? 'true' : 'false';
-    }
-
+    /**
+     * Toggle data-empty attribute on input depending on its emptiness
+     *
+     * @param event - input or focus event
+     */
     function handleInputOrFocusChange(event: Event): void {
       const input = event.target as HTMLElement;
 
-      toggleEmptyMark(input);
+      const isInputEmpty = $.isEmpty(input);
+
+      input.dataset.empty = isInputEmpty ? 'true' : 'false';
     }
 
     this.readOnlyMutableListeners.on(this.nodes.wrapper, 'input', handleInputOrFocusChange);

--- a/src/components/modules/ui.ts
+++ b/src/components/modules/ui.ts
@@ -891,7 +891,8 @@ export default class UI extends Module<UINodes> {
   private enableInputsEmptyMark(): void {
     /**
      * Toggle data-empty attribute on input depending on its emptiness
-     * @param event
+     *
+     * @param event - input or focus event
      */
     function handleInputOrFocusChange(event: Event): void {
       const input = event.target as HTMLElement;

--- a/src/components/modules/ui.ts
+++ b/src/components/modules/ui.ts
@@ -5,7 +5,7 @@
  * @type {UI}
  */
 import Module from '../__module';
-import $ from '../dom';
+import $, { toggleEmptyMark } from '../dom';
 import * as _ from '../utils';
 
 import Selection from '../selection';
@@ -891,15 +891,12 @@ export default class UI extends Module<UINodes> {
   private enableInputsEmptyMark(): void {
     /**
      * Toggle data-empty attribute on input depending on its emptiness
-     *
-     * @param event - input or focus event
+     * @param event
      */
     function handleInputOrFocusChange(event: Event): void {
       const input = event.target as HTMLElement;
 
-      const isInputEmpty = $.isEmpty(input);
-
-      input.dataset.empty = isInputEmpty ? 'true' : 'false';
+      toggleEmptyMark(input);
     }
 
     this.readOnlyMutableListeners.on(this.nodes.wrapper, 'input', handleInputOrFocusChange);

--- a/src/components/utils/mutations.ts
+++ b/src/components/utils/mutations.ts
@@ -8,6 +8,13 @@ export function isMutationBelongsToElement(mutationRecord: MutationRecord, eleme
   const { type, target, addedNodes, removedNodes } = mutationRecord;
 
   /**
+   * Skip own technical mutations, for example, data-empty attribute changes
+   */
+  if (mutationRecord.type === 'attributes' && mutationRecord.attributeName === 'data-empty'){
+    return false;
+  }
+
+  /**
    * Covers all types of mutations happened to the element or it's descendants with the only one exception - removing/adding the element itself;
    */
   if (element.contains(target)) {

--- a/src/components/utils/mutations.ts
+++ b/src/components/utils/mutations.ts
@@ -10,7 +10,7 @@ export function isMutationBelongsToElement(mutationRecord: MutationRecord, eleme
   /**
    * Skip own technical mutations, for example, data-empty attribute changes
    */
-  if (mutationRecord.type === 'attributes' && mutationRecord.attributeName === 'data-empty'){
+  if (mutationRecord.type === 'attributes' && mutationRecord.attributeName === 'data-empty') {
     return false;
   }
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -11,4 +11,5 @@
 @import './input.css';
 @import './popover.css';
 @import './popover-inline.css';
+@import './placeholders.css';
 

--- a/src/styles/placeholders.css
+++ b/src/styles/placeholders.css
@@ -1,0 +1,45 @@
+
+/**
+ * We support two types of placeholders for contenteditable:
+ *
+ * 1. Regular-like placeholders. Will be visible when element is empty.
+      -- Best choice for rare-used blocks like Headings.
+ * 2. Current-block placeholders. Will be visible when element is empty and the block is focused.
+      -- Best choice for common-used blocks like Paragraphs.
+ */
+ :root {
+  --placeholder {
+    pointer-events: none;
+    color: var(--grayText);
+    cursor: text;
+  }
+ }
+
+.codex-editor {
+  /**
+   * Use [data-placeholder="..."] to always show a placeholder on empty contenteditable.
+   */
+  [data-placeholder]:empty,
+  [data-placeholder][data-empty="true"] {
+    &::before {
+      @apply --placeholder;
+
+      content: attr(data-placeholder);
+    }
+  }
+
+   /**
+    * Use [data-placeholder-active="..."] to show a placeholder on empty contenteditable in current block.
+    */
+  [data-placeholder-active]:empty,
+  [data-placeholder-active][data-empty="true"] {
+    /* Paragraph tool shows the placeholder for the first block, event it is not focused, so we need to prepare styles for it */
+    &::before {
+      @apply --placeholder;
+    }
+
+    &:focus::before {
+      content: attr(data-placeholder-active);
+    }
+  }
+}

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -261,3 +261,18 @@ Cypress.Commands.add('keydown', {
 
   return cy.wrap(subject);
 });
+
+/**
+ * Extract content of pseudo element
+ *
+ * @example cy.get('element').getPseudoElementContent('::before').should('eq', 'my-test-string')
+ */
+Cypress.Commands.add('getPseudoElementContent', {
+  prevSubject: true
+}, (subject, pseudoElement: 'string') => {
+  const win = subject[0].ownerDocument.defaultView;
+  const computedStyle = win.getComputedStyle(subject[0], pseudoElement);
+  const content = computedStyle.getPropertyValue('content');
+
+  return content.replace(/['"]/g, ''); // Remove quotes around the content
+});

--- a/test/cypress/support/commands.ts
+++ b/test/cypress/support/commands.ts
@@ -268,7 +268,7 @@ Cypress.Commands.add('keydown', {
  * @example cy.get('element').getPseudoElementContent('::before').should('eq', 'my-test-string')
  */
 Cypress.Commands.add('getPseudoElementContent', {
-  prevSubject: true
+  prevSubject: true,
 }, (subject, pseudoElement: 'string') => {
   const win = subject[0].ownerDocument.defaultView;
   const computedStyle = win.getComputedStyle(subject[0], pseudoElement);

--- a/test/cypress/support/index.d.ts
+++ b/test/cypress/support/index.d.ts
@@ -93,6 +93,13 @@ declare global {
        * @param keyCode - key code to dispatch
        */
       keydown(keyCode: number): Chainable<Subject>;
+
+      /**
+       * Extract content of pseudo element
+       *
+       * @example cy.get('element').getPseudoElementContent('::before').should('eq', 'my-test-string')
+       */
+      getPseudoElementContent(pseudoElement: string): Chainable<string>;
     }
 
     interface ApplicationWindow {

--- a/test/cypress/support/utils/createEditorWithTextBlocks.ts
+++ b/test/cypress/support/utils/createEditorWithTextBlocks.ts
@@ -1,3 +1,4 @@
+import { EditorConfig } from '../../../../types/index';
 import Chainable = Cypress.Chainable;
 import type EditorJS from '../../../../types/index';
 
@@ -6,9 +7,10 @@ import type EditorJS from '../../../../types/index';
  * Creates Editor instance with list of Paragraph blocks of passed texts
  *
  * @param textBlocks - list of texts for Paragraph blocks
+ * @param editorConfig - config to pass to the editor
  */
-export function createEditorWithTextBlocks(textBlocks: string[]): Chainable<EditorJS> {
-  return cy.createEditor({
+export function createEditorWithTextBlocks(textBlocks: string[], editorConfig?: Omit<EditorConfig, 'data'>): Chainable<EditorJS> {
+  return cy.createEditor(Object.assign(editorConfig || {}, {
     data: {
       blocks: textBlocks.map((text) => ({
         type: 'paragraph',
@@ -16,6 +18,6 @@ export function createEditorWithTextBlocks(textBlocks: string[]): Chainable<Edit
           text,
         },
       })),
-    },
-  });
+    }
+  }));
 }

--- a/test/cypress/support/utils/createEditorWithTextBlocks.ts
+++ b/test/cypress/support/utils/createEditorWithTextBlocks.ts
@@ -18,6 +18,6 @@ export function createEditorWithTextBlocks(textBlocks: string[], editorConfig?: 
           text,
         },
       })),
-    }
+    },
   }));
 }

--- a/test/cypress/tests/modules/InlineToolbar.cy.ts
+++ b/test/cypress/tests/modules/InlineToolbar.cy.ts
@@ -27,7 +27,7 @@ describe('Inline Toolbar', () => {
 
         const range = selection.getRangeAt(0);
         const rect = range.getBoundingClientRect();
-        
+
         expect($toolbar.offset().left).to.be.closeTo(rect.left, 1);
       });
   });
@@ -67,7 +67,7 @@ describe('Inline Toolbar', () => {
         cy.get('@blockWrapper')
           .then(($blockWrapper) => {
             const blockWrapperRect = $blockWrapper.get(0).getBoundingClientRect();
-            
+
             /**
              * Toolbar should be aligned with right side of text column
              */

--- a/test/cypress/tests/tools/ToolsFactory.cy.ts
+++ b/test/cypress/tests/tools/ToolsFactory.cy.ts
@@ -34,7 +34,7 @@ describe('ToolsFactory', (): void => {
             prop1: 'prop1',
             prop2: 'prop2',
           };
-        }
+        },
       } as any
     );
   });

--- a/test/cypress/tests/ui/BlockTunes.cy.ts
+++ b/test/cypress/tests/ui/BlockTunes.cy.ts
@@ -386,7 +386,7 @@ describe('BlockTunes', function () {
             icon: 'Icon',
             title: 'Tune',
             // eslint-disable-next-line @typescript-eslint/no-empty-function
-            onActivate: () => {}
+            onActivate: () => {},
           };
         }
 

--- a/test/cypress/tests/ui/DataEmpty.cy.ts
+++ b/test/cypress/tests/ui/DataEmpty.cy.ts
@@ -51,4 +51,21 @@ describe('inputs [data-empty] mark', function () {
       .last()
       .should('have.attr', 'data-empty', 'true');
   });
+
+  it('should be added to the new block inputs', function () {
+    createEditorWithTextBlocks([
+      'First', // not empty block
+      '' // empty block
+    ])
+
+    cy.get('[data-cy=editorjs]')
+      .find('.ce-paragraph')
+      .last()
+      .type('{enter}');
+
+    cy.get('[data-cy=editorjs]')
+      .find('.ce-paragraph')
+      .last()
+      .should('have.attr', 'data-empty', 'true');
+  });
 });

--- a/test/cypress/tests/ui/DataEmpty.cy.ts
+++ b/test/cypress/tests/ui/DataEmpty.cy.ts
@@ -1,7 +1,7 @@
 import { createEditorWithTextBlocks } from '../../support/utils/createEditorWithTextBlocks';
 
 describe('inputs [data-empty] mark', function () {
-  it('should be added to the editor on initialization', function () {
+  it('should be added to inputs of editor on initialization', function () {
     createEditorWithTextBlocks([
       'First', // not empty block
       '', // empty block
@@ -18,7 +18,7 @@ describe('inputs [data-empty] mark', function () {
       .should('have.attr', 'data-empty', 'true');
   });
 
-  it('should be added to the block on input', function () {
+  it('should be added as "false" to the input on typing', function () {
     createEditorWithTextBlocks([
       'First', // not empty block
       '', // empty block
@@ -35,16 +35,16 @@ describe('inputs [data-empty] mark', function () {
       .should('have.attr', 'data-empty', 'false');
   });
 
-  it('should be added to the block on focus', function () {
+  it('should be added as "true" to the input on chars removal', function () {
     createEditorWithTextBlocks([
-      'First', // not empty block
       '', // empty block
+      'Some text', // not empty block
     ]);
 
     cy.get('[data-cy=editorjs]')
       .find('.ce-paragraph')
       .last()
-      .click();
+      .type('{selectall}{backspace}');
 
     cy.get('[data-cy=editorjs]')
       .find('.ce-paragraph')

--- a/test/cypress/tests/ui/DataEmpty.cy.ts
+++ b/test/cypress/tests/ui/DataEmpty.cy.ts
@@ -1,0 +1,54 @@
+import { createEditorWithTextBlocks } from "../../support/utils/createEditorWithTextBlocks";
+
+describe('inputs [data-empty] mark', function () {
+  it('should be added to the editor on initialization', function () {
+    createEditorWithTextBlocks([
+      'First', // not empty block
+      '' // empty block
+    ])
+
+    cy.get('[data-cy=editorjs]')
+      .find('.ce-paragraph')
+      .first()
+      .should('have.attr', 'data-empty', 'false');
+
+    cy.get('[data-cy=editorjs]')
+      .find('.ce-paragraph')
+      .last()
+      .should('have.attr', 'data-empty', 'true');
+  });
+
+  it('should be added to the block on input', function () {
+    createEditorWithTextBlocks([
+      'First', // not empty block
+      '' // empty block
+    ])
+
+    cy.get('[data-cy=editorjs]')
+      .find('.ce-paragraph')
+      .last()
+      .type('Some text');
+
+    cy.get('[data-cy=editorjs]')
+      .find('.ce-paragraph')
+      .last()
+      .should('have.attr', 'data-empty', 'false');
+  });
+
+  it('should be added to the block on focus', function () {
+    createEditorWithTextBlocks([
+      'First', // not empty block
+      '' // empty block
+    ])
+
+    cy.get('[data-cy=editorjs]')
+      .find('.ce-paragraph')
+      .last()
+      .click();
+
+    cy.get('[data-cy=editorjs]')
+      .find('.ce-paragraph')
+      .last()
+      .should('have.attr', 'data-empty', 'true');
+  });
+});

--- a/test/cypress/tests/ui/DataEmpty.cy.ts
+++ b/test/cypress/tests/ui/DataEmpty.cy.ts
@@ -1,11 +1,11 @@
-import { createEditorWithTextBlocks } from "../../support/utils/createEditorWithTextBlocks";
+import { createEditorWithTextBlocks } from '../../support/utils/createEditorWithTextBlocks';
 
 describe('inputs [data-empty] mark', function () {
   it('should be added to the editor on initialization', function () {
     createEditorWithTextBlocks([
       'First', // not empty block
-      '' // empty block
-    ])
+      '', // empty block
+    ]);
 
     cy.get('[data-cy=editorjs]')
       .find('.ce-paragraph')
@@ -21,8 +21,8 @@ describe('inputs [data-empty] mark', function () {
   it('should be added to the block on input', function () {
     createEditorWithTextBlocks([
       'First', // not empty block
-      '' // empty block
-    ])
+      '', // empty block
+    ]);
 
     cy.get('[data-cy=editorjs]')
       .find('.ce-paragraph')
@@ -38,8 +38,8 @@ describe('inputs [data-empty] mark', function () {
   it('should be added to the block on focus', function () {
     createEditorWithTextBlocks([
       'First', // not empty block
-      '' // empty block
-    ])
+      '', // empty block
+    ]);
 
     cy.get('[data-cy=editorjs]')
       .find('.ce-paragraph')
@@ -55,8 +55,8 @@ describe('inputs [data-empty] mark', function () {
   it('should be added to the new block inputs', function () {
     createEditorWithTextBlocks([
       'First', // not empty block
-      '' // empty block
-    ])
+      '', // empty block
+    ]);
 
     cy.get('[data-cy=editorjs]')
       .find('.ce-paragraph')

--- a/test/cypress/tests/ui/InlineToolbar.cy.ts
+++ b/test/cypress/tests/ui/InlineToolbar.cy.ts
@@ -47,12 +47,13 @@ describe('Inline Toolbar', () => {
         tools: {
           header: {
             class: Header,
-            inlineToolbar: ['bold', 'testTool', 'link']
+            inlineToolbar: ['bold', 'testTool', 'link'],
 
           },
           testTool: {
             class: class {
               public static isInline = true;
+              // eslint-disable-next-line jsdoc/require-jsdoc
               public render(): MenuConfig {
                 return {
                   icon: 'n',
@@ -64,14 +65,14 @@ describe('Inline Toolbar', () => {
                         icon: 'm',
                         title: 'Test Tool Item',
                         // eslint-disable-next-line  @typescript-eslint/no-empty-function
-                        onActivate: () => {}
-                      }
-                    ]
-                  }
+                        onActivate: () => {},
+                      },
+                    ],
+                  },
                 };
               }
-            }
-          }
+            },
+          },
         },
         data: {
           blocks: [
@@ -115,12 +116,13 @@ describe('Inline Toolbar', () => {
         tools: {
           header: {
             class: Header,
-            inlineToolbar: ['bold', 'testTool']
+            inlineToolbar: ['bold', 'testTool'],
 
           },
           testTool: {
             class: class {
               public static isInline = true;
+              // eslint-disable-next-line jsdoc/require-jsdoc
               public render(): MenuConfig {
                 return {
                   icon: 'n',
@@ -132,14 +134,14 @@ describe('Inline Toolbar', () => {
                         icon: 'm',
                         title: 'Test Tool Item',
                         // eslint-disable-next-line  @typescript-eslint/no-empty-function
-                        onActivate: () => {}
-                      }
-                    ]
-                  }
+                        onActivate: () => {},
+                      },
+                    ],
+                  },
                 };
               }
-            }
-          }
+            },
+          },
         },
         data: {
           blocks: [

--- a/test/cypress/tests/ui/Placeholders.cy.ts
+++ b/test/cypress/tests/ui/Placeholders.cy.ts
@@ -1,5 +1,3 @@
-import { createEditorWithTextBlocks } from "../../support/utils/createEditorWithTextBlocks";
-
 /**
  * Text will be passed as a placeholder to the editor
  */

--- a/test/cypress/tests/ui/Placeholders.cy.ts
+++ b/test/cypress/tests/ui/Placeholders.cy.ts
@@ -1,3 +1,5 @@
+import { createEditorWithTextBlocks } from "../../support/utils/createEditorWithTextBlocks";
+
 /**
  * Text will be passed as a placeholder to the editor
  */
@@ -7,7 +9,7 @@ describe('Placeholders', function () {
   it('should be shown near first block if passed via editor config', function () {
     cy.createEditor({
       placeholder: PLACEHOLDER_TEXT,
-    }).as('editorInstance');
+    });
 
     cy.get('[data-cy=editorjs]')
       .find('.ce-paragraph')
@@ -19,39 +21,18 @@ describe('Placeholders', function () {
     cy.createEditor({
       placeholder: PLACEHOLDER_TEXT,
       autofocus: true,
-    }).as('editorInstance');
+    });
 
     cy.get('[data-cy=editorjs]')
       .find('.ce-paragraph')
       .getPseudoElementContent('::before')
       .should('eq', PLACEHOLDER_TEXT);
-  });
-
-  it('should be shown only for current paragraph', function () {
-    cy.createEditor({
-      placeholder: PLACEHOLDER_TEXT,
-    }).as('editorInstance');
-
-    cy.get('[data-cy=editorjs]')
-      .find('.ce-paragraph')
-      .first()
-      .as('firstBlock')
-      .getPseudoElementContent('::before')
-      .should('eq', PLACEHOLDER_TEXT);
-
-    cy.get('@firstBlock')
-      .type('{enter}')
-      .type('a');
-
-    cy.get('@firstBlock')
-      .getPseudoElementContent('::before')
-      .should('eq', 'none');
   });
 
   it('should be shown event if input is focused', function () {
     cy.createEditor({
       placeholder: PLACEHOLDER_TEXT,
-    }).as('editorInstance');
+    });
 
     cy.get('[data-cy=editorjs]')
       .find('.ce-paragraph')
@@ -64,7 +45,7 @@ describe('Placeholders', function () {
   it('should be shown event when user removes all text by cmd+a and delete', function () {
     cy.createEditor({
       placeholder: PLACEHOLDER_TEXT,
-    }).as('editorInstance');
+    });
 
     cy.get('[data-cy=editorjs]')
       .find('.ce-paragraph')
@@ -77,7 +58,7 @@ describe('Placeholders', function () {
   it('should be hidden when user starts typing', function () {
     cy.createEditor({
       placeholder: PLACEHOLDER_TEXT,
-    }).as('editorInstance');
+    });
 
     cy.get('[data-cy=editorjs]')
       .find('.ce-paragraph')

--- a/test/cypress/tests/ui/Placeholders.cy.ts
+++ b/test/cypress/tests/ui/Placeholders.cy.ts
@@ -4,6 +4,14 @@
 const PLACEHOLDER_TEXT = 'Write something or press / to select a tool';
 
 describe('Placeholders', function () {
+  /**
+   * There is no ability to get pseudo elements content in Firefox
+   * It will return CSS-bases value (attr(data-placeholder) instead of DOM-based
+   */
+  if (Cypress.browser.family === 'firefox') {
+    return;
+  }
+
   it('should be shown near first block if passed via editor config', function () {
     cy.createEditor({
       placeholder: PLACEHOLDER_TEXT,

--- a/test/cypress/tests/ui/Placeholders.cy.ts
+++ b/test/cypress/tests/ui/Placeholders.cy.ts
@@ -1,0 +1,86 @@
+/**
+ * Text will be passed as a placeholder to the editor
+ */
+const PLACEHOLDER_TEXT = 'Write something or press / to select a tool';
+
+describe('Placeholders', function () {
+  it('should be shown near first block if passed via editor config', function () {
+    cy.createEditor({
+      placeholder: PLACEHOLDER_TEXT,
+    }).as('editorInstance');
+
+    cy.get('[data-cy=editorjs]')
+      .find('.ce-paragraph')
+      .getPseudoElementContent('::before')
+      .should('eq', PLACEHOLDER_TEXT);
+  });
+
+  it('should be shown when editor is autofocusable', function () {
+    cy.createEditor({
+      placeholder: PLACEHOLDER_TEXT,
+      autofocus: true,
+    }).as('editorInstance');
+
+    cy.get('[data-cy=editorjs]')
+      .find('.ce-paragraph')
+      .getPseudoElementContent('::before')
+      .should('eq', PLACEHOLDER_TEXT);
+  });
+
+  it('should be shown only for current paragraph', function () {
+    cy.createEditor({
+      placeholder: PLACEHOLDER_TEXT,
+    }).as('editorInstance');
+
+    cy.get('[data-cy=editorjs]')
+      .find('.ce-paragraph')
+      .first()
+      .as('firstBlock')
+      .getPseudoElementContent('::before')
+      .should('eq', PLACEHOLDER_TEXT);
+
+    cy.get('@firstBlock')
+      .type('{enter}');
+
+    cy.get('@firstBlock')
+      .getPseudoElementContent('::before')
+      .should('eq', 'none');
+
+    cy.get('[data-cy=editorjs]')
+      .find('.ce-paragraph')
+      .last()
+      .click()
+      .getPseudoElementContent('::before')
+      .should('eq', PLACEHOLDER_TEXT);
+  });
+
+  it('should be shown event if input is focused', function () {
+    cy.createEditor({
+      placeholder: PLACEHOLDER_TEXT,
+    }).as('editorInstance');
+
+    cy.get('[data-cy=editorjs]')
+      .find('.ce-paragraph')
+      .click()
+      .as('firstBlock')
+      .getPseudoElementContent('::before')
+      .should('eq', PLACEHOLDER_TEXT);
+  })
+
+  it('should be hidden when user starts typing', function () {
+    cy.createEditor({
+      placeholder: PLACEHOLDER_TEXT,
+    }).as('editorInstance');
+
+    cy.get('[data-cy=editorjs]')
+      .find('.ce-paragraph')
+      .as('firstBlock')
+      .getPseudoElementContent('::before')
+      .should('eq', PLACEHOLDER_TEXT);
+
+    cy.get('@firstBlock')
+      .type('a')
+      .getPseudoElementContent('::before')
+      .should('eq', 'none');
+  })
+});

--- a/test/cypress/tests/ui/Placeholders.cy.ts
+++ b/test/cypress/tests/ui/Placeholders.cy.ts
@@ -65,7 +65,7 @@ describe('Placeholders', function () {
       .as('firstBlock')
       .getPseudoElementContent('::before')
       .should('eq', PLACEHOLDER_TEXT);
-  })
+  });
 
   it('should be hidden when user starts typing', function () {
     cy.createEditor({
@@ -82,5 +82,5 @@ describe('Placeholders', function () {
       .type('a')
       .getPseudoElementContent('::before')
       .should('eq', 'none');
-  })
+  });
 });

--- a/test/cypress/tests/ui/Placeholders.cy.ts
+++ b/test/cypress/tests/ui/Placeholders.cy.ts
@@ -40,7 +40,8 @@ describe('Placeholders', function () {
       .should('eq', PLACEHOLDER_TEXT);
 
     cy.get('@firstBlock')
-      .type('{enter}');
+      .type('{enter}')
+      .type('a');
 
     cy.get('@firstBlock')
       .getPseudoElementContent('::before')

--- a/test/cypress/tests/ui/Placeholders.cy.ts
+++ b/test/cypress/tests/ui/Placeholders.cy.ts
@@ -45,13 +45,6 @@ describe('Placeholders', function () {
     cy.get('@firstBlock')
       .getPseudoElementContent('::before')
       .should('eq', 'none');
-
-    cy.get('[data-cy=editorjs]')
-      .find('.ce-paragraph')
-      .last()
-      .click()
-      .getPseudoElementContent('::before')
-      .should('eq', PLACEHOLDER_TEXT);
   });
 
   it('should be shown event if input is focused', function () {
@@ -63,6 +56,19 @@ describe('Placeholders', function () {
       .find('.ce-paragraph')
       .click()
       .as('firstBlock')
+      .getPseudoElementContent('::before')
+      .should('eq', PLACEHOLDER_TEXT);
+  });
+
+  it('should be shown event when user removes all text by cmd+a and delete', function () {
+    cy.createEditor({
+      placeholder: PLACEHOLDER_TEXT,
+    }).as('editorInstance');
+
+    cy.get('[data-cy=editorjs]')
+      .find('.ce-paragraph')
+      .type('aaa')
+      .type('{selectall}{backspace}')
       .getPseudoElementContent('::before')
       .should('eq', PLACEHOLDER_TEXT);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -571,10 +571,10 @@
   dependencies:
     "@codexteam/icons" "^0.0.5"
 
-"@editorjs/paragraph@^2.11.4":
-  version "2.11.4"
-  resolved "https://registry.yarnpkg.com/@editorjs/paragraph/-/paragraph-2.11.4.tgz#ee91fc2d97f0aa9790860854fd804ef5d83d988e"
-  integrity sha512-OuTINHoHrJwKxlpTm6FtiXazwagALJbP49hfbQWBOLTNiBICncqPe1hdGfgDpeEgH9ZEGZsJelhEDxw2iwcmPA==
+"@editorjs/paragraph@^2.11.6":
+  version "2.11.6"
+  resolved "https://registry.yarnpkg.com/@editorjs/paragraph/-/paragraph-2.11.6.tgz#011444187a74dc603201dce37d2fc6d054022407"
+  integrity sha512-i9B50Ylvh+0ZzUGWIba09PfUXsA00Y//zFZMwqsyaXXKxMluSIJ6ADFJbbK0zaV9Ijx49Xocrlg+CEPRqATk9w==
   dependencies:
     "@codexteam/icons" "^0.0.4"
 


### PR DESCRIPTION
## Problem

1. Placeholders are being hidden on focus. It's not the best UX.
2. `autofocus` ruins `placeholder` option because of 1.
3. There are separated placeholder implementations in Tools CSS code.
4. Current implementation relies on CSS `:empty` state, but the is often a case when input has just `<br>` tag. Placeholder won't be shown in this case.

## Solution

1. Placeholder implementation moved to editor core. Now anyone can add `data-placeholder` to the contenteditable element inside editor and it will work.
2. Placeholders won't be hidden on focus
3. Now we're watching all inputs and mark them as empty via the `data-empty="true"` attribute if they are really empty.
4. We also support `data-placeholder-active` attribute to show placeholder only for current block. It is used for Paragraph tool — we don't want to show placeholders to each empty paragraphs on a page, only for the current.

Also, paragraph tool has a hack for showing `data-placeholder-active` event for not-current block in case if it is the only paragraph in empty editor. It is needed to make `placeholder` config option work when `autofocus` is false. See https://github.com/editor-js/paragraph/pull/89


https://github.com/codex-team/editor.js/assets/3684889/d9e09635-b09b-43c7-ab10-b1d9c2048a7e

