### PR TITLE
fix(link-tool): open new window with url when formatted link clicked via ctrl key

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.31.5
+
+- `Fix` - Handle __Ctrl + click__ on links with inline styles applied (e.g., bold, italic)
+
 ### 2.31.4
 
 - `Fix` - Prevent inline-toolbar re-renders when linked text is selected

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/editorjs",
-  "version": "2.31.4",
+  "version": "2.31.5",
   "description": "Editor.js — open source block-style WYSIWYG editor with JSON output",
   "main": "dist/editorjs.umd.js",
   "module": "dist/editorjs.mjs",

--- a/src/components/dom.ts
+++ b/src/components/dom.ts
@@ -567,6 +567,16 @@ export default class Dom {
   }
 
   /**
+   * Returns the closest ancestor anchor (A tag) of the given element (including itself)
+   * 
+   * @param element - element to check
+   * @returns {HTMLAnchorElement | null}
+   */
+  public static getAnchor(element: Element): HTMLAnchorElement | null {
+    return element.closest("a");
+  }
+
+  /**
    * Return element's offset related to the document
    *
    * @todo handle case when editor initialized in scrollable popup

--- a/src/components/dom.ts
+++ b/src/components/dom.ts
@@ -572,7 +572,7 @@ export default class Dom {
    * @param element - element to check
    * @returns {HTMLAnchorElement | null}
    */
-  public static getAnchor(element: Element): HTMLAnchorElement | null {
+  public static getClosestAnchor(element: Element): HTMLAnchorElement | null {
     return element.closest("a");
   }
 

--- a/src/components/modules/ui.ts
+++ b/src/components/modules/ui.ts
@@ -773,12 +773,13 @@ export default class UI extends Module<UINodes> {
      */
     const element = event.target as Element;
     const ctrlKey = event.metaKey || event.ctrlKey;
-
-    if ($.isAnchor(element) && ctrlKey) {
+    const anchor = $.getAnchor(element);
+  
+    if (anchor && ctrlKey) {
       event.stopImmediatePropagation();
       event.stopPropagation();
 
-      const href = element.getAttribute('href');
+      const href = anchor.getAttribute('href');
       const validUrl = _.getValidUrl(href);
 
       _.openTab(validUrl);

--- a/src/components/modules/ui.ts
+++ b/src/components/modules/ui.ts
@@ -773,7 +773,7 @@ export default class UI extends Module<UINodes> {
      */
     const element = event.target as Element;
     const ctrlKey = event.metaKey || event.ctrlKey;
-    const anchor = $.getAnchor(element);
+    const anchor = $.getClosestAnchor(element);
   
     if (anchor && ctrlKey) {
       event.stopImmediatePropagation();

--- a/test/cypress/tests/inline-tools/link.cy.ts
+++ b/test/cypress/tests/inline-tools/link.cy.ts
@@ -192,4 +192,34 @@ describe('Inline Tool Link', () => {
       .should('have.attr', 'href', 'https://editorjs.io')
       .should('contain', 'Bold and italic text');
   });
+
+  it('should open formatted link in the same tab', () => {
+    cy.createEditor({
+      data: {
+        blocks: [
+          {
+            type: 'paragraph',
+            data: {
+              text: 'Link text',
+            },
+          },
+        ],
+      },
+    });
+
+    const editor = '[data-cy=editorjs]';
+
+    cy.get(`${editor} .ce-paragraph`).selectText('Link text');
+    cy.get(`${editor} [data-item-name=link]`).click();
+    cy.get(`${editor} .ce-inline-tool-input`).type('https://test.io{enter}');
+
+    cy.get(`${editor} a`).selectText('Link text');
+    cy.get(`${editor} [data-item-name=italic]`).click();
+
+    cy.window().then((win) => cy.stub(win, 'open').as('open'));
+
+    cy.contains(`${editor} i`, 'Link text').click({ ctrlKey: true });
+
+    cy.get('@open').should('have.been.calledWith', 'https://test.io/');
+  })
 });

--- a/test/cypress/tests/inline-tools/link.cy.ts
+++ b/test/cypress/tests/inline-tools/link.cy.ts
@@ -193,7 +193,7 @@ describe('Inline Tool Link', () => {
       .should('contain', 'Bold and italic text');
   });
 
-  it('should open formatted link in the same tab', () => {
+  it('should open a link if it is wrapped in another formatting', () => {
     cy.createEditor({
       data: {
         blocks: [

--- a/test/cypress/tests/inline-tools/link.cy.ts
+++ b/test/cypress/tests/inline-tools/link.cy.ts
@@ -207,19 +207,35 @@ describe('Inline Tool Link', () => {
       },
     });
 
-    const editor = '[data-cy=editorjs]';
+    cy.get('[data-cy=editorjs]')
+      .find('.ce-paragraph')
+      .selectText('Link text');
 
-    cy.get(`${editor} .ce-paragraph`).selectText('Link text');
-    cy.get(`${editor} [data-item-name=link]`).click();
-    cy.get(`${editor} .ce-inline-tool-input`).type('https://test.io{enter}');
+    cy.get('[data-cy=editorjs]')
+      .find('[data-item-name=link]')
+      .click();
 
-    cy.get(`${editor} a`).selectText('Link text');
-    cy.get(`${editor} [data-item-name=italic]`).click();
+    cy.get('[data-cy=editorjs]')
+      .find('.ce-inline-tool-input')
+      .type('https://test.io/')
+      .type('{enter}');
 
-    cy.window().then((win) => cy.stub(win, 'open').as('open'));
+    cy.get('[data-cy=editorjs]')
+      .find('div.ce-block')
+      .find('a')
+      .selectText('Link text');
 
-    cy.contains(`${editor} i`, 'Link text').click({ ctrlKey: true });
+    cy.get('[data-cy=editorjs]')
+      .find('[data-item-name=italic]')
+      .click();
 
-    cy.get('@open').should('have.been.calledWith', 'https://test.io/');
-  })
+    cy.window().then((win) => {
+      cy.stub(win, 'open').as('windowOpen');
+    });
+
+    cy.contains('[data-cy=editorjs] div.ce-block i', 'Link text')
+      .click({ ctrlKey: true });
+
+    cy.get('@windowOpen').should('be.calledWith', 'https://test.io/');
+  });
 });


### PR DESCRIPTION
**Problem:**
When clicking a formatted link, inline elements (e.g., bold, italic) may be returned as the event target instead of the anchor element. As a result, the expected link behavior is not triggered.

**Issue:**
https://github.com/codex-team/editor.js/issues/2995

**Solution:**
Check whether the event target has an anchor (<a>) element among its ancestors and use that element to process the link action.