### PR TITLE
fix(Inline-toolbar): fake selection stays on screen after toggling convert to

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 2.30.1
 
-- `Fix` – Remove fake selection on convert to inline tool toggle
+- `Fix` – Remove fake selection after multiple "convert to" inline tool toggles
 
 ### 2.30.0
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.30.1
+
+- `Fix` – Remove fake selection on convert to inline tool toggle
+
 ### 2.30.0
 
 - `New` – Block Tunes now supports nesting items

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/editorjs",
-  "version": "2.30.0",
+  "version": "2.30.1",
   "description": "Editor.js — open source block-style WYSIWYG editor with JSON output",
   "main": "dist/editorjs.umd.js",
   "module": "dist/editorjs.mjs",

--- a/src/components/utils/popover/popover-inline.ts
+++ b/src/components/utils/popover/popover-inline.ts
@@ -127,8 +127,9 @@ export class PopoverInline extends PopoverDesktop {
    */
   protected override showNestedItems(item: PopoverItemDefault | PopoverItemHtml): void {
     if (this.nestedPopoverTriggerItem === item) {
-      this.nestedPopoverTriggerItem = null;
       this.destroyNestedPopoverIfExists();
+      
+      this.nestedPopoverTriggerItem = null;
 
       return;
     }


### PR DESCRIPTION

https://github.com/codex-team/editor.js/assets/31101125/72fb0f6a-e46d-4fc8-b6ce-986e2c0b62fe

