### PR TITLE
notifier and tooltip, fix closes #2591, #2390, #2462

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `New` - Inline tools (those with `isReadOnlySupported` specified) can now be used in read-only mode
 - `Fix` - Fix selection of first block in read-only initialization with "autofocus=true"
 - `Fix` - Incorrect caret position after blocks merging in Safari
+- `Fix` - codex-notifier and codex-tooltip moved from devDependencies to dependencies in package.json to solve type errors
 
 ### 2.30.6
 

--- a/package.json
+++ b/package.json
@@ -50,8 +50,6 @@
     "@editorjs/simple-image": "^1.4.1",
     "@types/node": "^18.15.11",
     "chai-subset": "^1.6.0",
-    "codex-notifier": "^1.1.2",
-    "codex-tooltip": "^1.0.5",
     "core-js": "3.30.0",
     "cypress": "^13.13.3",
     "cypress-intellij-reporter": "^0.0.7",
@@ -79,6 +77,8 @@
     "url": "https://opencollective.com/editorjs"
   },
   "dependencies": {
-    "@editorjs/caret": "^1.0.1"
+    "@editorjs/caret": "^1.0.1",
+    "codex-notifier": "^1.1.2",
+    "codex-tooltip": "^1.0.5"
   }
 }


### PR DESCRIPTION
This fix moves the packages codex-notifier and codex-tooltip from devDependencies to dependencies.

Both packages are not only used as type imports:

https://github.com/codex-team/editor.js/blob/eb7ffcba3c1387404a61046bb9360ae1cd926efc/src/components/utils/notifier.ts#L7
https://github.com/codex-team/editor.js/blob/eb7ffcba3c1387404a61046bb9360ae1cd926efc/src/components/utils/tooltip.ts#L5

The patch fixes the following types errors:

```
node_modules/.pnpm/@editorjs+editorjs@2.30.6/node_modules/@editorjs/editorjs/types/api/notifier.d.ts:1:78 - error TS2307: Cannot find module 'codex-notifier' or its corresponding type declarations.

1 import {ConfirmNotifierOptions, NotifierOptions, PromptNotifierOptions} from 'codex-notifier';
                                                                               ~~~~~~~~~~~~~~~~

node_modules/.pnpm/@editorjs+editorjs@2.30.6/node_modules/@editorjs/editorjs/types/api/tooltip.d.ts:4:46 - error TS2307: Cannot find module 'codex-tooltip' or its corresponding type declarations.

4 import {TooltipContent, TooltipOptions} from 'codex-tooltip';
```