### PR TITLE
fix: respect tool's sanitize config when building paste sanitizer rules

### DIFF
--- a/src/components/modules/paste.ts
+++ b/src/components/modules/paste.ts
@@ -204,11 +204,26 @@ export default class Paste extends Module {
 
     /** Add all tags that can be substituted to sanitizer configuration */
     const toolsTags = Object.keys(this.toolsTags).reduce((result, tag) => {
+      const tagLowerCase = tag.toLowerCase();
+
       /**
        * If Tool explicitly specifies sanitizer configuration for the tag, use it.
-       * Otherwise, remove all attributes
+       * Otherwise, check if the tool's sanitize config has rules for this tag.
+       * If not, remove all attributes.
        */
-      result[tag.toLowerCase()] = this.toolsTags[tag].sanitizationConfig ?? {};
+      const sanitizationConfig = this.toolsTags[tag].sanitizationConfig;
+
+      if (sanitizationConfig !== null) {
+        result[tagLowerCase] = sanitizationConfig;
+      } else {
+        const toolSanitizeConfig = this.toolsTags[tag].tool.sanitizeConfig;
+
+        if (toolSanitizeConfig?.[tagLowerCase]) {
+          result[tagLowerCase] = toolSanitizeConfig[tagLowerCase];
+        } else {
+          result[tagLowerCase] = {};
+        }
+      }
 
       return result;
     }, {});
@@ -656,15 +671,16 @@ export default class Paste extends Module {
           const tags = this.collectTagNames(tagOrSanitizeConfig);
 
           tags.forEach((tag) => {
+            const tagLowerCase = tag.toLowerCase();
             const sanitizationConfig = _.isObject(tagOrSanitizeConfig) ? tagOrSanitizeConfig[tag] : null;
 
-            result[tag.toLowerCase()] = sanitizationConfig || {};
+            result[tagLowerCase] = sanitizationConfig ?? tool.sanitizeConfig[tagLowerCase] ?? {};
           });
 
           return result;
         }, {});
 
-        const customConfig = Object.assign({}, toolTags, tool.baseSanitizeConfig);
+        const customConfig = Object.assign({}, toolTags, tool.sanitizeConfig);
 
         /**
          * A workaround for the HTMLJanitor bug with Tables (incorrect sanitizing of table.innerHTML)


### PR DESCRIPTION
## Description

Fixes #2984

When pasting HTML content, the editor's paste module builds sanitizer configuration from pasteConfig.tags, but ignored the tool's static `sanitize()` configuration. This caused style attributes (and other explicitly allowed attributes) to be stripped from paste elements before reaching the tool's onPaste handler.

### Root cause

There are two sanitization passes in the paste pipeline:

1. **processDataTransfer** (first pass): builds per-tag sanitizer config from `pasteConfig.tags` only. When tags are specified as plain strings (e.g., `[P, 'DIV', 'SPAN']`), the `sanitizationConfig` is null, resulting in `{}` (all attributes stripped). The tool's `sanitize()` static rules were never consulted.

2. **processHTML** (second pass): same issue — per-tag config was derived from `pasteConfig` only, and the `customConfig` used `tool.baseSanitizeConfig` (inline tools + tunes only) instead of `tool.sanitizeConfig` (which includes the tool's own rules).

### Fix

Both sanitization passes now fall back to the tool's `sanitizeConfig` for a tag when no explicit pasteConfig sanitization is provided. The second pass also uses `tool.sanitizeConfig` instead of `tool.baseSanitizeConfig`.

### Test Plan

- [x] A tool with `pasteConfig: { tags: ['P'] }` and `sanitize: { p: { style: true } }` now preserves `style` attributes on pasted `<p>` elements.
- [x] Existing behavior preserved for tools that specify explicit sanitization in pasteConfig.
- [x] Existing behavior preserved for tags without any sanitize rules (all attributes stripped).