### PR TITLE
fix: prevent inline toolbar from closing when clicking on form controls inside it

### DIFF
--- a/src/components/modules/ui.ts
+++ b/src/components/modules/ui.ts
@@ -861,10 +861,19 @@ export default class UI extends Module<UINodes> {
       /**
        * If there is no selected range, close inline toolbar
        *
+       * But do not close it if the user is interacting with a form control
+       * inside the Inline Toolbar popover (e.g. clicking on an <input> or <select>).
+       * In such case the selection is lost, but the Inline Toolbar should stay open.
+       *
        * @todo Make this method more straightforward
        */
       if (!Selection.range) {
-        this.Editor.InlineToolbar.close();
+        const activeElement = document.activeElement;
+        const isActiveElementInsideInlineToolbar = activeElement !== null && this.Editor.InlineToolbar.containsNode(activeElement);
+
+        if (!isActiveElementInsideInlineToolbar) {
+          this.Editor.InlineToolbar.close();
+        }
       }
 
       return;
@@ -932,3 +941,4 @@ export default class UI extends Module<UINodes> {
     this.readOnlyMutableListeners.on(this.nodes.wrapper, 'focusout', handleInputOrFocusChange);
   }
 }
+


### PR DESCRIPTION
## Description

Fixes #2985

When clicking on a form control (e.g. <select> or <input>) inside the Inline Toolbar popover, the selection is lost, which triggers a selectionchange event. The selectionChanged handler was unconditionally closing the Inline Toolbar when there is no selection range, even if the user is interacting with a form control inside the toolbar.

## Changes

- In ui.ts selectionChanged() : before closing the Inline Toolbar when there is no selection range, check if document.activeElement is inside the Inline Toolbar. If the user is focused on a form control inside the toolbar, keep it open.