### PR TITLE
Fix: Typo In Sanitazer Config Interface

### DIFF
--- a/types/configs/sanitizer-config.d.ts
+++ b/types/configs/sanitizer-config.d.ts
@@ -21,7 +21,7 @@ export interface SanitizerConfig {
    *
    * @example Save A tags with TARGET="_blank" attribute
    * a: function (aTag) {
-   *   return aTag.target === '_black';
+   *   return aTag.target === '_blank';
    * }
    *
    * @example Save U tags that are not empty


### PR DESCRIPTION
Corrected a typo in the example comment from '_black' to '_blank'. The change is present in types/configs/sanitizer-config.d.ts