### PR TITLE
fix: opening formatted links

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `DX` - Tools submodules removed from the repository
 - `Improvement` - Shift + Down/Up will allow to select next/previous line instead of Inline Toolbar flipping
 - `Improvement` - The API `caret.setToBlock()` offset now works across the entire block content, not just the first or last node.
+- `Fix` - Opening links (via ctrl/cmd key + click) that are additionally formatted (e.g. bold)
 
 ### 2.30.7
 

--- a/src/components/dom.ts
+++ b/src/components/dom.ts
@@ -557,16 +557,6 @@ export default class Dom {
   }
 
   /**
-   * Returns true if element is anchor (is A tag)
-   *
-   * @param {Element} element - element to check
-   * @returns {boolean}
-   */
-  public static isAnchor(element: Element): element is HTMLAnchorElement {
-    return element.tagName.toLowerCase() === 'a';
-  }
-
-  /**
    * Return element's offset related to the document
    *
    * @todo handle case when editor initialized in scrollable popup

--- a/src/components/modules/ui.ts
+++ b/src/components/modules/ui.ts
@@ -767,26 +767,57 @@ export default class UI extends Module<UINodes> {
       return;
     }
 
-    /**
-     * case when user clicks on anchor element
-     * if it is clicked via ctrl key, then we open new window with url
-     */
-    const element = event.target as Element;
-    const ctrlKey = event.metaKey || event.ctrlKey;
-
-    if ($.isAnchor(element) && ctrlKey) {
-      event.stopImmediatePropagation();
-      event.stopPropagation();
-
-      const href = element.getAttribute('href');
-      const validUrl = _.getValidUrl(href);
-
-      _.openTab(validUrl);
-
+    if (this.processLinkClick(event)) {
       return;
     }
 
     this.processBottomZoneClick(event);
+  }
+
+  /**
+   * Check if user clicks on a link while holding down the ctrl/cmd key.
+   * In that case, open it in a new tab/window.
+   *
+   * @param event - click event
+   * @returns true if a link has been opened
+   */
+  private processLinkClick(event: MouseEvent): boolean {
+    const ctrlKey = event.metaKey || event.ctrlKey;
+
+    if (ctrlKey && event.target instanceof Element) {
+      let currentElement: Element | null = event.target;
+      let anchor = null;
+
+      while (currentElement) {
+        if (currentElement === this.nodes.redactor) {
+          return false;
+        }
+
+        if (currentElement.tagName === 'A') {
+          anchor = currentElement;
+          break;
+        }
+
+        currentElement = currentElement.parentElement;
+      }
+
+      if (anchor) {
+        event.stopImmediatePropagation();
+        event.stopPropagation();
+
+        const href = anchor.getAttribute('href');
+
+        if (href !== null) {
+          const validUrl = _.getValidUrl(href);
+
+          window.open(validUrl, '_blank');
+        }
+
+        return true;
+      }
+    }
+
+    return false;
   }
 
   /**

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -666,15 +666,6 @@ export function generateBlockId(): string {
 }
 
 /**
- * Opens new Tab with passed URL
- *
- * @param {string} url - URL address to redirect
- */
-export function openTab(url: string): void {
-  window.open(url, '_blank');
-}
-
-/**
  * Returns random generated identifier
  *
  * @param {string} prefix - identifier prefix


### PR DESCRIPTION
Fixes #2735 by traversing up from the clicked element (at most until redactor is reached) and checking if any of the parent elements is a link. Also moves logic into a separate method (like `processBottomZoneClick`) and removes two superfluous internal functions, which were only used for this part.