### PR TITLE
fix: prevent scrollbars in inline toolbar on Safari

### DIFF
--- a/src/styles/popover-inline.css
+++ b/src/styles/popover-inline.css
@@ -14,6 +14,7 @@
 
   .ce-popover__items {
     display: flex;
+    overflow: hidden;
   }
   
   .ce-popover__container {


### PR DESCRIPTION
Fixes #2988

The inline toolbar shows scrollbars in Safari because `.ce-popover__items` inherits `overflow-y: auto` from `popover.css`. Safari renders the scroll control even when the content fits in the container, partially covering toolbar items.

Adding `overflow: hidden` to the `.ce-popover__items` selector inside `.ce-popover--inline` prevents this. The flex layout already handles all item placement so scrolling isn't needed here.

One line change to `src/styles/popover-inline.css`.