### PR TITLE
ci: update deprecated GitHub Actions runners

### DIFF
--- a/.github/workflows/bump-version-on-merge-next.yml
+++ b/.github/workflows/bump-version-on-merge-next.yml
@@ -17,7 +17,7 @@ jobs:
   # If pull request was merged then we should check for a package version update
   check-for-no-version-changing:
     if: github.event.pull_request.merged == true
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       actions: write
     steps:

--- a/.github/workflows/create-a-release-draft.yml
+++ b/.github/workflows/create-a-release-draft.yml
@@ -17,7 +17,7 @@ jobs:
   # If pull request was merged then we should check for a package version update
   check-version-changing:
     if: github.event.pull_request.merged == true
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       actions: write
     steps:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -8,12 +8,12 @@ jobs:
       matrix:
         browser: [firefox, chrome, edge]
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: 18
-      - uses: actions/checkout@v4
       - uses: cypress-io/github-action@v6
         with:
           config: video=false

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -14,6 +14,13 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+
+      - name: Setup Firefox
+        if: matrix.browser == 'firefox'
+        uses: browser-actions/setup-firefox@v1
+        with:
+          firefox-version: '115.0esr'
+
       - uses: cypress-io/github-action@v6
         with:
           config: video=false

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         browser: [firefox, chrome, edge]
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   lint:
     name: ESlint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -9,6 +9,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
       - name: Cache dependencies
         uses: actions/cache@v4
         with:

--- a/.github/workflows/publish-package-to-npm.yml
+++ b/.github/workflows/publish-package-to-npm.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       # Checkout to target branch
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

GitHub Actions workflows are stuck in "Queued" state indefinitely because they use `ubuntu-20.04` runner which [deprecated and removed by GitHub](https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/).

This blocks all PRs from being merged.

## Solution

Update `runs-on` from `ubuntu-20.04` to `ubuntu-latest` in:
- `.github/workflows/cypress.yml`
- `.github/workflows/eslint.yml`
- `.github/workflows/publish-package-to-npm.yml`
- `.github/workflows/create-a-release-draft.yml`
- `.github/workflows/bump-version-on-merge-next.yml`