### PR TITLE
Fix rendering of examples

### DIFF
--- a/example/example-i18n.html
+++ b/example/example-i18n.html
@@ -107,7 +107,7 @@
       image: ImageTool,
 
       list: {
-        class: List,
+        class: EditorjsList,
         inlineToolbar: true,
         shortcut: 'CMD+SHIFT+L'
       },

--- a/example/example-rtl.html
+++ b/example/example-rtl.html
@@ -121,7 +121,7 @@
       },
 
       list: {
-        class: List,
+        class: EditorjsList,
         inlineToolbar: true,
         shortcut: 'CMD+SHIFT+L'
       },

--- a/example/example.html
+++ b/example/example.html
@@ -120,7 +120,7 @@
         image: SimpleImage,
 
         list: {
-          class: List,
+          class: EditorjsList,
           inlineToolbar: true,
           shortcut: 'CMD+SHIFT+L'
         },


### PR DESCRIPTION
It seems like the default export of `@editorjs/list` changed to `EditorjsList` and it breaks when I try to run the example.html from `examples/example.html`