### PR TITLE
fix(inline-tool-link): restore unlink behavior and add dynamic tooltip with keyboard Shortcut

### DIFF
--- a/src/components/inline-tools/inline-tool-link.ts
+++ b/src/components/inline-tools/inline-tool-link.ts
@@ -124,6 +124,7 @@ export default class LinkInlineTool implements InlineTool {
     this.nodes.button.classList.add(this.CSS.button, this.CSS.buttonModifier);
 
     this.nodes.button.innerHTML = IconLink;
+    this.nodes.button.title = LinkInlineTool.title;
 
     return this.nodes.button;
   }
@@ -172,21 +173,11 @@ export default class LinkInlineTool implements InlineTool {
        * Unlink icon pressed
        */
       if (parentAnchor) {
-        /**
-         * If input is not opened, treat click as explicit unlink action.
-         * If input is opened (e.g., programmatic close when switching tools), avoid unlinking.
-         */
-        if (!this.inputOpened) {
-          this.selection.expandToTag(parentAnchor);
-          this.unlink();
-          this.closeActions();
-          this.checkState();
-          this.toolbar.close();
-        } else {
-          /** Only close actions without clearing saved selection to preserve user state */
-          this.closeActions(false);
-          this.checkState();
-        }
+        this.selection.expandToTag(parentAnchor);
+        this.unlink();
+        this.closeActions();
+        this.checkState();
+        this.toolbar.close();
 
         return;
       }
@@ -205,6 +196,7 @@ export default class LinkInlineTool implements InlineTool {
       this.nodes.button.innerHTML = IconUnlink;
       this.nodes.button.classList.add(this.CSS.buttonUnlink);
       this.nodes.button.classList.add(this.CSS.buttonActive);
+      this.nodes.button.title = 'Unlink';
       this.openActions();
 
       /**
@@ -219,6 +211,7 @@ export default class LinkInlineTool implements InlineTool {
       this.nodes.button.innerHTML = IconLink;
       this.nodes.button.classList.remove(this.CSS.buttonUnlink);
       this.nodes.button.classList.remove(this.CSS.buttonActive);
+      this.nodes.button.title = 'Link';
     }
 
     return !!anchorTag;
@@ -236,6 +229,13 @@ export default class LinkInlineTool implements InlineTool {
    */
   public get shortcut(): string {
     return 'CMD+K';
+  }
+
+  /**
+   * Returns dynamic title based on whether the current selection is inside a link
+   */
+  public getTitle(): string {
+    return this.selection.findParentTag('A') ? 'Unlink' : 'Link';
   }
 
   /**

--- a/src/components/modules/toolbar/inline.ts
+++ b/src/components/modules/toolbar/inline.ts
@@ -432,6 +432,18 @@ export default class InlineToolbar extends Module<InlineToolbarNodes> {
             instance.checkState?.(SelectionUtils.get());
           }
 
+          /**
+           * Allow inline tools to provide a dynamic title based on current selection state
+           */
+          const dynamicTitle = (instance as { getTitle?: () => string }).getTitle?.();
+
+          if (dynamicTitle !== undefined) {
+            (popoverItem as PopoverItemHtmlParams).hint = {
+              ...(popoverItem as PopoverItemHtmlParams).hint,
+              title: dynamicTitle,
+            };
+          }
+
           popoverItems.push(popoverItem);
         } else if (item.type === PopoverItemType.Html) {
           /**

--- a/src/components/utils/popover/popover-inline.ts
+++ b/src/components/utils/popover/popover-inline.ts
@@ -166,13 +166,7 @@ export class PopoverInline extends PopoverDesktop {
   protected override handleItemClick(item: PopoverItem): void {
     if (item !== this.nestedPopoverTriggerItem) {
       /**
-       * In case tool had special handling for toggling button (like link tool which modifies selection)
-       * we need to call handleClick on nested popover trigger item
-       */
-      this.nestedPopoverTriggerItem?.handleClick();
-
-      /**
-       * Then close the nested popover
+       * Close the nested popover when switching to another tool
        */
       super.destroyNestedPopoverIfExists();
     }


### PR DESCRIPTION
## Problem

In v2.31.6, three regressions appeared in the Link Inline Tool:

1. **Unlink button does not work** — clicking the Link tool icon while the selection is inside an anchor does nothing. The anchor is never removed.
2. **Cmd/Ctrl+K shortcut cannot remove links** — pressing `⌘+K` (Mac) or `Ctrl+K` (Win/Linux) while the selection is inside an existing link also fails to unlink.
3. **Formatting tools removed existing links** — applying Bold, Italic, Marker, or Inline Code to linked text could remove or break the existing anchor element, causing the link to be lost.

The unlink regressions were introduced by commit `9f942ca`, which added a `!this.inputOpened` guard around the unlink logic. Because `checkState()` always opens the link input when an anchor is detected, the guard was never satisfied, preventing `unlink()` from being executed.

Additionally, inline formatting tools did not consistently preserve anchor elements when modifying linked content.

## Solution

- Remove the `!this.inputOpened` guard in `surround()` so that clicking the Link tool or pressing `Cmd/Ctrl+K` while inside an anchor always performs an unlink operation, restoring the behavior from v2.29.1.
- Add dynamic tooltip support through a new `getTitle()` method on `LinkInlineTool`:
  - When selection is inside a link → tooltip shows **"Unlink"**
  - Otherwise → tooltip shows **"Link"**
- Update the Inline Toolbar to read dynamic titles from tool instances so the popover hint reflects the current state.
- Preserve anchor elements when applying:
  - Bold
  - Italic
  - Marker
  - Inline Code
- Ensure inline formatting can be applied to linked text without removing the underlying anchor element or its attributes.

## Changes

| File | Change |
|--------|--------|
| `src/components/inline-tools/inline-tool-link.ts` | Fix `surround()` to always unlink when `parentAnchor` exists; add `getTitle()`; update `render()` and `checkState()` to support dynamic button titles |
| `src/components/modules/toolbar/inline.ts` | Read `instance.getTitle?.()` after `checkState()` to update popover hint text dynamically |
| `src/components/utils/popover/popover-inline.ts` | Preserve existing anchor elements when applying Bold, Italic, Marker, and Inline Code formatting |

## Acceptance Criteria

- [x] Existing links are detected correctly
- [x] Cmd+K (Mac) toggles link creation and removal
- [x] Ctrl+K (Windows/Linux) toggles link creation and removal
- [x] Link dialog enters edit mode when a link is selected
- [x] Unlink button is visible and functional
- [x] Unlink removes the anchor tag while keeping text intact
- [x] Tooltip shows **"Unlink"** when inside a link and **"Link"** otherwise
- [x] Applying Bold preserves existing links
- [x] Applying Italic preserves existing links
- [x] Applying Marker preserves existing links
- [x] Applying Inline Code preserves existing links
- [x] Existing link attributes remain intact after formatting operations

Fix Video :


https://github.com/user-attachments/assets/39c2845b-70c0-4318-b877-72a0cb62ed18



Closes #3005