### PR TITLE
resolve "Can't find a Block to remove" error in renderFromHTML

### DIFF
--- a/src/components/blocks.ts
+++ b/src/components/blocks.ts
@@ -287,9 +287,8 @@ export default class Blocks {
       index = this.length - 1;
     }
 
-    this.blocks[index].holder.remove();
-
     this.blocks[index].call(BlockToolAPI.REMOVED);
+    this.blocks[index].holder.remove();
 
     this.blocks.splice(index, 1);
   }

--- a/src/components/blocks.ts
+++ b/src/components/blocks.ts
@@ -287,8 +287,9 @@ export default class Blocks {
       index = this.length - 1;
     }
 
-    this.blocks[index].call(BlockToolAPI.REMOVED);
     this.blocks[index].holder.remove();
+
+    this.blocks[index].call(BlockToolAPI.REMOVED);
 
     this.blocks.splice(index, 1);
   }

--- a/src/components/modules/api/blocks.ts
+++ b/src/components/modules/api/blocks.ts
@@ -224,8 +224,8 @@ export default class BlocksAPI extends Module {
    * @param {string} data - HTML string to render
    * @returns {Promise<void>}
    */
-  public renderFromHTML(data: string): Promise<void> {
-    this.Editor.BlockManager.clear();
+  public async renderFromHTML(data: string): Promise<void> {
+    await this.Editor.BlockManager.clear();
 
     return this.Editor.Paste.processText(data, true);
   }

--- a/src/components/modules/blockManager.ts
+++ b/src/components/modules/blockManager.ts
@@ -533,8 +533,8 @@ export default class BlockManager extends Module {
         throw new Error('Can\'t find a Block to remove');
       }
 
-      block.destroy();
       this._blocks.remove(index);
+      block.destroy();
 
       /**
        * Force call of didMutated event on Block removal
@@ -894,7 +894,10 @@ export default class BlockManager extends Module {
   public async clear(needToAddDefaultBlock = false): Promise<void> {
     const queue = new PromiseQueue();
 
-    this.blocks.forEach((block) => {
+    // Create a copy of the blocks array to avoid issues with array modification during iteration
+    const blocksToRemove = [...this.blocks];
+    
+    blocksToRemove.forEach((block) => {
       queue.add(async () => {
         await this.removeBlock(block, false);
       });


### PR DESCRIPTION
fix: resolve "Can't find a Block to remove" error in renderFromHTML

- Make renderFromHTML async and await BlockManager.clear() to prevent race condition
- Change removeBlock order: remove from array before destroy to prevent index invalidation  
- Fix clear() method to copy blocks array before iteration to avoid modification during loop

Fixes issue where renderFromHTML would fail with "Can't find a Block to remove" error
due to concurrent block removal operations and array modification during iteration.

Resolves #2518