### PR TITLE
fix(drag-n-drop): prevent block selection on file drop (#2980)

### DIFF
--- a/src/components/modules/dragNDrop.ts
+++ b/src/components/modules/dragNDrop.ts
@@ -92,14 +92,18 @@ export default class DragNDrop extends Module {
     const targetBlock = BlockManager.setCurrentBlockByChildNode(dropEvent.target as Node);
 
     if (targetBlock) {
-      this.Editor.Caret.setToBlock(targetBlock, Caret.positions.END);
+      // this.Editor.Caret.setToBlock(targetBlock, Caret.positions.END);
     } else {
-      const lastBlock = BlockManager.setCurrentBlockByChildNode(BlockManager.lastBlock.holder);
+      // const lastBlock = BlockManager.setCurrentBlockByChildNode(BlockManager.lastBlock.holder);
 
-      this.Editor.Caret.setToBlock(lastBlock, Caret.positions.END);
+      // this.Editor.Caret.setToBlock(lastBlock, Caret.positions.END);
     }
 
     await Paste.processDataTransfer(dropEvent.dataTransfer, true);
+
+    _.delay(() => {
+      this.Editor.BlockSelection.clearSelection();
+    }, 50)();
   }
 
   /**


### PR DESCRIPTION
Problem:
When dropping a file (e.g., image) onto a block, the editor currently highlights the block as "Selected" (adds the .ce-block--selected class). This leaves a persistent blue background behind the dropped content, which is incorrect behavior for a drag-and-drop action.

Fix:
Removed forced caret placement: The dragNDrop module was calling Caret.setToBlock(targetBlock) upon drop. This action forces the block to be focused/selected. I removed this call to prevent the block from capturing selection during a drop event.
Ensured Selection Clearing: Added a safety check to explicitly clear block selection (BlockSelection.clearSelection()) after the drop is processed, ensuring a clean state.

Verification:
Verified manually in a reproduction environment.
Result: Dropping a file now correctly inserts/uploads the file without toggling the "Selected" state of the block. No blue background appears.

Resolves #2980