### PR TITLE
fix(popover-inline): prevent scrollbars from appearing in Safari

### DIFF
--- a/src/styles/popover-inline.css
+++ b/src/styles/popover-inline.css
@@ -14,6 +14,7 @@
 
   .ce-popover__items {
     display: flex;
+    overflow-y: visible;
   }
   
   .ce-popover__container {


### PR DESCRIPTION
Fixes #2988

## Summary

In Safari, the inline toolbar popover shows native scrollbars that partially cover the toolbar items. This happens because the base `.ce-popover__items` class sets `overflow-y: auto`, and Safari renders visible scrollbars even when content doesn't overflow.

## Root Cause

The base popover styles (`popover.css`) set `overflow-y: auto` on `.ce-popover__items` to enable scrolling in dropdown popovers with many items. However, the inline toolbar already uses `width: max-content` on its container, meaning it grows to fit content rather than constraining to a fixed width. Scrolling is unnecessary for the inline toolbar.

## Fix

Added `overflow-y: visible` to `.ce-popover__items` inside the `.ce-popover--inline` scope, overriding the base popover's `overflow-y: auto`. This follows the maintainer's suggested approach #1 from the issue: disable scrolling in the inline toolbar and let it grow based on content.

## How to test

1. Open the editor in Safari
2. Select some text to trigger the inline toolbar
3. Verify no scrollbars appear on the toolbar popover

*This PR was created with the assistance of Claude Opus 4.6 by Anthropic. Happy to make any adjustments! Reviewed and submitted by a human.*

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>