### PR TITLE
Fix EditorJS default import types for Node16

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,23 @@
   "main": "dist/editorjs.umd.js",
   "module": "dist/editorjs.mjs",
   "types": "./types/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./types/index.d.mts",
+        "default": "./dist/editorjs.mjs"
+      },
+      "require": {
+        "types": "./types/index.d.ts",
+        "default": "./dist/editorjs.umd.js"
+      },
+      "default": "./dist/editorjs.umd.js"
+    },
+    "./package.json": "./package.json",
+    "./types": "./types/index.d.ts",
+    "./dist/*": "./dist/*",
+    "./*": "./*"
+  },
   "keywords": [
     "codex editor",
     "text editor",
@@ -17,6 +34,7 @@
     "dev": "vite",
     "build": "vite build --mode production",
     "build:test": "vite build --mode test",
+    "test:types": "tsc -p test/types/tsconfig.node16.json",
     "lint": "eslint src/ --ext .ts && yarn lint:tests",
     "lint:errors": "eslint src/ --ext .ts --quiet",
     "lint:fix": "eslint src/ --ext .ts --fix",

--- a/test/types/node16-default-import.mts
+++ b/test/types/node16-default-import.mts
@@ -1,0 +1,7 @@
+import EditorJS from '@editorjs/editorjs';
+
+const editor = new EditorJS({
+  holder: 'editor',
+});
+
+editor.destroy();

--- a/test/types/tsconfig.node16.json
+++ b/test/types/tsconfig.node16.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "lib": ["DOM", "ES2022"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022"
+  },
+  "include": ["node16-default-import.mts"]
+}

--- a/types/index.d.mts
+++ b/types/index.d.mts
@@ -1,0 +1,14 @@
+export type * from './index.js';
+export {
+  BlockAddedMutationType,
+  BlockChangedMutationType,
+  BlockMovedMutationType,
+  BlockRemovedMutationType,
+  LogLevels,
+  PopoverEvent,
+  PopoverItemType,
+} from './index.js';
+
+declare const EditorJS: typeof import('./index.js').default;
+
+export default EditorJS;

--- a/types/index.d.mts
+++ b/types/index.d.mts
@@ -1,3 +1,9 @@
+/**
+ * ESM declaration entry point for Node16/NodeNext consumers.
+ *
+ * TypeScript treats `index.d.ts` as a CommonJS declaration in this package, so
+ * ESM imports need a `.d.mts` wrapper to keep `import EditorJS` typed correctly.
+ */
 export type * from './index.js';
 export {
   BlockAddedMutationType,


### PR DESCRIPTION
## Summary
- add conditional package exports so Node16/NodeNext import resolution can use an ESM declaration entrypoint
- add an `index.d.mts` wrapper that keeps the default `EditorJS` export constructable while preserving existing named type/value exports
- add a type fixture covering default construction with `moduleResolution: Node16`

Fixes #2624.

## Verification
- `yarn install --frozen-lockfile --ignore-scripts --ignore-engines`
- `yarn test:types`
- `npx -y -p typescript@5.9.3 tsc -p test/types/tsconfig.node16.json --pretty false`
- `npx -y -p typescript@5.9.3 tsc -p test/types/tsconfig.node16.json --module NodeNext --moduleResolution NodeNext --pretty false`
- `yarn lint:errors`
- `yarn build`
- `git diff --check`
