### PR TITLE
fix(ci): align workflow Node.js version with package engines

### DIFF
--- a/.github/workflows/bump-version-on-merge-next.yml
+++ b/.github/workflows/bump-version-on-merge-next.yml
@@ -64,7 +64,7 @@ jobs:
       # Setup node environment
       - uses: actions/setup-node@v1
         with:
-          node-version: 16
+          node-version: 18
 
       # Bump version to the next prerelease (patch) with rc suffix
       - name: Suggest the new version

--- a/.github/workflows/bump-version-on-merge-next.yml
+++ b/.github/workflows/bump-version-on-merge-next.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@v2
 
       # Setup node environment
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: 18
 

--- a/.github/workflows/create-a-release-draft.yml
+++ b/.github/workflows/create-a-release-draft.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
       # Checkout to target branch
       - uses: actions/checkout@v2
         with:
@@ -70,7 +70,7 @@ jobs:
       # Setup node environment
       - uses: actions/setup-node@v1
         with:
-          node-version: 16
+          node-version: 18
 
       # Prepare, build and publish project
       - name: Install dependencies

--- a/.github/workflows/create-a-release-draft.yml
+++ b/.github/workflows/create-a-release-draft.yml
@@ -68,7 +68,7 @@ jobs:
           submodules: 'recursive'
 
       # Setup node environment
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: 18
 

--- a/.github/workflows/publish-package-to-npm.yml
+++ b/.github/workflows/publish-package-to-npm.yml
@@ -22,7 +22,7 @@ jobs:
       # Setup node environment
       - uses: actions/setup-node@v1
         with:
-          node-version: 16
+          node-version: 18
           registry-url: https://registry.npmjs.org/
 
       # Prepare, build and publish project

--- a/.github/workflows/publish-package-to-npm.yml
+++ b/.github/workflows/publish-package-to-npm.yml
@@ -20,7 +20,7 @@ jobs:
         uses: codex-team/action-nodejs-package-info@v1
 
       # Setup node environment
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: 18
           registry-url: https://registry.npmjs.org/


### PR DESCRIPTION
## Why
`.nvmrc` pins Node to `v18.20.1`, but several CI workflows still pin `node-version` to `16`.

That can make CI run on a runtime the project no longer targets.

## What changed
Update the affected workflow `node-version` pins so they match `.nvmrc` (`18`).

Also bump EOL `actions/setup-node@v1` → `@v3` in the same files, matching other workflows in this repo (`eslint.yml`, `cypress.yml`, etc.).

* `.github/workflows/bump-version-on-merge-next.yml`
  * `node-version: 16` → `node-version: 18`
  * `actions/setup-node@v1` → `@v3`
* `.github/workflows/create-a-release-draft.yml`
  * `node-version: 16` → `node-version: 18`
  * `actions/setup-node@v1` → `@v3`
* `.github/workflows/publish-package-to-npm.yml`
  * `node-version: 16` → `node-version: 18`
  * `actions/setup-node@v1` → `@v3`

## Test plan
- [x] `.nvmrc` is still `v18.20.1`
- [x] Updated workflows use Node 18 consistently with that pin
- [x] Updated workflows use `actions/setup-node@v3` like the rest of the repo
- [ ] Relevant CI jobs on this branch look healthy

Found while auditing CI/package version consistency across popular repos.