### PR TITLE
fix: properly handle visible whitespaces in empty blocks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `Fix` - Several toolbox items exported by the one tool have the same shortcut displayed in toolbox
 - `Improvement` - The current block reference will be updated in read-only mode when blocks are clicked
 - `Fix` - codex-notifier and codex-tooltip moved from devDependencies to dependencies in package.json to solve type errors
+- `Fix` - Handle whitespace input in empty placeholder elements to prevent caret from moving unexpectedly to the end of the placeholder
 
 ### 2.30.6
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/editorjs",
-  "version": "2.31.0-rc.5",
+  "version": "2.31.0-rc.6",
   "description": "Editor.js — open source block-style WYSIWYG editor with JSON output",
   "main": "dist/editorjs.umd.js",
   "module": "dist/editorjs.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/editorjs",
-  "version": "2.31.0-rc.4",
+  "version": "2.31.0-rc.5",
   "description": "Editor.js — open source block-style WYSIWYG editor with JSON output",
   "main": "dist/editorjs.umd.js",
   "module": "dist/editorjs.mjs",

--- a/src/components/dom.ts
+++ b/src/components/dom.ts
@@ -126,7 +126,7 @@ export default class Dom {
   public static swap(el1: HTMLElement, el2: HTMLElement): void {
     // create marker element and insert it where el1 is
     const temp = document.createElement('div'),
-      parent = el1.parentNode;
+        parent = el1.parentNode;
 
     parent.insertBefore(temp, el1);
 
@@ -225,7 +225,7 @@ export default class Dom {
      * @type {string}
      */
     const child = atLast ? 'lastChild' : 'firstChild',
-      sibling = atLast ? 'previousSibling' : 'nextSibling';
+        sibling = atLast ? 'previousSibling' : 'nextSibling';
 
     if (node && node.nodeType === Node.ELEMENT_NODE && node[child]) {
       let nodeChild = node[child] as Node;
@@ -400,7 +400,7 @@ export default class Dom {
    * @returns {boolean}
    */
   public static isEmpty(node: Node, ignoreChars?: string): boolean {
-    const treeWalker = [node];
+    const treeWalker = [ node ];
 
     while (treeWalker.length > 0) {
       node = treeWalker.shift();
@@ -534,7 +534,7 @@ export default class Dom {
    */
   public static getDeepestBlockElements(parent: HTMLElement): HTMLElement[] {
     if (Dom.containsOnlyInlineElements(parent)) {
-      return [parent];
+      return [ parent ];
     }
 
     return Array.from(parent.children).reduce((result, element) => {

--- a/src/components/dom.ts
+++ b/src/components/dom.ts
@@ -126,7 +126,7 @@ export default class Dom {
   public static swap(el1: HTMLElement, el2: HTMLElement): void {
     // create marker element and insert it where el1 is
     const temp = document.createElement('div'),
-        parent = el1.parentNode;
+      parent = el1.parentNode;
 
     parent.insertBefore(temp, el1);
 
@@ -225,7 +225,7 @@ export default class Dom {
      * @type {string}
      */
     const child = atLast ? 'lastChild' : 'firstChild',
-        sibling = atLast ? 'previousSibling' : 'nextSibling';
+      sibling = atLast ? 'previousSibling' : 'nextSibling';
 
     if (node && node.nodeType === Node.ELEMENT_NODE && node[child]) {
       let nodeChild = node[child] as Node;
@@ -405,7 +405,7 @@ export default class Dom {
      */
     node.normalize();
 
-    const treeWalker = [ node ];
+    const treeWalker = [node];
 
     while (treeWalker.length > 0) {
       node = treeWalker.shift();
@@ -539,7 +539,7 @@ export default class Dom {
    */
   public static getDeepestBlockElements(parent: HTMLElement): HTMLElement[] {
     if (Dom.containsOnlyInlineElements(parent)) {
-      return [ parent ];
+      return [parent];
     }
 
     return Array.from(parent.children).reduce((result, element) => {
@@ -670,5 +670,16 @@ export function calculateBaseline(element: Element): number {
  * @param element - The element to toggle the [data-empty] attribute on
  */
 export function toggleEmptyMark(element: HTMLElement): void {
-  element.dataset.empty = Dom.isEmpty(element) ? 'true' : 'false';
+  const isOnlyWhitespace = isCollapsedWhitespaces(element.textContent || '');
+
+  const isElementEmpty = Dom.isEmpty(element) && isOnlyWhitespace;
+
+  element.dataset.empty = isElementEmpty ? 'true' : 'false';
+
+  if (isElementEmpty) {
+    const lastChild = element.lastChild;
+    if (lastChild && lastChild.nodeType === Node.ELEMENT_NODE && (lastChild as HTMLElement).tagName === 'BR') {
+      element.removeChild(lastChild);
+    }
+  }
 }

--- a/src/components/dom.ts
+++ b/src/components/dom.ts
@@ -373,7 +373,7 @@ export default class Dom {
       nodeText = nodeText.replace(new RegExp(ignoreChars, 'g'), '');
     }
 
-    return nodeText.trim().length === 0;
+    return nodeText.length === 0;
   }
 
   /**
@@ -670,16 +670,5 @@ export function calculateBaseline(element: Element): number {
  * @param element - The element to toggle the [data-empty] attribute on
  */
 export function toggleEmptyMark(element: HTMLElement): void {
-  const isOnlyWhitespace = isCollapsedWhitespaces(element.textContent || '');
-
-  const isElementEmpty = Dom.isEmpty(element) && isOnlyWhitespace;
-
-  element.dataset.empty = isElementEmpty ? 'true' : 'false';
-
-  if (isElementEmpty) {
-    const lastChild = element.lastChild;
-    if (lastChild && lastChild.nodeType === Node.ELEMENT_NODE && (lastChild as HTMLElement).tagName === 'BR') {
-      element.removeChild(lastChild);
-    }
-  }
+  element.dataset.empty = Dom.isEmpty(element) ? 'true' : 'false';
 }

--- a/test/cypress/tests/modules/BlockEvents/Backspace.cy.ts
+++ b/test/cypress/tests/modules/BlockEvents/Backspace.cy.ts
@@ -122,7 +122,7 @@ describe('Backspace keydown', function () {
     it('&nbsp; &nbsp;| — should delete visible and invisble whitespaces in the abscence of any non whitespace characters', function () {
       createEditorWithTextBlocks([
         '1',
-        ' &nbsp;',
+        '&nbsp; &nbsp;',
       ]);
 
       cy.get('[data-cy=editorjs]')
@@ -130,6 +130,8 @@ describe('Backspace keydown', function () {
         .last()
         .click()
         .type('{downArrow}')
+        .type('{backspace}')
+        .type('{backspace}')
         .type('{backspace}')
         .type('{backspace}');
 

--- a/test/cypress/tests/modules/BlockEvents/Backspace.cy.ts
+++ b/test/cypress/tests/modules/BlockEvents/Backspace.cy.ts
@@ -118,6 +118,26 @@ describe('Backspace keydown', function () {
         .last()
         .should('have.text', '12');
     });
+
+    it('&nbsp; &nbsp;| — should delete visible and invisble whitespaces in the abscence of any non whitespace characters', function () {
+      createEditorWithTextBlocks([
+        '1',
+        ' &nbsp;',
+      ]);
+
+      cy.get('[data-cy=editorjs]')
+        .find('.ce-paragraph')
+        .last()
+        .click()
+        .type('{downArrow}')
+        .type('{backspace}')
+        .type('{backspace}');
+
+      cy.get('[data-cy=editorjs]')
+        .find('div.ce-block')
+        .last()
+        .should('have.text', '1');
+    });
   });
 
   it('should just delete chars (native behaviour) when some fragment is selected', function () {
@@ -184,7 +204,7 @@ describe('Backspace keydown', function () {
        * Saving logic is not necessary for this test
        */
       // eslint-disable-next-line @typescript-eslint/no-empty-function
-      public save(): void {}
+      public save(): void { }
     }
 
     cy.createEditor({
@@ -545,7 +565,7 @@ describe('Backspace keydown', function () {
        * Saving logic is not necessary for this test
        */
       // eslint-disable-next-line @typescript-eslint/no-empty-function
-      public save(): void {}
+      public save(): void { }
     }
 
     cy.createEditor({
@@ -678,7 +698,7 @@ describe('Backspace keydown', function () {
 
   describe('at the start of the first Block', function () {
     it('should do nothing if Block is not empty', function () {
-      createEditorWithTextBlocks([ 'The only block. Not empty' ]);
+      createEditorWithTextBlocks(['The only block. Not empty']);
 
       cy.get('[data-cy=editorjs]')
         .find('.ce-paragraph')

--- a/test/cypress/tests/ui/Placeholders.cy.ts
+++ b/test/cypress/tests/ui/Placeholders.cy.ts
@@ -77,4 +77,21 @@ describe('Placeholders', function () {
       .getPseudoElementContent('::before')
       .should('eq', 'none');
   });
+
+  it('should be hidden when user adds trailing whitespace characters', function () {
+    cy.createEditor({
+      placeholder: PLACEHOLDER_TEXT,
+    });
+
+    cy.get('[data-cy=editorjs]')
+      .find('.ce-paragraph')
+      .as('firstBlock')
+      .getPseudoElementContent('::before')
+      .should('eq', PLACEHOLDER_TEXT);
+
+    cy.get('@firstBlock')
+      .type('   ')
+      .getPseudoElementContent('::before')
+      .should('eq', 'none');
+  });
 });


### PR DESCRIPTION
# Problem
Improper handling of visible whitespaces causing unwanted behaviour such as:
- unable to delete trailing whitespaces in empty blocks.
- caret jumping to the end of placeholder in `paragraph` block.

# Solution
Update the `isNodeEmpty()` to handle visible whitespaces by removing the method call `trim()` in `nodeText.trim().length` as it would remove the trailing whitespaces if any exist which in turn falsely marks a block as empty. And because of this the whitespaces are unable to be removed. 