### PR TITLE
fix(inline-tool-link): use defaultValue to prevent selectionchange event

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.31.4
+
+- `Fix` - Prevent inline-toolbar re-renders when linked text is selected
+
 ### 2.31.3
 
 - `Fix` - Prevent text formatting removal when applying link

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/editorjs",
-  "version": "2.31.3",
+  "version": "2.31.4",
   "description": "Editor.js — open source block-style WYSIWYG editor with JSON output",
   "main": "dist/editorjs.umd.js",
   "module": "dist/editorjs.mjs",

--- a/src/components/inline-tools/inline-tool-link.ts
+++ b/src/components/inline-tools/inline-tool-link.ts
@@ -212,7 +212,7 @@ export default class LinkInlineTool implements InlineTool {
        */
       const hrefAttr = anchorTag.getAttribute('href');
 
-      this.nodes.input.value = hrefAttr !== 'null' ? hrefAttr : '';
+      this.nodes.input.defaultValue = hrefAttr !== 'null' ? hrefAttr : '';
 
       this.selection.save();
     } else {

--- a/src/components/modules/ui.ts
+++ b/src/components/modules/ui.ts
@@ -771,10 +771,11 @@ export default class UI extends Module<UINodes> {
      * case when user clicks on anchor element
      * if it is clicked via ctrl key, then we open new window with url
      */
-    const element = (event.target as Element).closest("a");
+    const element = event.target as Element;
     const ctrlKey = event.metaKey || event.ctrlKey;
+    const hasParentAnchor = !!(event.target as Element).closest("a");
 
-    if ($.isAnchor(element) && ctrlKey) {
+    if ((hasParentAnchor || $.isAnchor(element)) && ctrlKey) {
       event.stopImmediatePropagation();
       event.stopPropagation();
 

--- a/src/components/modules/ui.ts
+++ b/src/components/modules/ui.ts
@@ -771,11 +771,10 @@ export default class UI extends Module<UINodes> {
      * case when user clicks on anchor element
      * if it is clicked via ctrl key, then we open new window with url
      */
-    const element = event.target as Element;
+    const element = (event.target as Element).closest("a");
     const ctrlKey = event.metaKey || event.ctrlKey;
-    const hasParentAnchor = !!(event.target as Element).closest("a");
 
-    if ((hasParentAnchor || $.isAnchor(element)) && ctrlKey) {
+    if ($.isAnchor(element) && ctrlKey) {
       event.stopImmediatePropagation();
       event.stopPropagation();
 

--- a/src/components/modules/ui.ts
+++ b/src/components/modules/ui.ts
@@ -771,7 +771,7 @@ export default class UI extends Module<UINodes> {
      * case when user clicks on anchor element
      * if it is clicked via ctrl key, then we open new window with url
      */
-    const element = (event.target as Element).closest("a");
+    const element = event.target as Element;
     const ctrlKey = event.metaKey || event.ctrlKey;
 
     if ($.isAnchor(element) && ctrlKey) {

--- a/src/components/modules/ui.ts
+++ b/src/components/modules/ui.ts
@@ -771,7 +771,7 @@ export default class UI extends Module<UINodes> {
      * case when user clicks on anchor element
      * if it is clicked via ctrl key, then we open new window with url
      */
-    const element = event.target as Element;
+    const element = (event.target as Element).closest("a");
     const ctrlKey = event.metaKey || event.ctrlKey;
 
     if ($.isAnchor(element) && ctrlKey) {


### PR DESCRIPTION
**Problem:**
Inline-popover re-renders constantly while text with `link-tool` formatting is selected.

**Description:**
Value assignment at [line-215](https://github.com/codex-team/editor.js/blob/a89f3d0eda284490693abc9663c365b3d1f7556a/src/components/inline-tools/inline-tool-link.ts#L215)
causes a `selectionchange` event that triggers inline-popover re-render.

<details>
<summary>example</summary>

```html
<!DOCTYPE html>
<html lang="en">
<head>
  <meta charset="UTF-8" />
  <title>selectionchange demo</title>
</head>
<body>
  <button id="valueBtn">Set value</button>
  <button id="defaultValueBtn">Set defaultValue</button>
  <br /><br />

  <input id="input" />

  <script>
    const input = document.getElementById('input');

    document.addEventListener('selectionchange', () => {
      console.log('selectionchange');
    });

    document.getElementById('valueBtn').onclick = () => {
      input.value = 'value text';
      console.log('value set');
    };

    document.getElementById('defaultValueBtn').onclick = () => {
      input.defaultValue = 'defaultValue text';
      console.log('defaultValue set');
    };
  </script>
</body>
</html>
```
</details>

Issue:
https://github.com/codex-team/editor.js/issues/2987

Solution:
Change input value assignment to defaultValue to prevent the selectionchange event.