### PR TITLE
fix: properly handle visible whitespaces in empty blocks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.30.8
+
+- `Fix` - Handle whitespace input in empty placeholder elements to prevent caret from moving unexpectedly to the end of the placeholder
+
 ### 2.30.7
 
 - `Fix` - Link insertion in Safari fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/editorjs",
-  "version": "2.30.7",
+  "version": "2.30.8",
   "description": "Editor.js — open source block-style WYSIWYG editor with JSON output",
   "main": "dist/editorjs.umd.js",
   "module": "dist/editorjs.mjs",

--- a/src/components/dom.ts
+++ b/src/components/dom.ts
@@ -373,7 +373,7 @@ export default class Dom {
       nodeText = nodeText.replace(new RegExp(ignoreChars, 'g'), '');
     }
 
-    return nodeText.trim().length === 0;
+    return nodeText.length === 0;
   }
 
   /**

--- a/test/cypress/tests/modules/BlockEvents/Backspace.cy.ts
+++ b/test/cypress/tests/modules/BlockEvents/Backspace.cy.ts
@@ -118,6 +118,29 @@ describe('Backspace keydown', function () {
         .last()
         .should('have.text', '12');
     });
+
+
+    it('&nbsp; &nbsp;| — should delete visible and invisble whitespaces in the abscence of any non whitespace characters', function () {
+      createEditorWithTextBlocks([
+        '1',
+        '&nbsp; &nbsp;',
+      ]);
+
+      cy.get('[data-cy=editorjs]')
+        .find('.ce-paragraph')
+        .last()
+        .click()
+        .type('{downArrow}')
+        .type('{backspace}')
+        .type('{backspace}')
+        .type('{backspace}')
+        .type('{backspace}');
+
+      cy.get('[data-cy=editorjs]')
+        .find('div.ce-block')
+        .last()
+        .should('have.text', '1');
+    });
   });
 
   it('should just delete chars (native behaviour) when some fragment is selected', function () {
@@ -184,7 +207,7 @@ describe('Backspace keydown', function () {
        * Saving logic is not necessary for this test
        */
       // eslint-disable-next-line @typescript-eslint/no-empty-function
-      public save(): void {}
+      public save(): void { }
     }
 
     cy.createEditor({
@@ -545,7 +568,7 @@ describe('Backspace keydown', function () {
        * Saving logic is not necessary for this test
        */
       // eslint-disable-next-line @typescript-eslint/no-empty-function
-      public save(): void {}
+      public save(): void { }
     }
 
     cy.createEditor({
@@ -678,7 +701,7 @@ describe('Backspace keydown', function () {
 
   describe('at the start of the first Block', function () {
     it('should do nothing if Block is not empty', function () {
-      createEditorWithTextBlocks([ 'The only block. Not empty' ]);
+      createEditorWithTextBlocks(['The only block. Not empty']);
 
       cy.get('[data-cy=editorjs]')
         .find('.ce-paragraph')

--- a/test/cypress/tests/ui/Placeholders.cy.ts
+++ b/test/cypress/tests/ui/Placeholders.cy.ts
@@ -77,4 +77,21 @@ describe('Placeholders', function () {
       .getPseudoElementContent('::before')
       .should('eq', 'none');
   });
+
+  it('should be hidden when user adds trailing whitespace characters', function () {
+    cy.createEditor({
+      placeholder: PLACEHOLDER_TEXT,
+    });
+
+    cy.get('[data-cy=editorjs]')
+      .find('.ce-paragraph')
+      .as('firstBlock')
+      .getPseudoElementContent('::before')
+      .should('eq', PLACEHOLDER_TEXT);
+
+    cy.get('@firstBlock')
+      .type('   ')
+      .getPseudoElementContent('::before')
+      .should('eq', 'none');
+  });
 });


### PR DESCRIPTION
# Problem
Improper handling of visible whitespaces causing unwanted behaviour such as:
- unable to delete trailing whitespaces in empty blocks.
- caret jumping to the end of placeholder in `paragraph` block.

# Solution
Update the `isNodeEmpty()` to handle visible whitespaces by removing the method call `trim()` in `nodeText.trim().length` as it would remove the trailing whitespaces if any exist which in turn falsely marks a block as empty. And because of this the whitespaces are unable to be removed. 