### PR TITLE
feat(inline-toolbar): inline tools now can be used in the readonly mode

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 2.31.0
 
 - `New` - Inline tools (those with `isReadOnlySupported` specified) can now be used in read-only mode
+- `Fix` - Fix selection of first block in read-only initialization with "autofocus=true"
 
 ### 2.30.6
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog
 
+### 2.31.0
+
+- `New` - Inline tools (those with `isReadOnlySupported` specified) can now be used in read-only mode
+
 ### 2.30.6
 
-– `Fix` – Fix the display of ‘Convert To’ near blocks that do not have the ‘conversionConfig.export’ rule specified
-– `Fix` – The Plus button does not appear when the editor is loaded in an iframe in Chrome
+- `Fix` – Fix the display of ‘Convert To’ near blocks that do not have the ‘conversionConfig.export’ rule specified
+- `Fix` – The Plus button does not appear when the editor is loaded in an iframe in Chrome
 - `Fix` - Prevent inline toolbar from closing in nested instance of editor
 
 ### 2.30.5
@@ -33,7 +37,7 @@
 - `New` – Block Tunes now supports nesting items
 - `New` – Block Tunes now supports separator items
 - `New` – *Menu Config* – New item type – HTML
-– `New` – *Menu Config* – Default and HTML items now support hints
+- `New` – *Menu Config* – Default and HTML items now support hints
 - `New` – Inline Toolbar has new look 💅
 - `New` – Inline Tool's `render()` now supports [Menu Config](https://editorjs.io/menu-config/) format
 - `New` – *ToolsAPI* – All installed block tools now accessible via ToolsAPI `getBlockTools()` method

--- a/src/components/core.ts
+++ b/src/components/core.ts
@@ -61,7 +61,7 @@ export default class Core {
         UI.checkEmptiness();
         ModificationsObserver.enable();
 
-        if ((this.configuration as EditorConfig).autofocus) {
+        if ((this.configuration as EditorConfig).autofocus === true && this.configuration.readOnly !== true) {
           Caret.setToBlock(BlockManager.blocks[0], Caret.positions.START);
         }
 

--- a/src/components/modules/blockManager.ts
+++ b/src/components/modules/blockManager.ts
@@ -684,7 +684,7 @@ export default class BlockManager extends Module {
    *
    * @param {Node} element - html element to get Block by
    */
-  public getBlock(element: HTMLElement): Block {
+  public getBlock(element: HTMLElement): Block | undefined {
     if (!$.isElement(element) as boolean) {
       element = element.parentNode as HTMLElement;
     }

--- a/src/components/modules/toolbar/inline.ts
+++ b/src/components/modules/toolbar/inline.ts
@@ -292,7 +292,7 @@ export default class InlineToolbar extends Module<InlineToolbarNodes> {
     }
 
     /**
-     * In read-only mode, check that at least one tool is available in read-only mode for the current block
+     * Check that at least one tool is available for the current block
      */
     const toolsAvailable = this.getTools();
     const isAtLeastOneToolAvailable = toolsAvailable.some((tool) => currentBlock.tool.inlineTools.has(tool.name));
@@ -314,6 +314,13 @@ export default class InlineToolbar extends Module<InlineToolbarNodes> {
    *  Working with Tools
    *  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    */
+
+  /**
+   * Returns tools that are available for current block
+   *
+   * Used to check if Inline Toolbar could be shown
+   * and to render tools in the Inline Toolbar
+   */
   private getTools(): InlineToolAdapter[] {
     const currentBlock = this.Editor.BlockManager.currentBlock;
 
@@ -324,6 +331,10 @@ export default class InlineToolbar extends Module<InlineToolbarNodes> {
     const inlineTools = Array.from(currentBlock.tool.inlineTools.values());
 
     return inlineTools.filter((tool) => {
+      /**
+       * We support inline tools in read only mode.
+       * Such tools should have isReadOnlySupported flag set to true
+       */
       if (this.Editor.ReadOnly.isEnabled && tool.isReadOnlySupported !== true) {
         return false;
       }

--- a/src/components/modules/toolbar/inline.ts
+++ b/src/components/modules/toolbar/inline.ts
@@ -12,6 +12,7 @@ import { CommonInternalSettings } from '../../tools/base';
 import type { Popover, PopoverItemHtmlParams, PopoverItemParams, WithChildren } from '../../utils/popover';
 import { PopoverItemType } from '../../utils/popover';
 import { PopoverInline } from '../../utils/popover/popover-inline';
+import type InlineToolAdapter from 'src/components/tools/inline';
 
 /**
  * Inline Toolbar elements
@@ -54,7 +55,7 @@ export default class InlineToolbar extends Module<InlineToolbarNodes> {
   /**
    * Currently visible tools instances
    */
-  private toolsInstances: Map<string, IInlineTool> | null = new Map();
+  private tools: Map<InlineToolAdapter, IInlineTool> = new Map();
 
   /**
    * @param moduleConfiguration - Module Configuration
@@ -66,21 +67,10 @@ export default class InlineToolbar extends Module<InlineToolbarNodes> {
       config,
       eventsDispatcher,
     });
-  }
 
-  /**
-   * Toggles read-only mode
-   *
-   * @param {boolean} readOnlyEnabled - read-only mode
-   */
-  public toggleReadOnly(readOnlyEnabled: boolean): void {
-    if (!readOnlyEnabled) {
-      window.requestIdleCallback(() => {
-        this.make();
-      }, { timeout: 2000 });
-    } else {
-      this.destroy();
-    }
+    window.requestIdleCallback(() => {
+      this.make();
+    }, { timeout: 2000 });
   }
 
   /**
@@ -116,14 +106,10 @@ export default class InlineToolbar extends Module<InlineToolbarNodes> {
       return;
     }
 
-    if (this.Editor.ReadOnly.isEnabled) {
-      return;
-    }
+    for (const [tool, toolInstance] of this.tools) {
+      const shortcut = this.getToolShortcut(tool.name);
 
-    Array.from(this.toolsInstances.entries()).forEach(([name, toolInstance]) => {
-      const shortcut = this.getToolShortcut(name);
-
-      if (shortcut) {
+      if (shortcut !== undefined) {
         Shortcuts.remove(this.Editor.UI.nodes.redactor, shortcut);
       }
 
@@ -133,9 +119,9 @@ export default class InlineToolbar extends Module<InlineToolbarNodes> {
       if (_.isFunction(toolInstance.clear)) {
         toolInstance.clear();
       }
-    });
+    }
 
-    this.toolsInstances = null;
+    this.tools = new Map();
 
     this.reset();
     this.opened = false;
@@ -204,10 +190,12 @@ export default class InlineToolbar extends Module<InlineToolbarNodes> {
       this.popover.destroy();
     }
 
-    const inlineTools = await this.getInlineTools();
+    this.createToolsInstances();
+
+    const popoverItems = await this.getPopoverItems();
 
     this.popover = new PopoverInline({
-      items: inlineTools,
+      items: popoverItems,
       scopeElement: this.Editor.API.methods.ui.nodes.redactor,
       messages: {
         nothingFound: I18n.ui(I18nInternalNS.ui.popover, 'Nothing found'),
@@ -290,59 +278,90 @@ export default class InlineToolbar extends Module<InlineToolbarNodes> {
       return false;
     }
 
-    if (currentSelection && tagsConflictsWithSelection.includes(target.tagName)) {
+    if (currentSelection !== null && tagsConflictsWithSelection.includes(target.tagName)) {
       return false;
     }
 
-    // The selection of the element only in contenteditable
-    const contenteditable = target.closest('[contenteditable="true"]');
-
-    if (contenteditable === null) {
-      return false;
-    }
-
-    // is enabled by current Block's Tool
+    /**
+     * Check if there is at leas one tool enabled by current Block's Tool
+     */
     const currentBlock = this.Editor.BlockManager.getBlock(currentSelection.anchorNode as HTMLElement);
 
     if (!currentBlock) {
       return false;
     }
 
-    return currentBlock.tool.inlineTools.size !== 0;
+    /**
+     * In read-only mode, check that at least one tool is available in read-only mode for the current block
+     */
+    const toolsAvailable = this.getTools();
+    const isAtLeastOneToolAvailable = toolsAvailable.some((tool) => currentBlock.tool.inlineTools.has(tool.name));
+
+    if (isAtLeastOneToolAvailable === false) {
+      return false;
+    }
+
+    /**
+     * Inline toolbar will be shown only if the target is contenteditable
+     * In Read-Only mode, the target should be contenteditable with "false" value
+     */
+    const contenteditable = target.closest('[contenteditable]');
+
+    return contenteditable !== null;
   }
 
   /**
    *  Working with Tools
    *  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    */
+  private getTools(): InlineToolAdapter[] {
+    const currentBlock = this.Editor.BlockManager.currentBlock;
 
-  /**
-   * Returns Inline Tools segregated by their appearance type: popover items and custom html elements.
-   * Sets this.toolsInstances map
-   */
-  private async getInlineTools(): Promise<PopoverItemParams[]> {
-    const currentSelection = SelectionUtils.get();
-    const currentBlock = this.Editor.BlockManager.getBlock(currentSelection.anchorNode as HTMLElement);
+    if (!currentBlock) {
+      return [];
+    }
 
     const inlineTools = Array.from(currentBlock.tool.inlineTools.values());
 
+    return inlineTools.filter((tool) => {
+      if (this.Editor.ReadOnly.isEnabled && tool.isReadOnlySupported !== true) {
+        return false;
+      }
+
+      return true;
+    });
+  }
+
+  /**
+   * Constructs tools instances and saves them to this.tools
+   */
+  private createToolsInstances(): void {
+    this.tools = new Map();
+
+    const tools = this.getTools();
+
+    tools.forEach((tool) => {
+      const instance = tool.create();
+
+      this.tools.set(tool, instance);
+    });
+  }
+
+  /**
+   * Returns Popover Items for tools segregated by their appearance type: regular items and custom html elements.
+   */
+  private async getPopoverItems(): Promise<PopoverItemParams[]> {
     const popoverItems = [] as PopoverItemParams[];
 
-    if (this.toolsInstances === null) {
-      this.toolsInstances = new Map();
-    }
+    let i = 0;
 
-    for (let i = 0; i < inlineTools.length; i++) {
-      const tool = inlineTools[i];
-      const instance = tool.create();
+    for (const [tool, instance] of this.tools) {
       const renderedTool = await instance.render();
-
-      this.toolsInstances.set(tool.name, instance);
 
       /** Enable tool shortcut */
       const shortcut = this.getToolShortcut(tool.name);
 
-      if (shortcut) {
+      if (shortcut !== undefined) {
         try {
           this.enableShortcuts(tool.name, shortcut);
         } catch (e) {}
@@ -429,7 +448,9 @@ export default class InlineToolbar extends Module<InlineToolbarNodes> {
             type: PopoverItemType.Default,
           } as PopoverItemParams;
 
-          /** Prepend with separator if item has children and not the first one */
+          /**
+           * Prepend the separator if item has children and not the first one
+           */
           if ('children' in popoverItem && i !== 0) {
             popoverItems.push({
               type: PopoverItemType.Separator,
@@ -438,14 +459,18 @@ export default class InlineToolbar extends Module<InlineToolbarNodes> {
 
           popoverItems.push(popoverItem);
 
-          /** Append separator after the item is it has children and not the last one */
-          if ('children' in popoverItem && i < inlineTools.length - 1) {
+          /**
+           * Append a separator after the item if it has children and not the last one
+           */
+          if ('children' in popoverItem && i < this.tools.size - 1) {
             popoverItems.push({
               type: PopoverItemType.Separator,
             });
           }
         }
       });
+
+      i++;
     }
 
     return popoverItems;
@@ -533,7 +558,7 @@ export default class InlineToolbar extends Module<InlineToolbarNodes> {
    * Check Tools` state by selection
    */
   private checkToolsState(): void {
-    this.toolsInstances?.forEach((toolInstance) => {
+    this.tools?.forEach((toolInstance) => {
       toolInstance.checkState?.(SelectionUtils.get());
     });
   }

--- a/src/components/modules/ui.ts
+++ b/src/components/modules/ui.ts
@@ -363,7 +363,7 @@ export default class UI extends Module<UINodes> {
 
 
   /**
-   * Bind events on the Editor.js interface
+   * Adds listeners that should work only in read-only mode
    */
   private bindReadOnlySensitiveListeners(): void {
     this.readOnlyMutableListeners.on(this.nodes.redactor, 'click', (event: MouseEvent) => {
@@ -444,7 +444,7 @@ export default class UI extends Module<UINodes> {
   }
 
   /**
-   * Unbind events on the Editor.js interface
+   * Unbind events that should work only in read-only mode
    */
   private unbindReadOnlySensitiveListeners(): void {
     this.readOnlyMutableListeners.clearAll();

--- a/src/components/modules/ui.ts
+++ b/src/components/modules/ui.ts
@@ -117,6 +117,13 @@ export default class UI extends Module<UINodes> {
   }, 200);
 
   /**
+   * Handle selection change to manipulate Inline Toolbar appearance
+   */
+  private selectionChangeDebounced = _.debounce(() => {
+    this.selectionChanged();
+  }, selectionChangeDebounceTimeout);
+
+  /**
    * Making main interface
    */
   public async prepare(): Promise<void> {
@@ -222,6 +229,8 @@ export default class UI extends Module<UINodes> {
    */
   public destroy(): void {
     this.nodes.holder.innerHTML = '';
+
+    this.listeners.off(document, 'selectionchange', this.selectionChangeDebounced);
   }
 
   /**
@@ -331,6 +340,7 @@ export default class UI extends Module<UINodes> {
     $.prepend(document.head, tag);
   }
 
+
   /**
    * Bind events on the Editor.js interface
    */
@@ -361,14 +371,8 @@ export default class UI extends Module<UINodes> {
       this.documentClicked(event);
     }, true);
 
-    /**
-     * Handle selection change to manipulate Inline Toolbar appearance
-     */
-    const selectionChangeDebounced = _.debounce(() => {
-      this.selectionChanged();
-    }, selectionChangeDebounceTimeout);
 
-    this.readOnlyMutableListeners.on(document, 'selectionchange', selectionChangeDebounced, true);
+    this.listeners.on(document, 'selectionchange', this.selectionChangeDebounced);
 
     this.readOnlyMutableListeners.on(window, 'resize', () => {
       this.resizeDebouncer();
@@ -821,6 +825,9 @@ export default class UI extends Module<UINodes> {
   private selectionChanged(): void {
     const { CrossBlockSelection, BlockSelection } = this.Editor;
     const focusedElement = Selection.anchorElement;
+
+    console.log('selection changed');
+
 
     if (CrossBlockSelection.isCrossBlockSelectionStarted) {
       // Removes all ranges when any Block is selected

--- a/src/components/selection.ts
+++ b/src/components/selection.ts
@@ -317,7 +317,7 @@ export default class SelectionUtils {
    *
    * @returns {Selection}
    */
-  public static get(): Selection {
+  public static get(): Selection | null  {
     return window.getSelection();
   }
 

--- a/src/components/tools/base.ts
+++ b/src/components/tools/base.ts
@@ -86,6 +86,12 @@ export enum InternalInlineToolSettings {
    * Inline Tool title for toolbar
    */
   Title = 'title', // for Inline Tools. Block Tools can pass title along with icon through the 'toolbox' static prop.
+
+  /**
+   * Allows inline tool to be available in read-only mode
+   * Can be used, for example, by comments tool
+   */
+  IsReadOnlySupported = 'isReadOnlySupported',
 }
 
 /**

--- a/src/components/tools/inline.ts
+++ b/src/components/tools/inline.ts
@@ -34,4 +34,12 @@ export default class InlineToolAdapter extends BaseToolAdapter<ToolType.Inline, 
       config: this.settings,
     }) as IInlineTool;
   }
+
+  /**
+   * Allows inline tool to be available in read-only mode
+   * Can be used, for example, by comments tool
+   */
+  public get isReadOnlySupported(): boolean {
+    return this.constructable[InternalInlineToolSettings.IsReadOnlySupported] ?? false;
+  }
 }

--- a/test/cypress/tests/tools/InlineTool.cy.ts
+++ b/test/cypress/tests/tools/InlineTool.cy.ts
@@ -21,6 +21,7 @@ describe('InlineTool', () => {
       public static prepare;
 
       public static shortcut = 'CTRL+N';
+      public static isReadOnlySupported = true;
 
       public api: object;
       public config: ToolSettings;
@@ -190,6 +191,23 @@ describe('InlineTool', () => {
       const instance = tool.create() as any;
 
       expect(instance.config).to.be.deep.eq(options.config.config);
+    });
+  });
+
+  context('.isReadOnlySupported', () => {
+    it('should return Tool provided value', () => {
+      const tool = new InlineToolAdapter(options as any);
+
+      expect(tool.isReadOnlySupported).to.be.eq(options.constructable.isReadOnlySupported);
+    });
+
+    it('should return false if Tool provided value is not exist', () => {
+      const tool = new InlineToolAdapter({
+        ...options,
+        constructable: {},
+      } as any);
+
+      expect(tool.isReadOnlySupported).to.be.false;
     });
   });
 });

--- a/types/tools/inline-tool.d.ts
+++ b/types/tools/inline-tool.d.ts
@@ -57,4 +57,10 @@ export interface InlineToolConstructable extends BaseToolConstructable {
    * @param {InlineToolConstructorOptions} config - constructor parameters
    */
   new(config: InlineToolConstructorOptions): BaseTool;
+
+  /**
+   * Allows inline tool to be available in read-only mode
+   * Can be used, for example, by comments tool
+   */
+  isReadOnlySupported?: boolean;
 }


### PR DESCRIPTION
Inline Toolbar now can be shown in read-only mode. Can be useful for tools like "Comments".

Inline Tools now can specify `isReadOnlySupported` static getter. If at least one such tool is available, the Inline Toolbar will be shown.

![image](https://github.com/user-attachments/assets/96131123-77d5-403f-bda4-4ce32f5e7bf5)
