### PR TITLE
fix: prevent duplicate character when typing on selected blocks (Fixes #3012)

### DIFF
--- a/src/components/modules/blockSelection.ts
+++ b/src/components/modules/blockSelection.ts
@@ -239,6 +239,9 @@ export default class BlockSelection extends Module {
      * remove selected blocks and insert pressed key
      */
     if (this.anyBlockSelected && isKeyboard && isPrintableKey && !SelectionUtils.isSelectionExists) {
+      /** Prevent browser from also inserting the character (which would result in a double character) */
+      (reason as KeyboardEvent).preventDefault();
+
       const indexToInsert = BlockManager.removeSelectedBlocks();
 
       BlockManager.insertDefaultBlockAtIndex(indexToInsert, true);


### PR DESCRIPTION
### What does this PR do?

Fixes #3012 — Typed character is duplicated when replacing a selection (single block or cross-block).

### Root cause

When blocks are selected and a printable key is typed, the `clearSelection` method in `blockSelection.ts` removes the selected blocks, inserts a default block, and programmatically inserts the typed character via `Caret.insertContentAtCaretPosition` after a 20ms delay. However, the keyboard event was NOT being prevented (`preventDefault()` was missing), so the browser's native keydown handler also inserted the character at the caret position, resulting in the character appearing twice.

### Fix

Added `event.preventDefault()` in the `clearSelection` method when a printable key is typed while blocks are selected, preventing the browser from also inserting the character. The editor's manual insertion via `Caret.insertContentAtCaretPosition` is the only insertion that occurs.

### Technical details

- File: `src/components/modules/blockSelection.ts`
- The affected code path is in the `clearSelection` method, specifically when `anyBlockSelected && isKeyboard && isPrintableKey && !SelectionUtils.isSelectionExists` is true.
- The `preventDefault()` call is added right at the start of this block, before the block removal and character insertion logic.