### PR TITLE
fix: state of bold formatting in inline toolbar

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@
 - `DX` - Tools submodules removed from the repository
 - `Improvement` - Shift + Down/Up will allow to select next/previous line instead of Inline Toolbar flipping
 - `Improvement` - The API `caret.setToBlock()` offset now works across the entire block content, not just the first or last node.
+- `Fix` - Showing the correct state of bold formatting in the inline toolbar
 
 ### 2.30.7
 

--- a/src/components/inline-tools/inline-tool-bold.ts
+++ b/src/components/inline-tools/inline-tool-bold.ts
@@ -46,9 +46,8 @@ export default class BoldInlineTool implements InlineTool {
     return {
       icon: IconBold,
       name: 'bold',
-      onActivate: () => {
-        document.execCommand(this.commandName);
-      },
+      toggle: true,
+      onActivate: () => document.execCommand(this.commandName),
       isActive: () => document.queryCommandState(this.commandName),
     };
   }


### PR DESCRIPTION
Showing the correct state of bold formatting in the inline toolbar (tool needs to be marked as "toggleable"):

https://github.com/user-attachments/assets/2d12d226-1cc9-4be1-b287-9316683eebbf

https://github.com/user-attachments/assets/8ee0ef79-7bfb-4c08-a04e-702391d050c3