### PR TITLE
fix(inline-link): link insertion in safari

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.30.7
+
+- `Fix` - Link insertion in Safari fixed
+
 ### 2.30.6
 
 – `Fix` – Fix the display of ‘Convert To’ near blocks that do not have the ‘conversionConfig.export’ rule specified

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/editorjs",
-  "version": "2.30.6",
+  "version": "2.30.7",
   "description": "Editor.js — open source block-style WYSIWYG editor with JSON output",
   "main": "dist/editorjs.umd.js",
   "module": "dist/editorjs.mjs",

--- a/src/components/dom.ts
+++ b/src/components/dom.ts
@@ -400,11 +400,6 @@ export default class Dom {
    * @returns {boolean}
    */
   public static isEmpty(node: Node, ignoreChars?: string): boolean {
-    /**
-     * Normalize node to merge several text nodes to one to reduce tree walker iterations
-     */
-    node.normalize();
-
     const treeWalker = [ node ];
 
     while (treeWalker.length > 0) {


### PR DESCRIPTION
## Problem

Link insertion in Safari does not work

https://github.com/user-attachments/assets/bc9159bf-d74a-468b-9828-45499a13ad35

## Cause

Since #2758 we're checking all conteneditable elements for emptiness on each `input` event. `Dom.isEmpty()` contains `.normalize()` call which changes the DOM structure. The `selection.restore()` does not work then since `this.savedSelectionRange` is not attached to actual Dom now.

## Solution

I have removed `.normalize()` call from `.isEmpty()` check. It is unexpected side effect for such method.

Resolves #2844
Resolves #2499

This PR is a patch for the latest stable version 2.30