### PR TITLE
fix(paste): respect tool sanitize config for paste tags (Fixes #2984)

### DIFF
--- a/src/components/modules/paste.ts
+++ b/src/components/modules/paste.ts
@@ -204,11 +204,26 @@ export default class Paste extends Module {
 
     /** Add all tags that can be substituted to sanitizer configuration */
     const toolsTags = Object.keys(this.toolsTags).reduce((result, tag) => {
+      const tagLowerCase = tag.toLowerCase();
+
       /**
        * If Tool explicitly specifies sanitizer configuration for the tag, use it.
-       * Otherwise, remove all attributes
+       * Otherwise, check if the tool's sanitize config has rules for this tag.
+       * If not, remove all attributes.
        */
-      result[tag.toLowerCase()] = this.toolsTags[tag].sanitizationConfig ?? {};
+      const sanitizationConfig = this.toolsTags[tag].sanitizationConfig;
+
+      if (sanitizationConfig !== null) {
+        result[tagLowerCase] = sanitizationConfig;
+      } else {
+        const toolSanitizeConfig = this.toolsTags[tag].tool.sanitizeConfig as SanitizerConfig;
+
+        if (toolSanitizeConfig[tagLowerCase]) {
+          result[tagLowerCase] = toolSanitizeConfig[tagLowerCase];
+        } else {
+          result[tagLowerCase] = {};
+        }
+      }
 
       return result;
     }, {});
@@ -656,15 +671,16 @@ export default class Paste extends Module {
           const tags = this.collectTagNames(tagOrSanitizeConfig);
 
           tags.forEach((tag) => {
+            const tagLowerCase = tag.toLowerCase();
             const sanitizationConfig = _.isObject(tagOrSanitizeConfig) ? tagOrSanitizeConfig[tag] : null;
 
-            result[tag.toLowerCase()] = sanitizationConfig || {};
+            result[tagLowerCase] = sanitizationConfig ?? tool.sanitizeConfig[tagLowerCase] ?? {};
           });
 
           return result;
         }, {});
 
-        const customConfig = Object.assign({}, toolTags, tool.baseSanitizeConfig);
+        const customConfig = Object.assign({}, toolTags, tool.sanitizeConfig);
 
         /**
          * A workaround for the HTMLJanitor bug with Tables (incorrect sanitizing of table.innerHTML)


### PR DESCRIPTION
## What does this PR do?

Fixes #2984 — `pasteConfig` ignores tool's `sanitize` rules.

### Problem
When pasting HTML content, the paste module builds its sanitizer config **only** from the tool's `pasteConfig.tags`. When a tool declares its tags as plain strings (e.g. `tags: ['P', 'DIV']`), the `sanitizationConfig` for each tag is `null`, and the code falls back to `{}` — stripping **all** attributes from pasted elements.

Meanwhile the tool's `static get sanitize()` explicitly allows certain attributes (e.g. `p: { style: true }`). These rules are ignored during paste, so pasting from Google Docs loses paragraph indentation and other inline styles.

### Fix
In `Paste.processDataTransfer`, when a tag has no explicit sanitization config from `pasteConfig.tags`, fall back to the tool's `sanitizeConfig` rules for that tag. Only if neither provides a rule do we strip all attributes.

### Reproduction
```js
class MyTool {
  static get pasteConfig() { return { tags: ['P', 'DIV'] }; }
  static get sanitize() { return { p: { style: true } }; }
  onPaste(event) { /* receives element */ }
}
```

**Before**: pasted `<p style="text-indent: 36pt;">` becomes `<p><span>...</span></p>` (style stripped)
**After**: pasted `<p style="text-indent: 36pt;">` is delivered to the tool with its `style` attribute preserved.

### Checklist
- [x] Build passes (`vite build`)
- [x] No new type errors introduced
