### PR TITLE
Fix sanitize type to accept per-field SanitizerConfig

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.31.6
+
+- `Fix` - Widen `sanitize` type on `BlockTool` and `BaseToolConstructable` to accept per-field `SanitizerConfig`
+
 ### 2.31.5
 
 - `Fix` - Handle __Ctrl + click__ on links with inline styles applied (e.g., bold, italic)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/editorjs",
-  "version": "2.31.5",
+  "version": "2.31.6",
   "description": "Editor.js — open source block-style WYSIWYG editor with JSON output",
   "main": "dist/editorjs.umd.js",
   "module": "dist/editorjs.mjs",

--- a/types/tools/block-tool.d.ts
+++ b/types/tools/block-tool.d.ts
@@ -13,9 +13,15 @@ import { MenuConfig } from './menu-config';
  */
 export interface BlockTool extends BaseTool {
   /**
-   * Sanitizer rules description
+   * Sanitizer rules description.
+   *
+   * @example Flat config (tag-level rules applied to all output)
+   * { b: true, a: { href: true } }
+   *
+   * @example Per-field config
+   * { text: { br: true, b: true }, caption: { b: true, i: true } }
    */
-  sanitize?: SanitizerConfig;
+  sanitize?: SanitizerConfig | Record<string, SanitizerConfig>;
 
   /**
    * Process Tool's element in DOM and return raw data

--- a/types/tools/tool.d.ts
+++ b/types/tools/tool.d.ts
@@ -37,9 +37,12 @@ export interface BaseToolConstructable {
   isInline?: boolean;
 
   /**
-   * Tool`s sanitizer configuration
+   * Tool`s sanitizer configuration.
+   *
+   * For Block Tools, can be a Record mapping data field names to their SanitizerConfig.
+   * For Inline Tools, should be a flat SanitizerConfig with tag names as keys.
    */
-  sanitize?: SanitizerConfig;
+  sanitize?: SanitizerConfig | Record<string, SanitizerConfig>;
 
   /**
    * Title of Inline Tool.


### PR DESCRIPTION
## Summary

Fixes #2957

The `sanitize` property on `BlockTool` and `BaseToolConstructable` was typed as `SanitizerConfig`, which only allows tag-name keys with `SanitizerRule` values. In practice, Block Tools return an object mapping data field names to their own `SanitizerConfig`, as documented in the [Tools API](https://editorjs.io/tools-api/#sanitize) and used by official plugins like [Paragraph](https://github.com/editor-js/paragraph/blob/master/src/index.ts) and [Quote](https://github.com/editor-js/quote/blob/master/src/index.ts).

This caused TypeScript errors when using functions as sanitizer rules within per-field configs:

```ts
// Before: TS error — function not assignable to 'string | boolean'
static get sanitize() {
  return {
    text: {
      a: (el) => el.textContent !== ''  // TS2322
    }
  }
}
```

The fix widens the type to `SanitizerConfig | Record<string, SanitizerConfig>`, matching the runtime behavior already handled by `cleanObject()` in `src/components/utils/sanitizer.ts` (line 135).

### Changes

- `types/tools/block-tool.d.ts` — `BlockTool.sanitize` type widened
- `types/tools/tool.d.ts` — `BaseToolConstructable.sanitize` type widened (inherited by Block Tools)

### Verified

- Build passes (`yarn build`)
- TypeScript strict-mode check passes for all three usage patterns:
  1. Flat tag-level config: `{ b: true, a: { href: true } }`
  2. Per-field config: `{ text: { br: true }, caption: { b: true } }`
  3. Function rules in per-field config: `{ text: { a: (el) => el.textContent !== '' } }`