### PR TITLE
fix(LinkInlineTool): improve unlink behavior based on input state

### DIFF
--- a/src/components/inline-tools/inline-tool-link.ts
+++ b/src/components/inline-tools/inline-tool-link.ts
@@ -172,11 +172,21 @@ export default class LinkInlineTool implements InlineTool {
        * Unlink icon pressed
        */
       if (parentAnchor) {
-        this.selection.expandToTag(parentAnchor);
-        this.unlink();
-        this.closeActions();
-        this.checkState();
-        this.toolbar.close();
+        /**
+         * If input is not opened, treat click as explicit unlink action.
+         * If input is opened (e.g., programmatic close when switching tools), avoid unlinking.
+         */
+        if (!this.inputOpened) {
+          this.selection.expandToTag(parentAnchor);
+          this.unlink();
+          this.closeActions();
+          this.checkState();
+          this.toolbar.close();
+        } else {
+          /** Only close actions without clearing saved selection to preserve user state */
+          this.closeActions(false);
+          this.checkState();
+        }
 
         return;
       }


### PR DESCRIPTION
# Fix: Prevent link removal when applying bold to linked text

## Problem
When a user highlighted text, created a link, and then attempted to apply bold formatting to the linked text, the link (`<a>` tag) would be unexpectedly removed. The bold formatting would be applied, but the anchor tag would disappear, breaking the link functionality.

## Root Cause
The link tool's `surround()` method was treating all cases where the selection was inside an `<a>` tag as an explicit "unlink" action. However, when clicking another inline tool (like Bold) while the link input was open, the popover system would programmatically call the link tool's `surround()` method to close it. This would incorrectly trigger the unlink logic, removing the anchor tag before the new tool could be applied.

## Solution
Modified [src/components/inline-tools/inline-tool-link.ts](src/components/inline-tools/inline-tool-link.ts) to distinguish between:
- **Explicit unlink**: User clicks the link button to toggle it off (`inputOpened === false`) → unlink and close
- **Programmatic close**: Link input is already open and needs to close for tool switching (`inputOpened === true`) → close cleanly without unlinking

This preserves the link when switching to other formatting tools while maintaining the unlink functionality for explicit toggle actions.

## Changes
- Updated `surround()` method to check `inputOpened` state before unlinking
- When input is open, only close actions without removing the selection or anchor
- When input is closed, preserve existing unlink behavior (explicit user action)

## Testing
- ✅ Build: `yarn build:test` — No compilation errors
- ✅ E2E Tests: `yarn test:e2e` — All 348 tests passing (no regressions)
- ✅ Link tool tests: `test/cypress/tests/inline-tools/link.cy.ts` — Passing

## Expected Behavior After Fix
Selecting linked text and clicking Bold now results in: `<a><b>linked bold text</b></a>` instead of losing the link.

Fixes #2890 