### PR TITLE
fix(LinkInlineTool): improve unlink behavior based on input state

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.31.2
+
+- `Fix` - Prevent link removal when applying bold to linked text
+
 ### 2.31.1
 
 - `Fix` - Prevent the warning from appearing when `readOnly` mode is initially set to `true`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-### 2.31.2
-
-- `Fix` - Prevent link removal when applying bold to linked text
-
 ### 2.31.1
 
 - `Fix` - Prevent the warning from appearing when `readOnly` mode is initially set to `true`
@@ -25,8 +21,10 @@
 - `Improvement` - Shift + Down/Up will allow to select next/previous line instead of Inline Toolbar flipping
 - `Improvement` - The API `caret.setToBlock()` offset now works across the entire block content, not just the first or last node.
 - `Improvement` - The API `blocks.renderFromHTML()` became async and now can be awaited.
-- `Fix` - `blocks.renderFromHTML()` — Error "Can't find a Block to remove." fixed
+- `Fix` - `blocks.renderFromHTML()` — Error  "Can't find a Block to remove." fixed
 - `Fix` - The API `.clear()` index invalidation fixed
+
+
 
 ### 2.30.7
 
@@ -64,13 +62,13 @@
 
 - `New` – Block Tunes now supports nesting items
 - `New` – Block Tunes now supports separator items
-- `New` – _Menu Config_ – New item type – HTML
-- `New` – _Menu Config_ – Default and HTML items now support hints
+- `New` – *Menu Config* – New item type – HTML
+- `New` – *Menu Config* – Default and HTML items now support hints
 - `New` – Inline Toolbar has new look 💅
 - `New` – Inline Tool's `render()` now supports [Menu Config](https://editorjs.io/menu-config/) format
-- `New` – _ToolsAPI_ – All installed block tools now accessible via ToolsAPI `getBlockTools()` method
-- `New` – _SelectionAPI_ – Exposed methods `save()` and `restore()` that allow to save selection to be able to temporally move focus away, methods `setFakeBackground()` and `removeFakeBackground()` that allow to immitate selection while focus moved away
-- `New` – _BlocksAPI_ – Exposed `getBlockByElement()` method that helps find block by any child html element
+- `New` – *ToolsAPI* – All installed block tools now accessible via ToolsAPI `getBlockTools()` method
+- `New` – *SelectionAPI* – Exposed methods `save()` and `restore()` that allow to save selection to be able to temporally move focus away, methods `setFakeBackground()` and `removeFakeBackground()` that allow to immitate selection while focus moved away
+- `New` – *BlocksAPI* – Exposed `getBlockByElement()` method that helps find block by any child html element
 - `New` – "Convert to" control is now also available in Block Tunes
 - `New` — Editor.js now supports contenteditable placeholders out of the box. Just add `data-placeholder` or `data-placeholder-active` attribute to make it work. The first one will work like native placeholder while the second one will show placeholder only when block is current.
 - `Improvement` — Now Paragraph placeholder will be shown for the current paragraph, not only the first one.
@@ -78,12 +76,12 @@
 - `Improvement` — The ability to merge blocks of different types (if both tools provide the conversionConfig)
 - `Improvement` - The API `blocks.convert()` now returns the new block API
 - `Improvement` - The API `caret.setToBlock()` now can accept either BlockAPI or block index or block id
-- `Improvement` – _MenuConfig_ – `TunesMenuConfig` type is deprecated, use the `MenuConfig` instead
-  – `Improvement` — _Types_ — `BlockToolConstructorOptions` type improved, `block` and `config` are not optional anymore
+- `Improvement` – *MenuConfig* – `TunesMenuConfig` type is deprecated, use the `MenuConfig` instead
+– `Improvement` — *Types* — `BlockToolConstructorOptions` type improved, `block` and `config` are not optional anymore
 - `Improvement` - The Plus button and Block Tunes toggler are now better aligned with large line-height blocks, such as Headings
 - `Improvement` — Creating links on Android devices: now the mobile keyboard will have an "Enter" key for accepting the inserted link.
 - `Improvement` — Placeholders will stay visible on inputs focus.
-  – `Refactoring` – Switched to Vite as Cypress bundler
+– `Refactoring` – Switched to Vite as Cypress bundler
 - `Fix` — `onChange` will be called when removing the entire text within a descendant element of a block.
 - `Fix` - Unexpected new line on Enter press with selected block without caret
 - `Fix` - Search input autofocus loosing after Block Tunes opening
@@ -92,7 +90,7 @@
 - `Fix` - Unwanted soft line break on Enter press after period and space (". |") on iOS devices
 - `Fix` - Caret lost after block conversion on mobile devices.
 - `Fix` - Caret lost after Backspace at the start of block when previoius block is not convertable
-  – `Fix` — Deleting whitespaces at the start/end of the block
+– `Fix` — Deleting whitespaces at the start/end of the block
 - `Fix` — The problem caused by missed "import type" in block mutation event types resolved
 
 ### 2.29.1
@@ -153,6 +151,7 @@
 - `Improvement` - `blocks.update(id, data)` now will trigger onChange with only `block-change` event.
 - `Improvement` - `blocks.update(id, data)` will return a promise with BlockAPI object of the changed block.
 
+
 ### 2.27.2
 
 - `Fix` - `onChange` won't be called when element with data-mutation-free changes some attribute
@@ -163,18 +162,18 @@
 
 ### 2.27.0
 
-- `New` — _Toolbar API_ — Added a new method for toggling the toolbox.
+- `New` — *Toolbar API* — Added a new method for toggling the toolbox.
 - `New` — Added types for block mutation events
 - `New` — Batching added to the `onChange` callback. Now the second argument can contain an array of CustomEvents as well as a single one. Multiple changes made in a short period of time will be batched under a single `onChange` call.
-- `Improvement` — _Toolbox_ — Number of `close()` method calls optimized.
+- `Improvement` — *Toolbox* — Number of `close()` method calls optimized.
 - `Improvement` — The `onChange` callback can be muted if all mutations contain nodes with the `data-mutation-free` attribute.
 - `Improvement` — Pressing "Enter" at the end of a Block won't lead to redundant `block-changed` event triggering. Only `block-added` event will be dispatched.
 - `Improvement` — The block mutation handler is now called on every block change (including background changes), instead of only when a block is focused
 - `Improvement` — Number of caret saving method calls optimized for Block Tunes opening/closing.
 - `Improvement` — Package size reduced by removing redundant files.
 - `Refactoring` — Switched from Webpack to Vite as the build system.
-- `Refactoring` — _Dependencies_ — Upgraded Cypress to v12 and related libraries to the latest versions.
-- `Refactoring` — _Dependencies_ — Upgraded TypeScript to v5.
+- `Refactoring` — *Dependencies* — Upgraded Cypress to v12 and related libraries to the latest versions.
+- `Refactoring` — *Dependencies* — Upgraded TypeScript to v5.
 - `Refactoring` — `EventDispatcher` types improved. Now we can pass `EventsMap` via generic to specify a map of event names and their payloads that can be used in a particular EventDispatcher instance.
 - `Refactoring` — All events in common editor Event Bus now have own type declarations.
 - `Refactoring` — Removed the block mutation observer from blocks and attached a single observer to the editor's blocks wrapper element.
@@ -184,38 +183,38 @@
 - `Fix` — Resolved a compiler error caused by importing the `BlockToolData` type.
 - `Fix` — Resolved a problem where the document would scroll to the beginning after moving a block above the viewport.
 - `Fix`- Fixed several bugs caused by browser extensions — Removed the search for a block's container in the DOM on saving and kept it in memory instead, updating it when the tool changes a container element.
-- `Fix` — _ToolsAPI_ — `pasteConfig` getter with `false` value could be used to disable paste handling by Editor.js core. Could be useful if your tool has its own paste handler.
+- `Fix` — *ToolsAPI* — `pasteConfig` getter with `false` value could be used to disable paste handling by Editor.js core. Could be useful if your tool has its own paste handler.
 - `CI` — Ubuntu container is now used for Edge tests runner.
 - `CI` — Node 16 is used for GitHib Actions.
 
 ### 2.26.5
 
-- `Fix` — _Types_ — Remove unnecessary import that creates a dependency on the `cypress`.
+- `Fix` — *Types* — Remove unnecessary import that creates a dependency on the `cypress`.
 
 ### 2.26.4
 
-- `Improvement` — _Menu Config_ — Property `label` renamed to `title`.
+- `Improvement` — *Menu Config* — Property `label` renamed to `title`.
 
 ### 2.26.3
 
-- `Fix` — _Paste Module_ — fix for a problem with specifying of `pasteConfig().tags` in upper case [#2208](https://github.com/codex-team/editor.js/issues/2208).
+- `Fix` — *Paste Module* — fix for a problem with specifying of `pasteConfig().tags` in upper case  [#2208](https://github.com/codex-team/editor.js/issues/2208).
 
 ### 2.26.2
 
-- `Fix` — _Menu Config_ — Installed tunes are rendered above default tunes again.
+- `Fix` — *Menu Config* — Installed tunes are rendered above default tunes again.
 
 ### 2.26.1
 
-- `Improvement` — _Menu Config_ — Now it becomes possible to create toggle groups.
+- `Improvement` — *Menu Config* — Now it becomes possible to create toggle groups.
 
 ### 2.26.0
 
-- `New` — _UI_ — Block Tunes became vertical just like the Toolbox 🤩
-- `New` — _Block Tunes API_ — Now `render()` method of a Block Tune can return config with just icon, label and callback instead of custom HTML. This improvement is a key to the new straightforward way of configuring tune's appearance in Block Tunes menu.
-- `New` — _Tools API_ — As well as `render()` in `Tunes API`, Tool's `renderSettings()` now also supports new configuration format.
-- `New` — _UI_ — Meet the new icons from [CodeX Icons](https://github.com/codex-team/icons) pack 🛍 💝
-- `New` — _BlocksAPI_ — the `blocks.insert()` method now also have the optional `id` param. If passed, this id will be used instead of the generated one.
-- `Deprecated` — _Styles API_ — CSS classes `.cdx-settings-button` and `.cdx-settings-button--active` are not recommended to use. Consider configuring your block settings with new JSON API instead.
+- `New` — *UI* — Block Tunes became vertical just like the Toolbox 🤩
+- `New` — *Block Tunes API* — Now `render()` method of a Block Tune can return config with just icon, label and callback instead of custom HTML. This improvement is a key to the new straightforward way of configuring tune's appearance in Block Tunes menu.
+- `New` — *Tools API* — As well as `render()` in `Tunes API`, Tool's `renderSettings()` now also supports new configuration format.
+- `New` — *UI* — Meet the new icons from [CodeX Icons](https://github.com/codex-team/icons) pack 🛍 💝
+- `New` — *BlocksAPI* — the `blocks.insert()` method now also have the optional `id` param. If passed, this id will be used instead of the generated one.
+- `Deprecated` — *Styles API* — CSS classes `.cdx-settings-button` and `.cdx-settings-button--active` are not recommended to use. Consider configuring your block settings with new JSON API instead.
 - `Fix` — Wrong element not highlighted anymore when popover opened.
 - `Fix` — When Tunes Menu open keydown events can not be handled inside plugins.
 - `Fix` — If a Tool specifies some tags to substitute on paste, all attributes of that tags will be removed before passing them to the tool. Possible XSS vulnerability fixed.
@@ -223,15 +222,16 @@
 - `Fix` — Workaround for the HTMLJanitor bug with Tables (https://github.com/guardian/html-janitor/issues/3) added
 - `Fix` — Toolbox shortcuts appearance and execution fixed [#2112](https://github.com/codex-team/editor.js/issues/2112)
 - `Fix` — Inline Tools click handling on mobile devices improved
-- `Improvement` — _Tools API_ — `pasteConfig().tags` now support sanitizing configuration. It allows you to leave some explicitly specified attributes for pasted content.
-- `Improvement` — _CodeStyle_ — [CodeX ESLint Config](https://github.com/codex-team/eslint-config) has bee updated. All ESLint/Spelling issues resolved
-- `Improvement` — _ToolsAPI_ — The `icon` property of the `toolbox` getter became optional.
+- `Improvement` — *Tools API* — `pasteConfig().tags` now support sanitizing configuration. It allows you to leave some explicitly specified attributes for pasted content.
+- `Improvement` — *CodeStyle* — [CodeX ESLint Config](https://github.com/codex-team/eslint-config) has bee updated. All ESLint/Spelling issues resolved
+- `Improvement` — *ToolsAPI* — The `icon` property of the `toolbox` getter became optional.
+
 
 ### 2.25.0
 
-- `New` — _Tools API_ — Introducing new feature — toolbox now can have multiple entries for one tool! <br>
-  Due to that API changes: tool's `toolbox` getter now can return either a single config item or an array of config items
-- `New` — _Blocks API_ — `composeBlockData()` method was added.
+- `New` — *Tools API* — Introducing new feature — toolbox now can have multiple entries for one tool! <br>
+Due to that API changes: tool's `toolbox` getter now can return either a single config item or an array of config items
+- `New` — *Blocks API* — `composeBlockData()` method was added.
 
 ### 2.24.4
 
@@ -246,8 +246,8 @@
 - `Fix` — Scrolling issue when opening toolbox on mobile fixed
 - `Fix` — Typo in toolbox empty placeholder fixed
 - `Fix` — The issue with scroll jumping on block hovering have fixed [2036](https://github.com/codex-team/editor.js/issues/2036)
-- `Improvement` — _Dev Example Page_ - Add popup example page
-- `Improvement` — _UI_ - The Toolbox will restore the internal scroll on every opening
+- `Improvement` — *Dev Example Page* - Add popup example page
+- `Improvement` — *UI* - The Toolbox will restore the internal scroll on every opening
 
 ### 2.24.1
 
@@ -255,9 +255,9 @@
 
 ### 2.24.0
 
-- `New` — _UI_ — The Toolbox became vertical 🥳
-- `Improvement` — _UI_ — the Plus button will always be shown (previously, it appears only for empty blocks)
-- `Improvement` — _Dev Example Page_ - Server added to allow opening example page on other devices in network.
+- `New` — *UI* — The Toolbox became vertical 🥳
+- `Improvement` — *UI* — the Plus button will always be shown (previously, it appears only for empty blocks)
+- `Improvement` — *Dev Example Page* - Server added to allow opening example page on other devices in network.
 - `Fix` — `UI` — the Toolbar won't move on hover at mobile viewports. Resolves [#1972](https://github.com/codex-team/editor.js/issues/1972)
 - `Fix` — `OnChange` event invocation after block insertion. [#1997](https://github.com/codex-team/editor.js/issues/1997)
 - `Fix` — `ReadOnly` — the `readonly.isEnabled` API getter now works correctly after `readonly.toggle()` calling. Resolves [#1822](https://github.com/codex-team/editor.js/issues/1822)
@@ -273,21 +273,21 @@
 
 ### 2.23.0
 
-- `Improvement` — _EditorConfig_ — The `onChange` callback now accepts two arguments: EditorJS API and the CustomEvent with `type` and `detail` allowing to determine what happened with a Block
-- `New` — _Block API_ — The new `dispatchChange()` method allows to manually trigger the 'onChange' callback. Useful when Tool made a state mutation that is invisible for editor core.
-- `Improvement` — _UI_ — Block Tunes toggler moved to the left
-- `Improvement` — _UI_ — Block Actions (BT toggler + Plus Button) will appear on block hovering instead of click
-- `Improvement` — _UI_ — Block Tunes toggler icon and Plus button icon updated
-- `Improvement` — _Dev Example Page_ — The menu with helpful buttons added to the bottom of the screen
-- `Improvement` — _Dev Example Page_ — The 'dark' theme added. Now we can code at night more comfortably.
-- `Improvement` — _Rectangle Selection_ — paint optimized
-- `Fix` — _Rectangle Selection_ — the first click after RS was not clear selection state. Now does.
-- `Improvement` — _Blocks API_ — toolbar moving logic removed from `blocks.move()` and `blocks.swap()` methods. Instead, you should use Toolbar API (it was used by MoveUp and MoveDown tunes, they were updated).
-- `New` — _Blocks API_ — The `getBlockIndex()` method added
-- `New` — _Blocks API_ — the `insert()` method now has the `replace: boolean` parameter
-- `New` — _Blocks API_ — the `insert()` method now returns the inserted `Block API`
-- `New` — _Listeners API_ — the `on()` method now returns the listener id.
-- `New` — _Listeners API_ — the new `offById()` method added
+- `Improvement` — *EditorConfig* — The `onChange` callback now accepts two arguments: EditorJS API and the CustomEvent with `type` and `detail` allowing to determine what happened with a Block
+- `New` — *Block API* — The new `dispatchChange()` method allows to manually trigger the 'onChange' callback. Useful when Tool made a state mutation that is invisible for editor core.
+- `Improvement` — *UI* — Block Tunes toggler moved to the left
+- `Improvement` — *UI* — Block Actions (BT toggler + Plus Button) will appear on block hovering instead of click
+- `Improvement` — *UI* — Block Tunes toggler icon and Plus button icon updated
+- `Improvement` — *Dev Example Page* — The menu with helpful buttons added to the bottom of the screen
+- `Improvement` — *Dev Example Page* — The 'dark' theme added. Now we can code at night more comfortably.
+- `Improvement` — *Rectangle Selection* — paint optimized
+- `Fix` — *Rectangle Selection* — the first click after RS was not clear selection state. Now does.
+- `Improvement` — *Blocks API* — toolbar moving logic removed from `blocks.move()` and `blocks.swap()` methods. Instead, you should use Toolbar API (it was used by MoveUp and MoveDown tunes, they were updated).
+- `New` — *Blocks API* — The `getBlockIndex()` method added
+- `New` — *Blocks API* — the `insert()` method now has the `replace: boolean` parameter
+- `New` — *Blocks API* —  the `insert()` method now returns the inserted `Block API`
+- `New` — *Listeners API* — the `on()` method now returns the listener id.
+- `New` — *Listeners API* — the new `offById()` method added
 - `New` — `API` — The new `UiApi` section was added. It allows accessing some editor UI nodes and methods.
 - `Refactoring` — Toolbox became a standalone class instead of a Module. It can be accessed only through the Toolbar module.
 - `Refactoring` — CI flow optimized.
@@ -301,9 +301,9 @@
 ### 2.22.2
 
 - `Improvement` — Inline Toolbar might be used for any contenteditable element inside Editor.js zone
-- `Improvement` _Tunes API_ - Tunes now can provide sanitize configuration
-- `Fix` _Tunes API_ - Tune config now passed to constructor under `config` property
-- `Fix` _Types_ - Add common type for internal and external Tools configuration
+- `Improvement` *Tunes API* - Tunes now can provide sanitize configuration
+- `Fix` *Tunes API* - Tune config now passed to constructor under `config` property
+- `Fix` *Types* - Add common type for internal and external Tools configuration
 - `Fix` — Block's destroy method is called on block deletion
 - `Fix` - Fix jump to the button of editor zone on CBS
 
@@ -364,6 +364,7 @@
 - `Refactoring` - Shortcuts module is util now.
 - `Fix` - Fix bubbling on BlockManagers' listener [#1433](https://github.com/codex-team/editor.js/issues/1433).
 
+
 ### 2.19.1
 
 - `Improvements` - The [Cypress](https://www.cypress.io) was integrated as the end-to-end testing framework
@@ -383,7 +384,7 @@
 - `New` - Tool's `reset` static method added to the API to clean up any data added by Tool on initialization
 - `Improvements` - The `initialBlock` property of Editor config is deprecated. Use the `defaultBlock` instead. [#993](https://github.com/codex-team/editor.js/issues/993)
 - `Improvements` - BlockAPI `call()` method now returns the result of calling method, thus allowing it to expose arbitrary data as needed [#1205](https://github.com/codex-team/editor.js/pull/1205)
-- `Improvements` - Useless log about missed i18n section has been removed [#1269](https://github.com/codex-team/editor.js/issues/1269)
+- `Improvements` - Useless log about missed i18n section has been removed  [#1269](https://github.com/codex-team/editor.js/issues/1269)
 - `Improvements` - Allowed to set `false` as `toolbox` config in order to hide Toolbox button [#1221](https://github.com/codex-team/editor.js/issues/1221)
 - `Fix` — Fix problem with types usage [#1183](https://github.com/codex-team/editor.js/issues/1183)
 - `Fix` - Fixed issue with Spam clicking the "Click to tune" button duplicates the icons on FireFox. [#1273](https://github.com/codex-team/editor.js/issues/1273)
@@ -401,7 +402,7 @@
 
 ### 2.18
 
-- `New` _I18n API_ — Ability to provide internalization for Editor.js core and tools. [#751](https://github.com/codex-team/editor.js/issues/751)
+- `New` *I18n API* — Ability to provide internalization for Editor.js core and tools. [#751](https://github.com/codex-team/editor.js/issues/751)
 - `New` — Block API that allows you to access certain Block properties and methods
 - `Improvements` - TSLint (deprecated) replaced with ESLint, old config changed to [CodeX ESLint Config](https://github.com/codex-team/eslint-config).
 - `Improvements` - Fix many code-style issues, add missed annotations.
@@ -417,11 +418,11 @@
 - `Fix` - Editor's styles won't be appended to the `<head>` when another instance have already do that [#1079](https://github.com/codex-team/editor.js/issues/1079)
 - `Fix` - Fixed wrong toolbar icon centering in Firefox [#1120](https://github.com/codex-team/editor.js/pull/1120)
 - `Fix` - Toolbox: Tool's order in Toolbox now saved in accordance with `tools` object keys order [#1073](https://github.com/codex-team/editor.js/issues/1073)
-- `Fix` - Setting `autofocus` config property to `true` cause adding `.ce-block--focused` for the autofocused block [#1073](https://github.com/codex-team/editor.js/issues/1124)
+- `Fix` - Setting `autofocus` config property to `true` cause adding `.ce-block--focused` for the autofocused block  [#1073](https://github.com/codex-team/editor.js/issues/1124)
 - `Fix` - Public getter `shortcut` now works for Inline Tools [#1132](https://github.com/codex-team/editor.js/issues/1132)
 - `Fix` - `CMD+A` handler removed after Editor.js destroy [#1133](https://github.com/codex-team/editor.js/issues/1133)
 
-> _Breaking changes_ `blocks.getBlockByIndex` method now returns BlockAPI object. To access old value, use BlockAPI.holder property
+>  *Breaking changes* `blocks.getBlockByIndex` method now returns BlockAPI object. To access old value, use BlockAPI.holder property
 
 ### 2.17
 
@@ -438,6 +439,7 @@
 - `Fix` — Improve plain text paste [#1012](https://github.com/codex-team/editor.js/issues/1012)
 - `Fix` — Fix multiline paste [#1015](https://github.com/codex-team/editor.js/issues/1015)
 
+
 ### 2.16.1
 
 - `Fix` — Fix Firefox bug with incorrect height and cursor position of empty content editable elements [#947](https://github.com/codex-team/editor.js/issues/947) [#876](https://github.com/codex-team/editor.js/issues/876) [#608](https://github.com/codex-team/editor.js/issues/608) [#876](https://github.com/codex-team/editor.js/issues/876)
@@ -453,8 +455,8 @@
 - `Improvements` — Conversion Toolbar now included in the Inline Toolbar [#853](https://github.com/codex-team/editor.js/issues/853)
 - `Improvements` — All buttons now have beautiful Tooltips provided by [CodeX Tooltips](https://github.com/codex-team/codex.tooltips)
 - `New` — new Tooltips API for displaying tooltips near your custom elements
-- `New` _API_ — Block [lifecycle hooks](tools.md#block-lifecycle-hooks)
-- `New` _Inline Tools API_ — Ability to specify Tool's title via `title` static getter.
+- `New` *API* — Block [lifecycle hooks](tools.md#block-lifecycle-hooks)
+- `New` *Inline Tools API* — Ability to specify Tool's title via `title` static getter.
 - `Fix` — On selection from end to start backspace is working as expected now [#869](https://github.com/codex-team/editor.js/issues/869)
 - `Fix` — Fix flipper with empty dom iterator [#926](https://github.com/codex-team/editor.js/issues/926)
 - `Fix` — Normalize node before walking through children at `isEmpty` method [#943](https://github.com/codex-team/editor.js/issues/943)
@@ -476,8 +478,8 @@
 ### 2.15
 
 - `New` — New [`blocks.insert()`](api.md) API method [#715](https://github.com/codex-team/editor.js/issues/715).
-- `New` _Conversion Toolbar_ — Ability to convert one block to another [#704](https://github.com/codex-team/editor.js/issues/704)
-- `New` _Cross-block selection_ — Ability to select multiple blocks by mouse and with SHIFT+ARROWS [#703](https://github.com/codex-team/editor.js/issues/703)
+- `New` *Conversion Toolbar* — Ability to convert one block to another [#704](https://github.com/codex-team/editor.js/issues/704)
+- `New` *Cross-block selection* — Ability to select multiple blocks by mouse and with SHIFT+ARROWS [#703](https://github.com/codex-team/editor.js/issues/703)
 - `Deprecated` — [`blocks.insertNewBlock()`](api.md) method is deprecated. Use `blocks.insert()` instead.
 - `Improvements` — Inline Toolbar now works on mobile devices [#706](https://github.com/codex-team/editor.js/issues/706)
 - `Improvements` — Toolbar looks better on mobile devices [#706](https://github.com/codex-team/editor.js/issues/706)
@@ -490,7 +492,7 @@
 
 ### 2.14
 
-- `Fix` _Config_ — User config now has higher priority than internal settings [#771](https://github.com/codex-team/editor.js/issues/771)
+- `Fix` *Config* — User config now has higher priority than internal settings [#771](https://github.com/codex-team/editor.js/issues/771)
 - `New` — Ability to work with Block Actions and Inline Toolbar from the keyboard by Tab. [#705](https://github.com/codex-team/editor.js/issues/705)
 - `Fix` — Fix error thrown by click on the empty editor after `blocks.clear()` method calling [#761](https://github.com/codex-team/editor.js/issues/761)
 - `Fix` — Fix placeholder property appearance. Now you can assign it via `placeholder` property of EditorConfig. [#714](https://github.com/codex-team/editor.js/issues/714)
@@ -498,13 +500,13 @@
 
 ### 2.13
 
-- `Improvements` _BlockSelection_ — Block Selection allows to select single editable element via CMD+A
-- `New` _API_ — Added [API methods](api.md) to open and close inline toolbar [#665](https://github.com/codex-team/editor.js/issues/665)
-- `New` _Config_ - Added new property in EditorConfig `holder`, use this property for append Editor instead `holderId`. `holder` property now support reference on dom element. [#696](https://github.com/codex-team/editor.js/issues/696)
-- `Deprecated` _Config_ - `holderId` property now is deprecated and will removed in next major release. Use `holder` instead.
-- `Fix` _Types_ — Fixed error with `codex-notifier` package [#713](https://github.com/codex-team/editor.js/issues/713)
+- `Improvements` *BlockSelection* — Block Selection allows to select single editable element via CMD+A
+- `New` *API* — Added [API methods](api.md) to open and close inline toolbar [#665](https://github.com/codex-team/editor.js/issues/665)
+- `New` *Config* - Added new property in EditorConfig `holder`, use this property for append Editor instead `holderId`. `holder` property now support reference on dom element. [#696](https://github.com/codex-team/editor.js/issues/696)
+- `Deprecated` *Config* - `holderId` property now is deprecated and will removed in next major release. Use `holder` instead.
+- `Fix` *Types* — Fixed error with `codex-notifier` package [#713](https://github.com/codex-team/editor.js/issues/713)
 - `Improvements` — Close inline toolbar after creating a new link.
-- `New` _Config_ — Option `minHeight` for customizing Editor's bottom zone height added.
+- `New` *Config* — Option `minHeight` for customizing Editor's bottom zone height added.
 
 ### 2.12.4
 
@@ -519,7 +521,7 @@
 
 ### 2.12.2
 
-- New _Inline Tools_ — pass tool settings from configuration to Tool constructor
+- New *Inline Tools* — pass tool settings from configuration to Tool constructor
 
 ### 2.12.1
 
@@ -527,7 +529,7 @@
 
 ### 2.12.0
 
-- `New` _API_ - new `blocks` API method `renderFromHTML`
+- `New` *API* - new `blocks` API method `renderFromHTML`
 
 ### 2.11.11
 
@@ -547,15 +549,15 @@
 
 ### 2.11.7
 
-- `Fix` _Paste_ — Fix pasting into non-initial Blocks
+- `Fix` *Paste* — Fix pasting into non-initial Blocks
 
 ### 2.11.6
 
-- `Fix` _Paste_ — Polyfill for Microsoft Edge
+- `Fix` *Paste* — Polyfill for Microsoft Edge
 
 ### 2.11.5
 
-- `Fix` _RectangleSelection_ — Redesign of the scrolling zones
+- `Fix` *RectangleSelection* — Redesign of the scrolling zones
 
 ### 2.11.4
 
@@ -571,7 +573,7 @@
 
 ### 2.11.1
 
-- `Fix` _RectangleSelection_ — Selection is available only for the main mouse button
+- `Fix` *RectangleSelection* — Selection is available only for the main mouse button
 
 ### 2.11.0
 
@@ -603,19 +605,19 @@
 
 ### 2.9.0
 
-- `New` _RectangleSelection_ — Ability to select Block or several Blocks with mouse
+- `New` *RectangleSelection* — Ability to select Block or several Blocks with mouse
 
 ### 2.8.1
 
-- `Fix` _Caret_ — Fix "History back" call on backspace in Firefox
+- `Fix` *Caret* — Fix "History back" call on backspace in Firefox
 
 ### 2.8.0
 
-- `Improvements` _API_ — Added [API methods](api.md#caretapi) to manage caret position
+- `Improvements` *API* — Added [API methods](api.md#caretapi) to manage caret position
 
 ### 2.7.32
 
-- `Improvements` _Types_ — TypeScript types sre updated
+- `Improvements` *Types* — TypeScript types sre updated
 
 ### 2.7.31
 
@@ -635,37 +637,37 @@
 
 ### 2.2.27
 
-- `New` _Mobile view_ — Editor now adopted for mobile devices
-- `New` _Narrow mode_ — Editor now adopted for narrow containers
+- `New` *Mobile view* — Editor now adopted for mobile devices
+- `New` *Narrow mode* — Editor now adopted for narrow containers
 
 ### 2.2.26
 
-- `Improvements` _Caret_ — Improvements of the caret behaviour: arrows, backspace and enter keys better handling.
+- `Improvements` *Caret* — Improvements of the caret behaviour: arrows, backspace and enter keys better handling.
 
 ### 2.2.25
 
-- `New` _Autofocus_ — Now you can set focus at Editor after page has been loaded
+- `New` *Autofocus* — Now you can set focus at Editor after page has been loaded
 
 ### 2.2.24
 
-- `Improvements` _Paste_ handling — minor paste handling improvements
+- `Improvements` *Paste* handling — minor paste handling improvements
 
 ### 2.2.23
 
-- `New` _Shortcuts_ — copy and cut Blocks selected by CMD+A
+- `New` *Shortcuts* — copy and cut Blocks selected by CMD+A
 
 ### 2.2—2.7
 
-- `New` _Sanitize API_ — [Sanitize Config](https://github.com/codex-team/editor.js/blob/master/docs/tools.md#automatic-sanitize) of `Block Tools` now automatically extends by tags of `Inline Tools` that is enabled by current Tool by `inlineToolbar` option. You don't need more to specify `a, b, mark, code` manually. This feature will be added to fields that supports inline markup.
-- `New` _Block Selection_ — Ability to select Block by `CMD+A`, and the whole Editor by double `CMD+A`. After that, you can copy (`CMD+C`), remove (`Backspace`) or clear (`Enter`) selected Blocks.
-- `New` _[Styles API](https://github.com/codex-team/editor.js/blob/master/types/api/styles.d.ts)_ — Added `button` class for stylization of any buttons provided by Tools with one unified style.
-- `New` _[Notifier API](https://github.com/codex-team/editor.js/blob/master/docs/api.md#notifierapi)_ — methods for showing user notifications: on success, errors, warnings, etc.
-- `New` _Block Tool_ — [Table](http://github.com/editor-js/table) constructor 💪
-- `New` If one of the Tools is unavailable on Editor initialization, its Blocks will be rendered with _Dummy Block_, describing that user can not edit content of this Block. Dummy Blocks can be moved, removed and saved as normal Blocks. So saved data won't be lost if one of the Tools is failed
+- `New` *Sanitize API* — [Sanitize Config](https://github.com/codex-team/editor.js/blob/master/docs/tools.md#automatic-sanitize) of `Block Tools` now automatically extends by tags of `Inline Tools` that is enabled by current Tool by `inlineToolbar` option. You don't need more to specify `a, b, mark, code` manually. This feature will be added to fields that supports inline markup.
+- `New` *Block Selection* — Ability to select Block by `CMD+A`, and the whole Editor by double `CMD+A`. After that, you can copy (`CMD+C`), remove (`Backspace`) or clear (`Enter`) selected Blocks.
+- `New` *[Styles API](https://github.com/codex-team/editor.js/blob/master/types/api/styles.d.ts)* — Added `button` class for stylization of any buttons provided by Tools with one unified style.
+- `New` *[Notifier API](https://github.com/codex-team/editor.js/blob/master/docs/api.md#notifierapi)* — methods for showing user notifications: on success, errors, warnings, etc.
+- `New` *Block Tool* — [Table](http://github.com/editor-js/table) constructor 💪
+- `New` If one of the Tools is unavailable on Editor initialization, its Blocks will be rendered with *Dummy Block*, describing that user can not edit content of this Block. Dummy Blocks can be moved, removed and saved as normal Blocks. So saved data won't be lost if one of the Tools is failed
 - `New` [Public TS-types](https://github.com/codex-team/editor.js/tree/master/types) are presented.
-- `Changes` _Tools API_ — options `irreplaceable` and `contentless` was removed.
-- `Changes` _Tools API_ — [Paste API](https://github.com/codex-team/editor.js/blob/master/docs/tools.md#paste-handling): tags, patterns and mime-types now should be specified by Tool's `pasteConfig` static property. Custom Paste Event should be handled by `onPaste(event)` that should not be static from now.
-- `Changes` _Tools API_ — options `displayInToolbox ` and `toolboxIcon` was removed. Use [`toolbox`](https://github.com/codex-team/editor.js/blob/master/docs/tools.md#internal-tool-settings) instead, that should return object with `icon` and `title` field, or `false` if Tool should not be placed at the Toolbox. Also, there are a way to override `toolbox {icon, title}` settings provided by Tool with you own settings at the Initial Config.
+- `Changes` *Tools API*  — options `irreplaceable` and `contentless` was removed.
+- `Changes` *Tools API* — [Paste API](https://github.com/codex-team/editor.js/blob/master/docs/tools.md#paste-handling): tags, patterns and mime-types now should be specified by Tool's `pasteConfig` static property. Custom Paste Event should be handled by `onPaste(event)` that should not be static from now.
+- `Changes` *Tools API* — options `displayInToolbox ` and `toolboxIcon` was removed. Use [`toolbox`](https://github.com/codex-team/editor.js/blob/master/docs/tools.md#internal-tool-settings) instead, that should return object with `icon` and `title` field, or `false` if Tool should not be placed at the Toolbox. Also, there are a way to override `toolbox {icon, title}` settings provided by Tool with you own settings at the Initial Config.
 - `Improvements` — All Projects code now on TypeScript
 - `Improvements` — NPM package size decreased from 1300kb to 422kb
 - `Improvements` — Bundle size decreased from 438kb to 252kb
@@ -683,8 +685,8 @@ See a whole [Changelog](/docs/)
 
 ### 2.1-beta changelog
 
-- `New` _Tools API_ — support pasted content via drag-n-drop or from the Buffer. See [documentation](https://github.com/codex-team/editor.js/blob/master/docs/tools.md#paste-handling) and [example](https://github.com/editor-js/simple-image/blob/master/src/index.js#L177) at the Simple Image Tool.
-- `New` _Tools API_ — new `sanitize` getter for Tools for automatic HTML sanitizing of returned data. See [documentation](https://github.com/codex-team/editor.js/blob/master/docs/tools.md#sanitize) and [example](https://github.com/editor-js/paragraph/blob/master/src/index.js#L121) at the Paragraph Tool
+- `New` *Tools API* — support pasted content via drag-n-drop or from the Buffer. See [documentation](https://github.com/codex-team/editor.js/blob/master/docs/tools.md#paste-handling) and [example](https://github.com/editor-js/simple-image/blob/master/src/index.js#L177) at the Simple Image Tool.
+- `New` *Tools API* — new `sanitize` getter for Tools for automatic HTML sanitizing of returned data. See [documentation](https://github.com/codex-team/editor.js/blob/master/docs/tools.md#sanitize) and [example](https://github.com/editor-js/paragraph/blob/master/src/index.js#L121) at the Paragraph Tool
 - `New` Added `onChange`-callback, fired after any modifications at the Editor. See [documentation](https://github.com/codex-team/editor.js/blob/master/docs/installation.md#features).
 - `New` New Inline Tool example — [Marker](https://github.com/editor-js/marker)
 - `New` New Inline Tool example — [Code](https://github.com/editor-js/code)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.31.2
+
+- `Fix` - Prevent link removal when applying bold to linked text
+
 ### 2.31.1
 
 - `Fix` - Prevent the warning from appearing when `readOnly` mode is initially set to `true`
@@ -21,10 +25,8 @@
 - `Improvement` - Shift + Down/Up will allow to select next/previous line instead of Inline Toolbar flipping
 - `Improvement` - The API `caret.setToBlock()` offset now works across the entire block content, not just the first or last node.
 - `Improvement` - The API `blocks.renderFromHTML()` became async and now can be awaited.
-- `Fix` - `blocks.renderFromHTML()` — Error  "Can't find a Block to remove." fixed
+- `Fix` - `blocks.renderFromHTML()` — Error "Can't find a Block to remove." fixed
 - `Fix` - The API `.clear()` index invalidation fixed
-
-
 
 ### 2.30.7
 
@@ -62,13 +64,13 @@
 
 - `New` – Block Tunes now supports nesting items
 - `New` – Block Tunes now supports separator items
-- `New` – *Menu Config* – New item type – HTML
-- `New` – *Menu Config* – Default and HTML items now support hints
+- `New` – _Menu Config_ – New item type – HTML
+- `New` – _Menu Config_ – Default and HTML items now support hints
 - `New` – Inline Toolbar has new look 💅
 - `New` – Inline Tool's `render()` now supports [Menu Config](https://editorjs.io/menu-config/) format
-- `New` – *ToolsAPI* – All installed block tools now accessible via ToolsAPI `getBlockTools()` method
-- `New` – *SelectionAPI* – Exposed methods `save()` and `restore()` that allow to save selection to be able to temporally move focus away, methods `setFakeBackground()` and `removeFakeBackground()` that allow to immitate selection while focus moved away
-- `New` – *BlocksAPI* – Exposed `getBlockByElement()` method that helps find block by any child html element
+- `New` – _ToolsAPI_ – All installed block tools now accessible via ToolsAPI `getBlockTools()` method
+- `New` – _SelectionAPI_ – Exposed methods `save()` and `restore()` that allow to save selection to be able to temporally move focus away, methods `setFakeBackground()` and `removeFakeBackground()` that allow to immitate selection while focus moved away
+- `New` – _BlocksAPI_ – Exposed `getBlockByElement()` method that helps find block by any child html element
 - `New` – "Convert to" control is now also available in Block Tunes
 - `New` — Editor.js now supports contenteditable placeholders out of the box. Just add `data-placeholder` or `data-placeholder-active` attribute to make it work. The first one will work like native placeholder while the second one will show placeholder only when block is current.
 - `Improvement` — Now Paragraph placeholder will be shown for the current paragraph, not only the first one.
@@ -76,12 +78,12 @@
 - `Improvement` — The ability to merge blocks of different types (if both tools provide the conversionConfig)
 - `Improvement` - The API `blocks.convert()` now returns the new block API
 - `Improvement` - The API `caret.setToBlock()` now can accept either BlockAPI or block index or block id
-- `Improvement` – *MenuConfig* – `TunesMenuConfig` type is deprecated, use the `MenuConfig` instead
-– `Improvement` — *Types* — `BlockToolConstructorOptions` type improved, `block` and `config` are not optional anymore
+- `Improvement` – _MenuConfig_ – `TunesMenuConfig` type is deprecated, use the `MenuConfig` instead
+  – `Improvement` — _Types_ — `BlockToolConstructorOptions` type improved, `block` and `config` are not optional anymore
 - `Improvement` - The Plus button and Block Tunes toggler are now better aligned with large line-height blocks, such as Headings
 - `Improvement` — Creating links on Android devices: now the mobile keyboard will have an "Enter" key for accepting the inserted link.
 - `Improvement` — Placeholders will stay visible on inputs focus.
-– `Refactoring` – Switched to Vite as Cypress bundler
+  – `Refactoring` – Switched to Vite as Cypress bundler
 - `Fix` — `onChange` will be called when removing the entire text within a descendant element of a block.
 - `Fix` - Unexpected new line on Enter press with selected block without caret
 - `Fix` - Search input autofocus loosing after Block Tunes opening
@@ -90,7 +92,7 @@
 - `Fix` - Unwanted soft line break on Enter press after period and space (". |") on iOS devices
 - `Fix` - Caret lost after block conversion on mobile devices.
 - `Fix` - Caret lost after Backspace at the start of block when previoius block is not convertable
-– `Fix` — Deleting whitespaces at the start/end of the block
+  – `Fix` — Deleting whitespaces at the start/end of the block
 - `Fix` — The problem caused by missed "import type" in block mutation event types resolved
 
 ### 2.29.1
@@ -151,7 +153,6 @@
 - `Improvement` - `blocks.update(id, data)` now will trigger onChange with only `block-change` event.
 - `Improvement` - `blocks.update(id, data)` will return a promise with BlockAPI object of the changed block.
 
-
 ### 2.27.2
 
 - `Fix` - `onChange` won't be called when element with data-mutation-free changes some attribute
@@ -162,18 +163,18 @@
 
 ### 2.27.0
 
-- `New` — *Toolbar API* — Added a new method for toggling the toolbox.
+- `New` — _Toolbar API_ — Added a new method for toggling the toolbox.
 - `New` — Added types for block mutation events
 - `New` — Batching added to the `onChange` callback. Now the second argument can contain an array of CustomEvents as well as a single one. Multiple changes made in a short period of time will be batched under a single `onChange` call.
-- `Improvement` — *Toolbox* — Number of `close()` method calls optimized.
+- `Improvement` — _Toolbox_ — Number of `close()` method calls optimized.
 - `Improvement` — The `onChange` callback can be muted if all mutations contain nodes with the `data-mutation-free` attribute.
 - `Improvement` — Pressing "Enter" at the end of a Block won't lead to redundant `block-changed` event triggering. Only `block-added` event will be dispatched.
 - `Improvement` — The block mutation handler is now called on every block change (including background changes), instead of only when a block is focused
 - `Improvement` — Number of caret saving method calls optimized for Block Tunes opening/closing.
 - `Improvement` — Package size reduced by removing redundant files.
 - `Refactoring` — Switched from Webpack to Vite as the build system.
-- `Refactoring` — *Dependencies* — Upgraded Cypress to v12 and related libraries to the latest versions.
-- `Refactoring` — *Dependencies* — Upgraded TypeScript to v5.
+- `Refactoring` — _Dependencies_ — Upgraded Cypress to v12 and related libraries to the latest versions.
+- `Refactoring` — _Dependencies_ — Upgraded TypeScript to v5.
 - `Refactoring` — `EventDispatcher` types improved. Now we can pass `EventsMap` via generic to specify a map of event names and their payloads that can be used in a particular EventDispatcher instance.
 - `Refactoring` — All events in common editor Event Bus now have own type declarations.
 - `Refactoring` — Removed the block mutation observer from blocks and attached a single observer to the editor's blocks wrapper element.
@@ -183,38 +184,38 @@
 - `Fix` — Resolved a compiler error caused by importing the `BlockToolData` type.
 - `Fix` — Resolved a problem where the document would scroll to the beginning after moving a block above the viewport.
 - `Fix`- Fixed several bugs caused by browser extensions — Removed the search for a block's container in the DOM on saving and kept it in memory instead, updating it when the tool changes a container element.
-- `Fix` — *ToolsAPI* — `pasteConfig` getter with `false` value could be used to disable paste handling by Editor.js core. Could be useful if your tool has its own paste handler.
+- `Fix` — _ToolsAPI_ — `pasteConfig` getter with `false` value could be used to disable paste handling by Editor.js core. Could be useful if your tool has its own paste handler.
 - `CI` — Ubuntu container is now used for Edge tests runner.
 - `CI` — Node 16 is used for GitHib Actions.
 
 ### 2.26.5
 
-- `Fix` — *Types* — Remove unnecessary import that creates a dependency on the `cypress`.
+- `Fix` — _Types_ — Remove unnecessary import that creates a dependency on the `cypress`.
 
 ### 2.26.4
 
-- `Improvement` — *Menu Config* — Property `label` renamed to `title`.
+- `Improvement` — _Menu Config_ — Property `label` renamed to `title`.
 
 ### 2.26.3
 
-- `Fix` — *Paste Module* — fix for a problem with specifying of `pasteConfig().tags` in upper case  [#2208](https://github.com/codex-team/editor.js/issues/2208).
+- `Fix` — _Paste Module_ — fix for a problem with specifying of `pasteConfig().tags` in upper case [#2208](https://github.com/codex-team/editor.js/issues/2208).
 
 ### 2.26.2
 
-- `Fix` — *Menu Config* — Installed tunes are rendered above default tunes again.
+- `Fix` — _Menu Config_ — Installed tunes are rendered above default tunes again.
 
 ### 2.26.1
 
-- `Improvement` — *Menu Config* — Now it becomes possible to create toggle groups.
+- `Improvement` — _Menu Config_ — Now it becomes possible to create toggle groups.
 
 ### 2.26.0
 
-- `New` — *UI* — Block Tunes became vertical just like the Toolbox 🤩
-- `New` — *Block Tunes API* — Now `render()` method of a Block Tune can return config with just icon, label and callback instead of custom HTML. This improvement is a key to the new straightforward way of configuring tune's appearance in Block Tunes menu.
-- `New` — *Tools API* — As well as `render()` in `Tunes API`, Tool's `renderSettings()` now also supports new configuration format.
-- `New` — *UI* — Meet the new icons from [CodeX Icons](https://github.com/codex-team/icons) pack 🛍 💝
-- `New` — *BlocksAPI* — the `blocks.insert()` method now also have the optional `id` param. If passed, this id will be used instead of the generated one.
-- `Deprecated` — *Styles API* — CSS classes `.cdx-settings-button` and `.cdx-settings-button--active` are not recommended to use. Consider configuring your block settings with new JSON API instead.
+- `New` — _UI_ — Block Tunes became vertical just like the Toolbox 🤩
+- `New` — _Block Tunes API_ — Now `render()` method of a Block Tune can return config with just icon, label and callback instead of custom HTML. This improvement is a key to the new straightforward way of configuring tune's appearance in Block Tunes menu.
+- `New` — _Tools API_ — As well as `render()` in `Tunes API`, Tool's `renderSettings()` now also supports new configuration format.
+- `New` — _UI_ — Meet the new icons from [CodeX Icons](https://github.com/codex-team/icons) pack 🛍 💝
+- `New` — _BlocksAPI_ — the `blocks.insert()` method now also have the optional `id` param. If passed, this id will be used instead of the generated one.
+- `Deprecated` — _Styles API_ — CSS classes `.cdx-settings-button` and `.cdx-settings-button--active` are not recommended to use. Consider configuring your block settings with new JSON API instead.
 - `Fix` — Wrong element not highlighted anymore when popover opened.
 - `Fix` — When Tunes Menu open keydown events can not be handled inside plugins.
 - `Fix` — If a Tool specifies some tags to substitute on paste, all attributes of that tags will be removed before passing them to the tool. Possible XSS vulnerability fixed.
@@ -222,16 +223,15 @@
 - `Fix` — Workaround for the HTMLJanitor bug with Tables (https://github.com/guardian/html-janitor/issues/3) added
 - `Fix` — Toolbox shortcuts appearance and execution fixed [#2112](https://github.com/codex-team/editor.js/issues/2112)
 - `Fix` — Inline Tools click handling on mobile devices improved
-- `Improvement` — *Tools API* — `pasteConfig().tags` now support sanitizing configuration. It allows you to leave some explicitly specified attributes for pasted content.
-- `Improvement` — *CodeStyle* — [CodeX ESLint Config](https://github.com/codex-team/eslint-config) has bee updated. All ESLint/Spelling issues resolved
-- `Improvement` — *ToolsAPI* — The `icon` property of the `toolbox` getter became optional.
-
+- `Improvement` — _Tools API_ — `pasteConfig().tags` now support sanitizing configuration. It allows you to leave some explicitly specified attributes for pasted content.
+- `Improvement` — _CodeStyle_ — [CodeX ESLint Config](https://github.com/codex-team/eslint-config) has bee updated. All ESLint/Spelling issues resolved
+- `Improvement` — _ToolsAPI_ — The `icon` property of the `toolbox` getter became optional.
 
 ### 2.25.0
 
-- `New` — *Tools API* — Introducing new feature — toolbox now can have multiple entries for one tool! <br>
-Due to that API changes: tool's `toolbox` getter now can return either a single config item or an array of config items
-- `New` — *Blocks API* — `composeBlockData()` method was added.
+- `New` — _Tools API_ — Introducing new feature — toolbox now can have multiple entries for one tool! <br>
+  Due to that API changes: tool's `toolbox` getter now can return either a single config item or an array of config items
+- `New` — _Blocks API_ — `composeBlockData()` method was added.
 
 ### 2.24.4
 
@@ -246,8 +246,8 @@ Due to that API changes: tool's `toolbox` getter now can return either a single 
 - `Fix` — Scrolling issue when opening toolbox on mobile fixed
 - `Fix` — Typo in toolbox empty placeholder fixed
 - `Fix` — The issue with scroll jumping on block hovering have fixed [2036](https://github.com/codex-team/editor.js/issues/2036)
-- `Improvement` — *Dev Example Page* - Add popup example page
-- `Improvement` — *UI* - The Toolbox will restore the internal scroll on every opening
+- `Improvement` — _Dev Example Page_ - Add popup example page
+- `Improvement` — _UI_ - The Toolbox will restore the internal scroll on every opening
 
 ### 2.24.1
 
@@ -255,9 +255,9 @@ Due to that API changes: tool's `toolbox` getter now can return either a single 
 
 ### 2.24.0
 
-- `New` — *UI* — The Toolbox became vertical 🥳
-- `Improvement` — *UI* — the Plus button will always be shown (previously, it appears only for empty blocks)
-- `Improvement` — *Dev Example Page* - Server added to allow opening example page on other devices in network.
+- `New` — _UI_ — The Toolbox became vertical 🥳
+- `Improvement` — _UI_ — the Plus button will always be shown (previously, it appears only for empty blocks)
+- `Improvement` — _Dev Example Page_ - Server added to allow opening example page on other devices in network.
 - `Fix` — `UI` — the Toolbar won't move on hover at mobile viewports. Resolves [#1972](https://github.com/codex-team/editor.js/issues/1972)
 - `Fix` — `OnChange` event invocation after block insertion. [#1997](https://github.com/codex-team/editor.js/issues/1997)
 - `Fix` — `ReadOnly` — the `readonly.isEnabled` API getter now works correctly after `readonly.toggle()` calling. Resolves [#1822](https://github.com/codex-team/editor.js/issues/1822)
@@ -273,21 +273,21 @@ Due to that API changes: tool's `toolbox` getter now can return either a single 
 
 ### 2.23.0
 
-- `Improvement` — *EditorConfig* — The `onChange` callback now accepts two arguments: EditorJS API and the CustomEvent with `type` and `detail` allowing to determine what happened with a Block
-- `New` — *Block API* — The new `dispatchChange()` method allows to manually trigger the 'onChange' callback. Useful when Tool made a state mutation that is invisible for editor core.
-- `Improvement` — *UI* — Block Tunes toggler moved to the left
-- `Improvement` — *UI* — Block Actions (BT toggler + Plus Button) will appear on block hovering instead of click
-- `Improvement` — *UI* — Block Tunes toggler icon and Plus button icon updated
-- `Improvement` — *Dev Example Page* — The menu with helpful buttons added to the bottom of the screen
-- `Improvement` — *Dev Example Page* — The 'dark' theme added. Now we can code at night more comfortably.
-- `Improvement` — *Rectangle Selection* — paint optimized
-- `Fix` — *Rectangle Selection* — the first click after RS was not clear selection state. Now does.
-- `Improvement` — *Blocks API* — toolbar moving logic removed from `blocks.move()` and `blocks.swap()` methods. Instead, you should use Toolbar API (it was used by MoveUp and MoveDown tunes, they were updated).
-- `New` — *Blocks API* — The `getBlockIndex()` method added
-- `New` — *Blocks API* — the `insert()` method now has the `replace: boolean` parameter
-- `New` — *Blocks API* —  the `insert()` method now returns the inserted `Block API`
-- `New` — *Listeners API* — the `on()` method now returns the listener id.
-- `New` — *Listeners API* — the new `offById()` method added
+- `Improvement` — _EditorConfig_ — The `onChange` callback now accepts two arguments: EditorJS API and the CustomEvent with `type` and `detail` allowing to determine what happened with a Block
+- `New` — _Block API_ — The new `dispatchChange()` method allows to manually trigger the 'onChange' callback. Useful when Tool made a state mutation that is invisible for editor core.
+- `Improvement` — _UI_ — Block Tunes toggler moved to the left
+- `Improvement` — _UI_ — Block Actions (BT toggler + Plus Button) will appear on block hovering instead of click
+- `Improvement` — _UI_ — Block Tunes toggler icon and Plus button icon updated
+- `Improvement` — _Dev Example Page_ — The menu with helpful buttons added to the bottom of the screen
+- `Improvement` — _Dev Example Page_ — The 'dark' theme added. Now we can code at night more comfortably.
+- `Improvement` — _Rectangle Selection_ — paint optimized
+- `Fix` — _Rectangle Selection_ — the first click after RS was not clear selection state. Now does.
+- `Improvement` — _Blocks API_ — toolbar moving logic removed from `blocks.move()` and `blocks.swap()` methods. Instead, you should use Toolbar API (it was used by MoveUp and MoveDown tunes, they were updated).
+- `New` — _Blocks API_ — The `getBlockIndex()` method added
+- `New` — _Blocks API_ — the `insert()` method now has the `replace: boolean` parameter
+- `New` — _Blocks API_ — the `insert()` method now returns the inserted `Block API`
+- `New` — _Listeners API_ — the `on()` method now returns the listener id.
+- `New` — _Listeners API_ — the new `offById()` method added
 - `New` — `API` — The new `UiApi` section was added. It allows accessing some editor UI nodes and methods.
 - `Refactoring` — Toolbox became a standalone class instead of a Module. It can be accessed only through the Toolbar module.
 - `Refactoring` — CI flow optimized.
@@ -301,9 +301,9 @@ Due to that API changes: tool's `toolbox` getter now can return either a single 
 ### 2.22.2
 
 - `Improvement` — Inline Toolbar might be used for any contenteditable element inside Editor.js zone
-- `Improvement` *Tunes API* - Tunes now can provide sanitize configuration
-- `Fix` *Tunes API* - Tune config now passed to constructor under `config` property
-- `Fix` *Types* - Add common type for internal and external Tools configuration
+- `Improvement` _Tunes API_ - Tunes now can provide sanitize configuration
+- `Fix` _Tunes API_ - Tune config now passed to constructor under `config` property
+- `Fix` _Types_ - Add common type for internal and external Tools configuration
 - `Fix` — Block's destroy method is called on block deletion
 - `Fix` - Fix jump to the button of editor zone on CBS
 
@@ -364,7 +364,6 @@ Due to that API changes: tool's `toolbox` getter now can return either a single 
 - `Refactoring` - Shortcuts module is util now.
 - `Fix` - Fix bubbling on BlockManagers' listener [#1433](https://github.com/codex-team/editor.js/issues/1433).
 
-
 ### 2.19.1
 
 - `Improvements` - The [Cypress](https://www.cypress.io) was integrated as the end-to-end testing framework
@@ -384,7 +383,7 @@ Due to that API changes: tool's `toolbox` getter now can return either a single 
 - `New` - Tool's `reset` static method added to the API to clean up any data added by Tool on initialization
 - `Improvements` - The `initialBlock` property of Editor config is deprecated. Use the `defaultBlock` instead. [#993](https://github.com/codex-team/editor.js/issues/993)
 - `Improvements` - BlockAPI `call()` method now returns the result of calling method, thus allowing it to expose arbitrary data as needed [#1205](https://github.com/codex-team/editor.js/pull/1205)
-- `Improvements` - Useless log about missed i18n section has been removed  [#1269](https://github.com/codex-team/editor.js/issues/1269)
+- `Improvements` - Useless log about missed i18n section has been removed [#1269](https://github.com/codex-team/editor.js/issues/1269)
 - `Improvements` - Allowed to set `false` as `toolbox` config in order to hide Toolbox button [#1221](https://github.com/codex-team/editor.js/issues/1221)
 - `Fix` — Fix problem with types usage [#1183](https://github.com/codex-team/editor.js/issues/1183)
 - `Fix` - Fixed issue with Spam clicking the "Click to tune" button duplicates the icons on FireFox. [#1273](https://github.com/codex-team/editor.js/issues/1273)
@@ -402,7 +401,7 @@ Due to that API changes: tool's `toolbox` getter now can return either a single 
 
 ### 2.18
 
-- `New` *I18n API* — Ability to provide internalization for Editor.js core and tools. [#751](https://github.com/codex-team/editor.js/issues/751)
+- `New` _I18n API_ — Ability to provide internalization for Editor.js core and tools. [#751](https://github.com/codex-team/editor.js/issues/751)
 - `New` — Block API that allows you to access certain Block properties and methods
 - `Improvements` - TSLint (deprecated) replaced with ESLint, old config changed to [CodeX ESLint Config](https://github.com/codex-team/eslint-config).
 - `Improvements` - Fix many code-style issues, add missed annotations.
@@ -418,11 +417,11 @@ Due to that API changes: tool's `toolbox` getter now can return either a single 
 - `Fix` - Editor's styles won't be appended to the `<head>` when another instance have already do that [#1079](https://github.com/codex-team/editor.js/issues/1079)
 - `Fix` - Fixed wrong toolbar icon centering in Firefox [#1120](https://github.com/codex-team/editor.js/pull/1120)
 - `Fix` - Toolbox: Tool's order in Toolbox now saved in accordance with `tools` object keys order [#1073](https://github.com/codex-team/editor.js/issues/1073)
-- `Fix` - Setting `autofocus` config property to `true` cause adding `.ce-block--focused` for the autofocused block  [#1073](https://github.com/codex-team/editor.js/issues/1124)
+- `Fix` - Setting `autofocus` config property to `true` cause adding `.ce-block--focused` for the autofocused block [#1073](https://github.com/codex-team/editor.js/issues/1124)
 - `Fix` - Public getter `shortcut` now works for Inline Tools [#1132](https://github.com/codex-team/editor.js/issues/1132)
 - `Fix` - `CMD+A` handler removed after Editor.js destroy [#1133](https://github.com/codex-team/editor.js/issues/1133)
 
->  *Breaking changes* `blocks.getBlockByIndex` method now returns BlockAPI object. To access old value, use BlockAPI.holder property
+> _Breaking changes_ `blocks.getBlockByIndex` method now returns BlockAPI object. To access old value, use BlockAPI.holder property
 
 ### 2.17
 
@@ -439,7 +438,6 @@ Due to that API changes: tool's `toolbox` getter now can return either a single 
 - `Fix` — Improve plain text paste [#1012](https://github.com/codex-team/editor.js/issues/1012)
 - `Fix` — Fix multiline paste [#1015](https://github.com/codex-team/editor.js/issues/1015)
 
-
 ### 2.16.1
 
 - `Fix` — Fix Firefox bug with incorrect height and cursor position of empty content editable elements [#947](https://github.com/codex-team/editor.js/issues/947) [#876](https://github.com/codex-team/editor.js/issues/876) [#608](https://github.com/codex-team/editor.js/issues/608) [#876](https://github.com/codex-team/editor.js/issues/876)
@@ -455,8 +453,8 @@ Due to that API changes: tool's `toolbox` getter now can return either a single 
 - `Improvements` — Conversion Toolbar now included in the Inline Toolbar [#853](https://github.com/codex-team/editor.js/issues/853)
 - `Improvements` — All buttons now have beautiful Tooltips provided by [CodeX Tooltips](https://github.com/codex-team/codex.tooltips)
 - `New` — new Tooltips API for displaying tooltips near your custom elements
-- `New` *API* — Block [lifecycle hooks](tools.md#block-lifecycle-hooks)
-- `New` *Inline Tools API* — Ability to specify Tool's title via `title` static getter.
+- `New` _API_ — Block [lifecycle hooks](tools.md#block-lifecycle-hooks)
+- `New` _Inline Tools API_ — Ability to specify Tool's title via `title` static getter.
 - `Fix` — On selection from end to start backspace is working as expected now [#869](https://github.com/codex-team/editor.js/issues/869)
 - `Fix` — Fix flipper with empty dom iterator [#926](https://github.com/codex-team/editor.js/issues/926)
 - `Fix` — Normalize node before walking through children at `isEmpty` method [#943](https://github.com/codex-team/editor.js/issues/943)
@@ -478,8 +476,8 @@ Due to that API changes: tool's `toolbox` getter now can return either a single 
 ### 2.15
 
 - `New` — New [`blocks.insert()`](api.md) API method [#715](https://github.com/codex-team/editor.js/issues/715).
-- `New` *Conversion Toolbar* — Ability to convert one block to another [#704](https://github.com/codex-team/editor.js/issues/704)
-- `New` *Cross-block selection* — Ability to select multiple blocks by mouse and with SHIFT+ARROWS [#703](https://github.com/codex-team/editor.js/issues/703)
+- `New` _Conversion Toolbar_ — Ability to convert one block to another [#704](https://github.com/codex-team/editor.js/issues/704)
+- `New` _Cross-block selection_ — Ability to select multiple blocks by mouse and with SHIFT+ARROWS [#703](https://github.com/codex-team/editor.js/issues/703)
 - `Deprecated` — [`blocks.insertNewBlock()`](api.md) method is deprecated. Use `blocks.insert()` instead.
 - `Improvements` — Inline Toolbar now works on mobile devices [#706](https://github.com/codex-team/editor.js/issues/706)
 - `Improvements` — Toolbar looks better on mobile devices [#706](https://github.com/codex-team/editor.js/issues/706)
@@ -492,7 +490,7 @@ Due to that API changes: tool's `toolbox` getter now can return either a single 
 
 ### 2.14
 
-- `Fix` *Config* — User config now has higher priority than internal settings [#771](https://github.com/codex-team/editor.js/issues/771)
+- `Fix` _Config_ — User config now has higher priority than internal settings [#771](https://github.com/codex-team/editor.js/issues/771)
 - `New` — Ability to work with Block Actions and Inline Toolbar from the keyboard by Tab. [#705](https://github.com/codex-team/editor.js/issues/705)
 - `Fix` — Fix error thrown by click on the empty editor after `blocks.clear()` method calling [#761](https://github.com/codex-team/editor.js/issues/761)
 - `Fix` — Fix placeholder property appearance. Now you can assign it via `placeholder` property of EditorConfig. [#714](https://github.com/codex-team/editor.js/issues/714)
@@ -500,13 +498,13 @@ Due to that API changes: tool's `toolbox` getter now can return either a single 
 
 ### 2.13
 
-- `Improvements` *BlockSelection* — Block Selection allows to select single editable element via CMD+A
-- `New` *API* — Added [API methods](api.md) to open and close inline toolbar [#665](https://github.com/codex-team/editor.js/issues/665)
-- `New` *Config* - Added new property in EditorConfig `holder`, use this property for append Editor instead `holderId`. `holder` property now support reference on dom element. [#696](https://github.com/codex-team/editor.js/issues/696)
-- `Deprecated` *Config* - `holderId` property now is deprecated and will removed in next major release. Use `holder` instead.
-- `Fix` *Types* — Fixed error with `codex-notifier` package [#713](https://github.com/codex-team/editor.js/issues/713)
+- `Improvements` _BlockSelection_ — Block Selection allows to select single editable element via CMD+A
+- `New` _API_ — Added [API methods](api.md) to open and close inline toolbar [#665](https://github.com/codex-team/editor.js/issues/665)
+- `New` _Config_ - Added new property in EditorConfig `holder`, use this property for append Editor instead `holderId`. `holder` property now support reference on dom element. [#696](https://github.com/codex-team/editor.js/issues/696)
+- `Deprecated` _Config_ - `holderId` property now is deprecated and will removed in next major release. Use `holder` instead.
+- `Fix` _Types_ — Fixed error with `codex-notifier` package [#713](https://github.com/codex-team/editor.js/issues/713)
 - `Improvements` — Close inline toolbar after creating a new link.
-- `New` *Config* — Option `minHeight` for customizing Editor's bottom zone height added.
+- `New` _Config_ — Option `minHeight` for customizing Editor's bottom zone height added.
 
 ### 2.12.4
 
@@ -521,7 +519,7 @@ Due to that API changes: tool's `toolbox` getter now can return either a single 
 
 ### 2.12.2
 
-- New *Inline Tools* — pass tool settings from configuration to Tool constructor
+- New _Inline Tools_ — pass tool settings from configuration to Tool constructor
 
 ### 2.12.1
 
@@ -529,7 +527,7 @@ Due to that API changes: tool's `toolbox` getter now can return either a single 
 
 ### 2.12.0
 
-- `New` *API* - new `blocks` API method `renderFromHTML`
+- `New` _API_ - new `blocks` API method `renderFromHTML`
 
 ### 2.11.11
 
@@ -549,15 +547,15 @@ Due to that API changes: tool's `toolbox` getter now can return either a single 
 
 ### 2.11.7
 
-- `Fix` *Paste* — Fix pasting into non-initial Blocks
+- `Fix` _Paste_ — Fix pasting into non-initial Blocks
 
 ### 2.11.6
 
-- `Fix` *Paste* — Polyfill for Microsoft Edge
+- `Fix` _Paste_ — Polyfill for Microsoft Edge
 
 ### 2.11.5
 
-- `Fix` *RectangleSelection* — Redesign of the scrolling zones
+- `Fix` _RectangleSelection_ — Redesign of the scrolling zones
 
 ### 2.11.4
 
@@ -573,7 +571,7 @@ Due to that API changes: tool's `toolbox` getter now can return either a single 
 
 ### 2.11.1
 
-- `Fix` *RectangleSelection* — Selection is available only for the main mouse button
+- `Fix` _RectangleSelection_ — Selection is available only for the main mouse button
 
 ### 2.11.0
 
@@ -605,19 +603,19 @@ Due to that API changes: tool's `toolbox` getter now can return either a single 
 
 ### 2.9.0
 
-- `New` *RectangleSelection* — Ability to select Block or several Blocks with mouse
+- `New` _RectangleSelection_ — Ability to select Block or several Blocks with mouse
 
 ### 2.8.1
 
-- `Fix` *Caret* — Fix "History back" call on backspace in Firefox
+- `Fix` _Caret_ — Fix "History back" call on backspace in Firefox
 
 ### 2.8.0
 
-- `Improvements` *API* — Added [API methods](api.md#caretapi) to manage caret position
+- `Improvements` _API_ — Added [API methods](api.md#caretapi) to manage caret position
 
 ### 2.7.32
 
-- `Improvements` *Types* — TypeScript types sre updated
+- `Improvements` _Types_ — TypeScript types sre updated
 
 ### 2.7.31
 
@@ -637,37 +635,37 @@ Due to that API changes: tool's `toolbox` getter now can return either a single 
 
 ### 2.2.27
 
-- `New` *Mobile view* — Editor now adopted for mobile devices
-- `New` *Narrow mode* — Editor now adopted for narrow containers
+- `New` _Mobile view_ — Editor now adopted for mobile devices
+- `New` _Narrow mode_ — Editor now adopted for narrow containers
 
 ### 2.2.26
 
-- `Improvements` *Caret* — Improvements of the caret behaviour: arrows, backspace and enter keys better handling.
+- `Improvements` _Caret_ — Improvements of the caret behaviour: arrows, backspace and enter keys better handling.
 
 ### 2.2.25
 
-- `New` *Autofocus* — Now you can set focus at Editor after page has been loaded
+- `New` _Autofocus_ — Now you can set focus at Editor after page has been loaded
 
 ### 2.2.24
 
-- `Improvements` *Paste* handling — minor paste handling improvements
+- `Improvements` _Paste_ handling — minor paste handling improvements
 
 ### 2.2.23
 
-- `New` *Shortcuts* — copy and cut Blocks selected by CMD+A
+- `New` _Shortcuts_ — copy and cut Blocks selected by CMD+A
 
 ### 2.2—2.7
 
-- `New` *Sanitize API* — [Sanitize Config](https://github.com/codex-team/editor.js/blob/master/docs/tools.md#automatic-sanitize) of `Block Tools` now automatically extends by tags of `Inline Tools` that is enabled by current Tool by `inlineToolbar` option. You don't need more to specify `a, b, mark, code` manually. This feature will be added to fields that supports inline markup.
-- `New` *Block Selection* — Ability to select Block by `CMD+A`, and the whole Editor by double `CMD+A`. After that, you can copy (`CMD+C`), remove (`Backspace`) or clear (`Enter`) selected Blocks.
-- `New` *[Styles API](https://github.com/codex-team/editor.js/blob/master/types/api/styles.d.ts)* — Added `button` class for stylization of any buttons provided by Tools with one unified style.
-- `New` *[Notifier API](https://github.com/codex-team/editor.js/blob/master/docs/api.md#notifierapi)* — methods for showing user notifications: on success, errors, warnings, etc.
-- `New` *Block Tool* — [Table](http://github.com/editor-js/table) constructor 💪
-- `New` If one of the Tools is unavailable on Editor initialization, its Blocks will be rendered with *Dummy Block*, describing that user can not edit content of this Block. Dummy Blocks can be moved, removed and saved as normal Blocks. So saved data won't be lost if one of the Tools is failed
+- `New` _Sanitize API_ — [Sanitize Config](https://github.com/codex-team/editor.js/blob/master/docs/tools.md#automatic-sanitize) of `Block Tools` now automatically extends by tags of `Inline Tools` that is enabled by current Tool by `inlineToolbar` option. You don't need more to specify `a, b, mark, code` manually. This feature will be added to fields that supports inline markup.
+- `New` _Block Selection_ — Ability to select Block by `CMD+A`, and the whole Editor by double `CMD+A`. After that, you can copy (`CMD+C`), remove (`Backspace`) or clear (`Enter`) selected Blocks.
+- `New` _[Styles API](https://github.com/codex-team/editor.js/blob/master/types/api/styles.d.ts)_ — Added `button` class for stylization of any buttons provided by Tools with one unified style.
+- `New` _[Notifier API](https://github.com/codex-team/editor.js/blob/master/docs/api.md#notifierapi)_ — methods for showing user notifications: on success, errors, warnings, etc.
+- `New` _Block Tool_ — [Table](http://github.com/editor-js/table) constructor 💪
+- `New` If one of the Tools is unavailable on Editor initialization, its Blocks will be rendered with _Dummy Block_, describing that user can not edit content of this Block. Dummy Blocks can be moved, removed and saved as normal Blocks. So saved data won't be lost if one of the Tools is failed
 - `New` [Public TS-types](https://github.com/codex-team/editor.js/tree/master/types) are presented.
-- `Changes` *Tools API*  — options `irreplaceable` and `contentless` was removed.
-- `Changes` *Tools API* — [Paste API](https://github.com/codex-team/editor.js/blob/master/docs/tools.md#paste-handling): tags, patterns and mime-types now should be specified by Tool's `pasteConfig` static property. Custom Paste Event should be handled by `onPaste(event)` that should not be static from now.
-- `Changes` *Tools API* — options `displayInToolbox ` and `toolboxIcon` was removed. Use [`toolbox`](https://github.com/codex-team/editor.js/blob/master/docs/tools.md#internal-tool-settings) instead, that should return object with `icon` and `title` field, or `false` if Tool should not be placed at the Toolbox. Also, there are a way to override `toolbox {icon, title}` settings provided by Tool with you own settings at the Initial Config.
+- `Changes` _Tools API_ — options `irreplaceable` and `contentless` was removed.
+- `Changes` _Tools API_ — [Paste API](https://github.com/codex-team/editor.js/blob/master/docs/tools.md#paste-handling): tags, patterns and mime-types now should be specified by Tool's `pasteConfig` static property. Custom Paste Event should be handled by `onPaste(event)` that should not be static from now.
+- `Changes` _Tools API_ — options `displayInToolbox ` and `toolboxIcon` was removed. Use [`toolbox`](https://github.com/codex-team/editor.js/blob/master/docs/tools.md#internal-tool-settings) instead, that should return object with `icon` and `title` field, or `false` if Tool should not be placed at the Toolbox. Also, there are a way to override `toolbox {icon, title}` settings provided by Tool with you own settings at the Initial Config.
 - `Improvements` — All Projects code now on TypeScript
 - `Improvements` — NPM package size decreased from 1300kb to 422kb
 - `Improvements` — Bundle size decreased from 438kb to 252kb
@@ -685,8 +683,8 @@ See a whole [Changelog](/docs/)
 
 ### 2.1-beta changelog
 
-- `New` *Tools API* — support pasted content via drag-n-drop or from the Buffer. See [documentation](https://github.com/codex-team/editor.js/blob/master/docs/tools.md#paste-handling) and [example](https://github.com/editor-js/simple-image/blob/master/src/index.js#L177) at the Simple Image Tool.
-- `New` *Tools API* — new `sanitize` getter for Tools for automatic HTML sanitizing of returned data. See [documentation](https://github.com/codex-team/editor.js/blob/master/docs/tools.md#sanitize) and [example](https://github.com/editor-js/paragraph/blob/master/src/index.js#L121) at the Paragraph Tool
+- `New` _Tools API_ — support pasted content via drag-n-drop or from the Buffer. See [documentation](https://github.com/codex-team/editor.js/blob/master/docs/tools.md#paste-handling) and [example](https://github.com/editor-js/simple-image/blob/master/src/index.js#L177) at the Simple Image Tool.
+- `New` _Tools API_ — new `sanitize` getter for Tools for automatic HTML sanitizing of returned data. See [documentation](https://github.com/codex-team/editor.js/blob/master/docs/tools.md#sanitize) and [example](https://github.com/editor-js/paragraph/blob/master/src/index.js#L121) at the Paragraph Tool
 - `New` Added `onChange`-callback, fired after any modifications at the Editor. See [documentation](https://github.com/codex-team/editor.js/blob/master/docs/installation.md#features).
 - `New` New Inline Tool example — [Marker](https://github.com/editor-js/marker)
 - `New` New Inline Tool example — [Code](https://github.com/editor-js/code)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/editorjs",
-  "version": "2.31.1",
+  "version": "2.31.2",
   "description": "Editor.js — open source block-style WYSIWYG editor with JSON output",
   "main": "dist/editorjs.umd.js",
   "module": "dist/editorjs.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/editorjs",
-  "version": "2.31.2-hotfix.0",
+  "version": "2.31.1",
   "description": "Editor.js — open source block-style WYSIWYG editor with JSON output",
   "main": "dist/editorjs.umd.js",
   "module": "dist/editorjs.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/editorjs",
-  "version": "2.31.1",
+  "version": "2.31.2-hotfix.0",
   "description": "Editor.js — open source block-style WYSIWYG editor with JSON output",
   "main": "dist/editorjs.umd.js",
   "module": "dist/editorjs.mjs",

--- a/src/components/inline-tools/inline-tool-link.ts
+++ b/src/components/inline-tools/inline-tool-link.ts
@@ -172,11 +172,21 @@ export default class LinkInlineTool implements InlineTool {
        * Unlink icon pressed
        */
       if (parentAnchor) {
-        this.selection.expandToTag(parentAnchor);
-        this.unlink();
-        this.closeActions();
-        this.checkState();
-        this.toolbar.close();
+        /**
+         * If input is not opened, treat click as explicit unlink action.
+         * If input is opened (e.g., programmatic close when switching tools), avoid unlinking.
+         */
+        if (!this.inputOpened) {
+          this.selection.expandToTag(parentAnchor);
+          this.unlink();
+          this.closeActions();
+          this.checkState();
+          this.toolbar.close();
+        } else {
+          /** Only close actions without clearing saved selection to preserve user state */
+          this.closeActions(false);
+          this.checkState();
+        }
 
         return;
       }

--- a/test/cypress/tests/inline-tools/link.cy.ts
+++ b/test/cypress/tests/inline-tools/link.cy.ts
@@ -87,11 +87,12 @@ describe('Inline Tool Link', () => {
     });
 
     cy.get('[data-cy=editorjs]')
-      .find('div.ce-block')
-      .click()
-      .type('{selectall}')
-      .wait(200)
-      .type('{ctrl}K');
+      .find('.ce-paragraph')
+      .selectText('Text with link');
+
+    cy.get('[data-cy=editorjs]')
+      .find('[data-item-name=link]')
+      .click();
 
     cy.get('[data-cy=editorjs]')
       .find('.ce-inline-tool-input')
@@ -106,10 +107,11 @@ describe('Inline Tool Link', () => {
     cy.get('[data-cy=editorjs]')
       .find('div.ce-block')
       .find('a')
-      .click()
-      .type('{selectall}')
-      .wait(200)
-      .type('{ctrl}B');
+      .selectText('Text with link');
+
+    cy.get('[data-cy=editorjs]')
+      .find('[data-item-name=bold]')
+      .click();
 
     cy.get('[data-cy=editorjs]')
       .find('div.ce-block')

--- a/test/cypress/tests/inline-tools/link.cy.ts
+++ b/test/cypress/tests/inline-tools/link.cy.ts
@@ -71,4 +71,52 @@ describe('Inline Tool Link', () => {
       .find('.ce-paragraph span[style]')
       .should('not.exist');
   });
+
+  it('should preserve link when applying bold to linked text', () => {
+    cy.createEditor({
+      data: {
+        blocks: [
+          {
+            type: 'paragraph',
+            data: {
+              text: 'Text with link',
+            },
+          },
+        ],
+      },
+    });
+
+    cy.get('[data-cy=editorjs]')
+      .find('div.ce-block')
+      .click()
+      .type('{selectall}')
+      .wait(200)
+      .type('{ctrl}K');
+
+    cy.get('[data-cy=editorjs]')
+      .find('.ce-inline-tool-input')
+      .type('https://editorjs.io')
+      .type('{enter}');
+
+    cy.get('[data-cy=editorjs]')
+      .find('div.ce-block')
+      .find('a')
+      .should('have.attr', 'href', 'https://editorjs.io');
+
+    cy.get('[data-cy=editorjs]')
+      .find('div.ce-block')
+      .find('a')
+      .click()
+      .type('{selectall}')
+      .wait(200)
+      .type('{ctrl}B');
+
+    cy.get('[data-cy=editorjs]')
+      .find('div.ce-block')
+      .find('a')
+      .should('have.attr', 'href', 'https://editorjs.io')
+      .find('b')
+      .should('exist')
+      .should('contain', 'Text with link');
+  });
 });


### PR DESCRIPTION
# Fix: Prevent link removal when applying bold to linked text

Fixes #2890

## Problem
When a user highlighted text, created a link, and then attempted to apply bold formatting to the linked text, the link (`<a>` tag) would be unexpectedly removed. The bold formatting would be applied, but the anchor tag would disappear, breaking the link functionality.

## Root Cause
The link tool's `surround()` method was treating all cases where the selection was inside an `<a>` tag as an explicit "unlink" action. However, when clicking another inline tool (like Bold) while the link input was open, the popover system would programmatically call the link tool's `surround()` method to close it. This would incorrectly trigger the unlink logic, removing the anchor tag before the new tool could be applied.

## Solution
Modified [src/components/inline-tools/inline-tool-link.ts](src/components/inline-tools/inline-tool-link.ts) to distinguish between:
- **Explicit unlink**: User clicks the link button to toggle it off (`inputOpened === false`) → unlink and close
- **Programmatic close**: Link input is already open and needs to close for tool switching (`inputOpened === true`) → close cleanly without unlinking

This preserves the link when switching to other formatting tools while maintaining the unlink functionality for explicit toggle actions.

## Changes
- Updated `surround()` method to check `inputOpened` state before unlinking
- When input is open, only close actions without removing the selection or anchor
- When input is closed, preserve existing unlink behavior (explicit user action)

## Testing
- ✅ Build: `yarn build:test` — No compilation errors
- ✅ E2E Tests: `yarn test:e2e` — All 348 tests passing (no regressions)
- ✅ Link tool tests: `test/cypress/tests/inline-tools/link.cy.ts` — Passing

## Expected Behavior After Fix
Selecting linked text and clicking Bold now results in: `<a><b>linked bold text</b></a>` instead of losing the link.