### PR TITLE
fix: block copy using settings button

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `Fix` - Fix selection of first block in read-only initialization with "autofocus=true"
 - `Fix` - Incorrect caret position after blocks merging in Safari
 - `Fix` - Several toolbox items exported by the one tool have the same shortcut displayed in toolbox
+- `Fix` - Fix issue where the block copy does not work when a block is selected using the settings button
 
 ### 2.30.6
 

--- a/src/components/utils/popover/popover-abstract.ts
+++ b/src/components/utils/popover/popover-abstract.ts
@@ -119,7 +119,9 @@ export abstract class PopoverAbstract<Nodes extends PopoverNodes = PopoverNodes>
     this.nodes.popover.classList.add(css.popoverOpened);
 
     if (this.search !== undefined) {
-      this.search.focus();
+      requestAnimationFrame(() => {
+        this.search?.focus();
+      });
     }
   }
 


### PR DESCRIPTION
Block copy (CMD + C) via settings button is broken in recent editorjs releases.

After debugging, I found the issue is related to this logic:
https://github.com/codex-team/editor.js/blob/631340912e7a1b3db1e114e930ddf1e97ec4ea61/src/components/utils/popover/popover-abstract.ts#L121-L123

It tries to focus the search input in the popover, **but it won't work.** 
We need to wrap it with `requestAnimationFrame`.

The old logic did the same:
https://github.com/codex-team/editor.js/blob/e9b4c30407d351d3772ff9f809ba02f3fd537422/src/components/utils/popover/index.ts#L239-L243

Why does this matter?

I found the answer after debugging both the old version and the latest version.

1. When a keydown event is detected on the document listener, it tries to decide if the event happens inside the editor element by:
https://github.com/codex-team/editor.js/blob/631340912e7a1b3db1e114e930ddf1e97ec4ea61/src/components/modules/ui.ts#L501

2. Since the popover does not manage to get the focus on the search element, so when we press `CMD + C` with the popover is showing, the `event.target` is actually `document` itself. So `keyDownOnEditor` is null.

3. When `keyDownOnEditor === null`:
https://github.com/codex-team/editor.js/blob/631340912e7a1b3db1e114e930ddf1e97ec4ea61/src/components/modules/ui.ts#L507-L511
It will call `this.Editor.BlockEvents.keydown(event)`, which will `close` the popover and `unselectBlock`. 
https://github.com/codex-team/editor.js/blob/631340912e7a1b3db1e114e930ddf1e97ec4ea61/src/components/modules/toolbar/blockSettings.ts#L184-L186
So we won't have a selected block any more when we do the keydown event handling later.

This PR fixs this issue by making the focus on the search element actually work again when we click the settings button.