### PR TITLE
fix(readonly): prevent warning on initial read-only mode toggle

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.31.1
+
+- `Fix` - Prevent the warning from appearing when `readOnly` mode is initially set to `true`
+
 ### 2.31.0
 
 - `New` - Inline tools (those with `isReadOnlySupported` specified) can now be used in read-only mode

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/editorjs",
-  "version": "2.31.0",
+  "version": "2.31.1",
   "description": "Editor.js — open source block-style WYSIWYG editor with JSON output",
   "main": "dist/editorjs.umd.js",
   "module": "dist/editorjs.mjs",

--- a/src/components/modules/toolbar/blockSettings.ts
+++ b/src/components/modules/toolbar/blockSettings.ts
@@ -69,6 +69,11 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
   }
 
   /**
+   * Flag that indicates whether the `EditorMobileLayoutToggled` event listener is attached.
+   */
+  private hasMobileLayoutToggleListener = false;
+
+  /**
    * Page selection utils
    */
   private selection: SelectionUtils = new SelectionUtils();
@@ -92,6 +97,7 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
     }
 
     this.eventsDispatcher.on(EditorMobileLayoutToggled, this.close);
+    this.hasMobileLayoutToggleListener = true;
   }
 
   /**
@@ -100,7 +106,11 @@ export default class BlockSettings extends Module<BlockSettingsNodes> {
   public destroy(): void {
     this.removeAllNodes();
     this.listeners.destroy();
-    this.eventsDispatcher.off(EditorMobileLayoutToggled, this.close);
+
+    if (this.hasMobileLayoutToggleListener) {
+      this.eventsDispatcher.off(EditorMobileLayoutToggled, this.close);
+      this.hasMobileLayoutToggleListener = false;
+    }
   }
 
   /**


### PR DESCRIPTION
**Problem:**
If `readOnly` is initially set to `true`, Console tab displays warning:
`EventDispatcher .off(): there is no subscribers for event "editor mobile layout toggled". Probably, .off() called before .on()`.

**Issue:**
https://github.com/codex-team/editor.js/issues/2772

**Solution:**
Add a guard to prevent unsubscribing from an event that was never subscribed when initial read-only mode is set to `true`.