### PR TITLE
Fix inline popover re renders

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.31.3
+
+- `Fix` - Prevent text formatting removal when applying link
+
 ### 2.31.2
 
 - `Fix` - Prevent link removal when applying bold to linked text

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/editorjs",
-  "version": "2.31.2",
+  "version": "2.31.3",
   "description": "Editor.js — open source block-style WYSIWYG editor with JSON output",
   "main": "dist/editorjs.umd.js",
   "module": "dist/editorjs.mjs",

--- a/src/components/inline-tools/inline-tool-link.ts
+++ b/src/components/inline-tools/inline-tool-link.ts
@@ -212,7 +212,7 @@ export default class LinkInlineTool implements InlineTool {
        */
       const hrefAttr = anchorTag.getAttribute('href');
 
-      this.nodes.input.value = hrefAttr !== 'null' ? hrefAttr : '';
+      this.nodes.input.defaultValue = hrefAttr !== 'null' ? hrefAttr : '';
 
       this.selection.save();
     } else {

--- a/src/components/selection.ts
+++ b/src/components/selection.ts
@@ -57,7 +57,7 @@ export default class SelectionUtils {
   public isFakeBackgroundEnabled = false;
 
   /**
-   * Native Document's commands for fake background
+   * Native Document's command for fake background
    */
   private readonly commandBackground: string = 'backColor';
 

--- a/src/components/selection.ts
+++ b/src/components/selection.ts
@@ -60,7 +60,6 @@ export default class SelectionUtils {
    * Native Document's commands for fake background
    */
   private readonly commandBackground: string = 'backColor';
-  private readonly commandRemoveFormat: string = 'removeFormat';
 
   /**
    * Editor styles
@@ -416,9 +415,9 @@ export default class SelectionUtils {
     if (!this.isFakeBackgroundEnabled) {
       return;
     }
+    document.execCommand(this.commandBackground, false, 'transparent');
 
     this.isFakeBackgroundEnabled = false;
-    document.execCommand(this.commandRemoveFormat);
   }
 
   /**

--- a/test/cypress/tests/inline-tools/link.cy.ts
+++ b/test/cypress/tests/inline-tools/link.cy.ts
@@ -121,4 +121,75 @@ describe('Inline Tool Link', () => {
       .should('exist')
       .should('contain', 'Text with link');
   });
+
+  it('should preserve bold and italic when applying link', () => {
+    cy.createEditor({
+      data: {
+        blocks: [
+          {
+            type: 'paragraph',
+            data: {
+              text: 'Bold and italic text',
+            },
+          },
+        ],
+      },
+    });
+
+    cy.get('[data-cy=editorjs]')
+      .find('.ce-paragraph')
+      .selectText('Bold and italic text');
+    
+    cy.get('[data-cy=editorjs]')
+      .find('[data-item-name=bold]')
+      .click();
+
+    cy.get('[data-cy=editorjs]')
+      .find('div.ce-block')
+      .find('b')
+      .should('exist')
+      .should('contain', 'Bold and italic text');
+    
+    cy.get('[data-cy=editorjs]')
+      .find('div.ce-block')
+      .find('b')
+      .selectText('Bold and italic text');
+
+    cy.get('[data-cy=editorjs]')
+      .find('[data-item-name=italic]')
+      .click();
+
+    cy.get('[data-cy=editorjs]')
+      .find('div.ce-block')
+      .find('b')
+      .should('exist')
+      .find('i')
+      .should('exist')
+      .should('contain', 'Bold and italic text');
+
+    cy.get('[data-cy=editorjs]')
+      .find('div.ce-block')
+      .find('b')
+      .find('i')
+      .selectText('Bold and italic text');
+
+    cy.get('[data-cy=editorjs]')
+      .find('[data-item-name=link]')
+      .click();
+
+    cy.get('[data-cy=editorjs]')
+      .find('.ce-inline-tool-input')
+      .type('https://editorjs.io')
+      .type('{enter}');
+
+    cy.get('[data-cy=editorjs]')
+      .find('div.ce-block')
+      .find('b')
+      .should('exist')
+      .find('i')
+      .should('exist')
+      .find('a')
+      .should('have.attr', 'href', 'https://editorjs.io')
+      .should('contain', 'Bold and italic text');
+  });
 });


### PR DESCRIPTION
**Problem:**
Inline-popover re-renders constantly while text with `link-tool` formatting is selected.

**Description:**
Value assignment at [line-215](https://github.com/codex-team/editor.js/blob/a89f3d0eda284490693abc9663c365b3d1f7556a/src/components/inline-tools/inline-tool-link.ts#L215) causes a `selectionchange` event that triggers inline-popover re-render.

<details>
<summary>example</summary>

```html
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8" />
  <title>selectionchange demo</title>
</head>
<body>
  <button id="valueBtn">Set value</button>
  <button id="defaultValueBtn">Set defaultValue</button>
  <br /><br />

  <input id="input" />

  <script>
    const input = document.getElementById('input');

    document.addEventListener('selectionchange', () => {
      console.log('selectionchange');
    });

    document.getElementById('valueBtn').onclick = () => {
      input.value = 'value text';
      console.log('value set');
    };

    document.getElementById('defaultValueBtn').onclick = () => {
      input.defaultValue = 'defaultValue text';
      console.log('defaultValue set');
    };
  </script>
</body>
</html>
```

</details>

Issue:
https://github.com/codex-team/editor.js/issues/2987

Solution:
Change input value assignment to defaultValue to prevent the selectionchange event.