### PR TITLE
eslint-config-codex 1.7.1 -> 2.0.2  (Support for node > 19)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `New` - Inline tools (those with `isReadOnlySupported` specified) can now be used in read-only mode
 - `Fix` - Fix selection of first block in read-only initialization with "autofocus=true"
 - `Fix` - Incorrect caret position after blocks merging in Safari
+- `Fix` - eslint-config-codex 1.7.1 -> 2.0.2 (Support for node > 19)
 
 ### 2.30.6
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "cypress-terminal-report": "^5.3.2",
     "cypress-vite": "^1.5.0",
     "eslint": "^8.37.0",
-    "eslint-config-codex": "^1.7.1",
+    "eslint-config-codex": "^2.0.2",
     "eslint-plugin-chai-friendly": "^0.7.2",
     "eslint-plugin-cypress": "2.12.1",
     "html-janitor": "^2.0.4",


### PR DESCRIPTION
This pr adds support for node > 19.

It updates eslint-config-codex from 1.7.1 to 2.0.2 

eslint-config-codex has an dependency to eslint-plugin-jsdoc@39.9.1

This package has an expected node version "^14 || ^16 || ^17 || ^18 || ^19".